### PR TITLE
feat: single source of truth for all distribution channel configs

### DIFF
--- a/docs/configs/claude-code-cli.sh
+++ b/docs/configs/claude-code-cli.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+claude mcp add mnemoverse \
+  -e MNEMOVERSE_API_KEY=mk_live_YOUR_KEY \
+  -- npx -y @mnemoverse/mcp-memory-server

--- a/docs/configs/claude-desktop.json
+++ b/docs/configs/claude-desktop.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "mnemoverse": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@mnemoverse/mcp-memory-server"
+      ],
+      "env": {
+        "MNEMOVERSE_API_KEY": "mk_live_YOUR_KEY"
+      }
+    }
+  }
+}

--- a/docs/configs/cursor-deep-link.txt
+++ b/docs/configs/cursor-deep-link.txt
@@ -1,0 +1,1 @@
+cursor://anysphere.cursor-deeplink/mcp/install?name=mnemoverse&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsIkBtbmVtb3ZlcnNlL21jcC1tZW1vcnktc2VydmVyIl0sImVudiI6eyJNTkVNT1ZFUlNFX0FQSV9LRVkiOiJta19saXZlX1lPVVJfS0VZIn19

--- a/docs/configs/cursor.json
+++ b/docs/configs/cursor.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "mnemoverse": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@mnemoverse/mcp-memory-server"
+      ],
+      "env": {
+        "MNEMOVERSE_API_KEY": "mk_live_YOUR_KEY"
+      }
+    }
+  }
+}

--- a/docs/configs/vscode-deep-link.txt
+++ b/docs/configs/vscode-deep-link.txt
@@ -1,0 +1,1 @@
+vscode:mcp/install?%7B%22name%22%3A%22mnemoverse%22%2C%22type%22%3A%22stdio%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40mnemoverse%2Fmcp-memory-server%22%5D%2C%22env%22%3A%7B%22MNEMOVERSE_API_KEY%22%3A%22mk_live_YOUR_KEY%22%7D%7D

--- a/docs/configs/vscode.json
+++ b/docs/configs/vscode.json
@@ -1,0 +1,15 @@
+{
+  "servers": {
+    "mnemoverse": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@mnemoverse/mcp-memory-server"
+      ],
+      "env": {
+        "MNEMOVERSE_API_KEY": "mk_live_YOUR_KEY"
+      }
+    }
+  }
+}

--- a/docs/configs/windsurf.json
+++ b/docs/configs/windsurf.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "mnemoverse": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@mnemoverse/mcp-memory-server"
+      ],
+      "env": {
+        "MNEMOVERSE_API_KEY": "mk_live_YOUR_KEY"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -12,8 +12,12 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "start": "node dist/index.js",
+    "generate:configs": "node scripts/generate-configs.mjs",
+    "verify:configs": "node scripts/generate-configs.mjs --check",
+    "prebuild": "npm run generate:configs",
     "prepublishOnly": "npm run build"
   },
+  "mcpName": "io.github.mnemoverse/mcp-memory-server",
   "keywords": [
     "mcp",
     "memory",

--- a/scripts/generate-configs.mjs
+++ b/scripts/generate-configs.mjs
@@ -1,0 +1,306 @@
+#!/usr/bin/env node
+/**
+ * generate-configs.mjs
+ *
+ * Single source of truth → all distribution channel configs.
+ *
+ * Reads: src/configs/source.json
+ * Writes: docs/configs/*, smithery.yaml, server.json
+ *
+ * Usage:
+ *   node scripts/generate-configs.mjs            # generate
+ *   node scripts/generate-configs.mjs --check    # CI: regenerate + diff (fail if changed)
+ *
+ * When you add a new distribution channel, add a new generator function below.
+ * Never edit generated files by hand — they will be overwritten.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { execSync } from "node:child_process";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const ROOT = resolve(__dirname, "..");
+
+// ─── Load source ─────────────────────────────────────────────────────────────
+
+const SOURCE_PATH = resolve(ROOT, "src/configs/source.json");
+const source = JSON.parse(readFileSync(SOURCE_PATH, "utf8"));
+
+const PACKAGE_VERSION = JSON.parse(
+  readFileSync(resolve(ROOT, "package.json"), "utf8"),
+).version;
+
+// Helper: extract { KEY: "value" } from source.env (which has nested {value, description, ...})
+function envValues(envObj) {
+  const result = {};
+  for (const [key, meta] of Object.entries(envObj)) {
+    result[key] = meta.value;
+  }
+  return result;
+}
+
+const ENV_VALUES = envValues(source.env);
+
+// ─── Generators ──────────────────────────────────────────────────────────────
+
+/**
+ * Cursor / Claude Desktop / Windsurf format (mcpServers key, stdio).
+ */
+function genMcpServersFormat() {
+  return {
+    mcpServers: {
+      [source.name]: {
+        command: source.command,
+        args: source.args,
+        env: ENV_VALUES,
+      },
+    },
+  };
+}
+
+/**
+ * VS Code (Copilot Chat) format — uses `servers` key (not `mcpServers`).
+ */
+function genVscodeFormat() {
+  return {
+    servers: {
+      [source.name]: {
+        type: source.type,
+        command: source.command,
+        args: source.args,
+        env: ENV_VALUES,
+      },
+    },
+  };
+}
+
+/**
+ * Cursor deep link.
+ *
+ * Format: cursor://anysphere.cursor-deeplink/mcp/install?name=NAME&config=BASE64
+ * The base64 payload is the inner server object (NOT wrapped in mcpServers).
+ */
+function genCursorDeepLink() {
+  const inner = {
+    command: source.command,
+    args: source.args,
+    env: ENV_VALUES,
+  };
+  const config = Buffer.from(JSON.stringify(inner)).toString("base64");
+  return `cursor://anysphere.cursor-deeplink/mcp/install?name=${encodeURIComponent(
+    source.name,
+  )}&config=${config}`;
+}
+
+/**
+ * VS Code deep link.
+ *
+ * Format: vscode:mcp/install?{URL_ENCODED_JSON}
+ * The JSON contains name + the server object (not wrapped in `servers`).
+ */
+function genVscodeDeepLink() {
+  const inner = {
+    name: source.name,
+    type: source.type,
+    command: source.command,
+    args: source.args,
+    env: ENV_VALUES,
+  };
+  return `vscode:mcp/install?${encodeURIComponent(JSON.stringify(inner))}`;
+}
+
+/**
+ * Claude Code CLI command.
+ *
+ * Format: claude mcp add NAME -e KEY=VAL ... -- command args...
+ */
+function genClaudeCodeCli() {
+  const envFlags = Object.entries(ENV_VALUES)
+    .map(([k, v]) => `  -e ${k}=${v}`)
+    .join(" \\\n");
+  return `claude mcp add ${source.name} \\\n${envFlags} \\\n  -- ${source.command} ${source.args.join(" ")}\n`;
+}
+
+/**
+ * Smithery.ai config — custom yaml with configSchema + commandFunction.
+ *
+ * Smithery shows configSchema fields to user as form, then calls commandFunction(config)
+ * to build the launch command.
+ */
+function genSmitheryYaml() {
+  // Build configSchema properties from source.env
+  const schemaProperties = {};
+  const required = [];
+  const camelCaseEnvMap = {}; // Smithery uses camelCase keys, then we map back to ENV_VAR
+
+  for (const [envKey, meta] of Object.entries(source.env)) {
+    // Convert MNEMOVERSE_API_KEY → mnemoverseApiKey
+    const camelKey = envKey
+      .toLowerCase()
+      .split("_")
+      .map((part, i) =>
+        i === 0 ? part : part.charAt(0).toUpperCase() + part.slice(1),
+      )
+      .join("");
+
+    camelCaseEnvMap[camelKey] = envKey;
+    schemaProperties[camelKey] = {
+      type: "string",
+      description: meta.description,
+    };
+    if (meta.required) required.push(camelKey);
+  }
+
+  // Build commandFunction body
+  const envAssignments = Object.entries(camelCaseEnvMap)
+    .map(([camel, envVar]) => `        ${envVar}: config.${camel},`)
+    .join("\n");
+
+  const yaml = `# Smithery configuration — AUTO-GENERATED from src/configs/source.json
+# Do not edit by hand. Run \`npm run generate:configs\` to regenerate.
+# Docs: https://smithery.ai/docs/build/project-config/smithery.yaml
+
+startCommand:
+  type: ${source.type}
+  configSchema:
+    type: object
+    required:
+${required.map((k) => `      - ${k}`).join("\n")}
+    properties:
+${Object.entries(schemaProperties)
+  .map(
+    ([key, prop]) => `      ${key}:
+        type: ${prop.type}
+        description: |
+          ${prop.description}`,
+  )
+  .join("\n")}
+  commandFunction:
+    |-
+    (config) => ({
+      command: '${source.command}',
+      args: ${JSON.stringify(source.args)},
+      env: {
+${envAssignments}
+      }
+    })
+`;
+  return yaml;
+}
+
+/**
+ * Official MCP Registry server.json.
+ *
+ * https://registry.modelcontextprotocol.io/
+ * Schema: https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json
+ */
+function genServerJson() {
+  return {
+    $schema:
+      "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+    name: "io.github.mnemoverse/mcp-memory-server",
+    description: source.description,
+    repository: {
+      url: source.metadata.repository,
+      source: "github",
+    },
+    version: PACKAGE_VERSION,
+    packages: [
+      {
+        registryName: source.package.registry,
+        name: source.package.name,
+        version: PACKAGE_VERSION,
+        runtimeArguments: source.args.slice(1), // skip "-y"
+        environmentVariables: Object.entries(source.env).map(([key, meta]) => ({
+          name: key,
+          description: meta.description,
+          isRequired: meta.required ?? false,
+          isSecret: meta.secret ?? false,
+        })),
+      },
+    ],
+  };
+}
+
+// ─── Output ──────────────────────────────────────────────────────────────────
+
+const OUTPUTS = [
+  {
+    path: "docs/configs/cursor.json",
+    content: JSON.stringify(genMcpServersFormat(), null, 2) + "\n",
+  },
+  {
+    path: "docs/configs/claude-desktop.json",
+    content: JSON.stringify(genMcpServersFormat(), null, 2) + "\n",
+  },
+  {
+    path: "docs/configs/windsurf.json",
+    content: JSON.stringify(genMcpServersFormat(), null, 2) + "\n",
+  },
+  {
+    path: "docs/configs/vscode.json",
+    content: JSON.stringify(genVscodeFormat(), null, 2) + "\n",
+  },
+  {
+    path: "docs/configs/cursor-deep-link.txt",
+    content: genCursorDeepLink() + "\n",
+  },
+  {
+    path: "docs/configs/vscode-deep-link.txt",
+    content: genVscodeDeepLink() + "\n",
+  },
+  {
+    path: "docs/configs/claude-code-cli.sh",
+    content: "#!/usr/bin/env bash\n" + genClaudeCodeCli(),
+  },
+  {
+    path: "smithery.yaml",
+    content: genSmitheryYaml(),
+  },
+  {
+    path: "server.json",
+    content: JSON.stringify(genServerJson(), null, 2) + "\n",
+  },
+];
+
+// ─── Write files ─────────────────────────────────────────────────────────────
+
+const checkMode = process.argv.includes("--check");
+
+let written = 0;
+let unchanged = 0;
+
+for (const { path, content } of OUTPUTS) {
+  const fullPath = resolve(ROOT, path);
+  mkdirSync(dirname(fullPath), { recursive: true });
+
+  const existing = existsSync(fullPath) ? readFileSync(fullPath, "utf8") : "";
+  if (existing === content) {
+    unchanged++;
+    continue;
+  }
+
+  if (checkMode) {
+    console.error(`✗ Drift detected: ${path}`);
+    console.error("  Expected (regenerated):");
+    console.error("  " + content.slice(0, 200).split("\n").join("\n  "));
+    console.error("  Got (committed):");
+    console.error("  " + existing.slice(0, 200).split("\n").join("\n  "));
+    process.exit(1);
+  }
+
+  writeFileSync(fullPath, content, "utf8");
+  console.log(`✓ Generated ${path}`);
+  written++;
+}
+
+if (checkMode) {
+  console.log(`✓ All ${OUTPUTS.length} configs in sync with source.json`);
+} else {
+  console.log(
+    `\nDone: ${written} written, ${unchanged} unchanged (${OUTPUTS.length} total)`,
+  );
+}

--- a/server.json
+++ b/server.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+  "name": "io.github.mnemoverse/mcp-memory-server",
+  "description": "Persistent memory for AI agents — write once, recall anywhere across all your AI tools",
+  "repository": {
+    "url": "https://github.com/mnemoverse/mcp-memory-server",
+    "source": "github"
+  },
+  "version": "0.1.1",
+  "packages": [
+    {
+      "registryName": "npm",
+      "name": "@mnemoverse/mcp-memory-server",
+      "version": "0.1.1",
+      "runtimeArguments": [
+        "@mnemoverse/mcp-memory-server"
+      ],
+      "environmentVariables": [
+        {
+          "name": "MNEMOVERSE_API_KEY",
+          "description": "Your Mnemoverse API key (starts with mk_live_). Get one free at https://console.mnemoverse.com",
+          "isRequired": true,
+          "isSecret": true
+        }
+      ]
+    }
+  ]
+}

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,24 @@
+# Smithery configuration — AUTO-GENERATED from src/configs/source.json
+# Do not edit by hand. Run `npm run generate:configs` to regenerate.
+# Docs: https://smithery.ai/docs/build/project-config/smithery.yaml
+
+startCommand:
+  type: stdio
+  configSchema:
+    type: object
+    required:
+      - mnemoverseApiKey
+    properties:
+      mnemoverseApiKey:
+        type: string
+        description: |
+          Your Mnemoverse API key (starts with mk_live_). Get one free at https://console.mnemoverse.com
+  commandFunction:
+    |-
+    (config) => ({
+      command: 'npx',
+      args: ["-y","@mnemoverse/mcp-memory-server"],
+      env: {
+        MNEMOVERSE_API_KEY: config.mnemoverseApiKey,
+      }
+    })

--- a/src/configs/source.json
+++ b/src/configs/source.json
@@ -1,0 +1,28 @@
+{
+  "$comment": "SINGLE SOURCE OF TRUTH for all distribution channel configs. Edit this file → run `npm run generate:configs` → all 9+ artifacts regenerate. CI verifies committed artifacts match source.",
+  "name": "mnemoverse",
+  "displayName": "Mnemoverse Memory",
+  "description": "Persistent memory for AI agents — write once, recall anywhere across all your AI tools",
+  "type": "stdio",
+  "command": "npx",
+  "args": ["-y", "@mnemoverse/mcp-memory-server"],
+  "env": {
+    "MNEMOVERSE_API_KEY": {
+      "value": "mk_live_YOUR_KEY",
+      "description": "Your Mnemoverse API key (starts with mk_live_). Get one free at https://console.mnemoverse.com",
+      "required": true,
+      "secret": true
+    }
+  },
+  "package": {
+    "registry": "npm",
+    "name": "@mnemoverse/mcp-memory-server"
+  },
+  "metadata": {
+    "homepage": "https://mnemoverse.com/docs/api/mcp-server",
+    "repository": "https://github.com/mnemoverse/mcp-memory-server",
+    "license": "MIT",
+    "author": "Mnemoverse",
+    "tags": ["memory", "persistent", "ai-agents", "cross-tool", "oauth"]
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,17 +8,22 @@ const API_URL =
   process.env.MNEMOVERSE_API_URL || "https://core.mnemoverse.com/api/v1";
 const API_KEY = process.env.MNEMOVERSE_API_KEY || "";
 
+// Hard cap on tool result size — required by Claude Connectors Directory
+// (https://support.claude.com/en/articles/12922490-remote-mcp-server-submission-guide).
+// Approximate token count = chars / 4. Cap at 24,000 tokens to leave headroom under the 25K limit.
+const MAX_RESULT_CHARS = 24_000 * 4;
+
 if (!API_KEY) {
   console.error(
     "Error: MNEMOVERSE_API_KEY environment variable is required.\n" +
-      "Get your free key at https://console.mnemoverse.com"
+      "Get your free key at https://console.mnemoverse.com",
   );
   process.exit(1);
 }
 
 async function apiFetch(
   path: string,
-  options: RequestInit = {}
+  options: RequestInit = {},
 ): Promise<unknown> {
   const res = await fetch(`${API_URL}${path}`, {
     ...options,
@@ -37,32 +42,59 @@ async function apiFetch(
   return res.json();
 }
 
+/**
+ * Truncate a result string to MAX_RESULT_CHARS, appending a notice if truncated.
+ * Required by Claude Connectors Directory submission policy.
+ */
+function capResult(text: string): string {
+  if (text.length <= MAX_RESULT_CHARS) return text;
+  const truncated = text.slice(0, MAX_RESULT_CHARS - 200);
+  return (
+    truncated +
+    `\n\n[…truncated to fit 25K token limit. Use a more specific query or smaller top_k to see all results.]`
+  );
+}
+
 // --- Server setup ---
 
 const server = new McpServer({
   name: "mnemoverse-memory",
-  version: "0.1.0",
+  version: "0.1.1",
 });
 
 // --- Tool: memory_write ---
 
-server.tool(
+server.registerTool(
   "memory_write",
-  "Store a memory that should persist across sessions — preferences, decisions, lessons learned, project facts, people and roles. Call this PROACTIVELY whenever the user states a preference, makes a decision, or you learn something important. Don't wait to be asked — if it's worth remembering, store it now.",
   {
-    content: z
-      .string()
-      .min(1)
-      .max(10000)
-      .describe("The memory to store — what happened, what was learned"),
-    concepts: z
-      .array(z.string())
-      .optional()
-      .describe("Key concepts for linking related memories (e.g. ['deploy', 'friday', 'staging'])"),
-    domain: z
-      .string()
-      .optional()
-      .describe("Namespace to organize memories (e.g. 'engineering', 'user:alice', 'project:acme')"),
+    description:
+      "Store a memory that should persist across sessions — preferences, decisions, lessons learned, project facts, people and roles. Memories you store are also accessible from Claude, ChatGPT, Cursor, VS Code, and any other AI tool the user connects to Mnemoverse — write once, recall everywhere. Call this PROACTIVELY whenever the user states a preference, makes a decision, or you learn something important. Don't wait to be asked — if it's worth remembering, store it now.",
+    inputSchema: {
+      content: z
+        .string()
+        .min(1)
+        .max(10000)
+        .describe("The memory to store — what happened, what was learned"),
+      concepts: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "Key concepts for linking related memories (e.g. ['deploy', 'friday', 'staging'])",
+        ),
+      domain: z
+        .string()
+        .optional()
+        .describe(
+          "Namespace to organize memories (e.g. 'engineering', 'user:alice', 'project:acme')",
+        ),
+    },
+    annotations: {
+      title: "Store Memory",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
   },
   async ({ content, concepts, domain }) => {
     const result = await apiFetch("/memory/write", {
@@ -99,31 +131,41 @@ server.tool(
         },
       ],
     };
-  }
+  },
 );
 
 // --- Tool: memory_read ---
 
-server.tool(
+server.registerTool(
   "memory_read",
-  "ALWAYS call this tool first when the user asks a question about preferences, past decisions, project setup, people, or anything that might have been discussed before. This is your long-term memory — it persists across sessions and tools. Search by natural language query. If you have any doubt whether you know something — check memory first.",
   {
-    query: z
-      .string()
-      .min(1)
-      .max(5000)
-      .describe("Natural language query — what are you looking for?"),
-    top_k: z
-      .number()
-      .int()
-      .min(1)
-      .max(50)
-      .optional()
-      .describe("Max results to return (default: 5)"),
-    domain: z
-      .string()
-      .optional()
-      .describe("Filter by domain namespace"),
+    description:
+      "ALWAYS call this tool first when the user asks a question about preferences, past decisions, project setup, people, or anything that might have been discussed before. This is your long-term memory — it persists across sessions and tools (Claude, ChatGPT, Cursor, VS Code, and any other AI tool the user connects). Search by natural language query. If you have any doubt whether you know something — check memory first.",
+    inputSchema: {
+      query: z
+        .string()
+        .min(1)
+        .max(5000)
+        .describe("Natural language query — what are you looking for?"),
+      top_k: z
+        .number()
+        .int()
+        .min(1)
+        .max(50)
+        .optional()
+        .describe("Max results to return (default: 5)"),
+      domain: z
+        .string()
+        .optional()
+        .describe("Filter by domain namespace"),
+    },
+    annotations: {
+      title: "Search Memories",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
   },
   async ({ query, top_k, domain }) => {
     const result = await apiFetch("/memory/read", {
@@ -159,35 +201,47 @@ server.tool(
         `${i + 1}. [${(item.relevance * 100).toFixed(0)}%] ${item.content}` +
         (item.concepts.length > 0
           ? ` (${item.concepts.join(", ")})`
-          : "")
+          : ""),
     );
+
+    const text = lines.join("\n\n") + `\n\n(${r.search_time_ms.toFixed(0)}ms)`;
 
     return {
       content: [
         {
           type: "text" as const,
-          text: lines.join("\n\n") + `\n\n(${r.search_time_ms.toFixed(0)}ms)`,
+          text: capResult(text),
         },
       ],
     };
-  }
+  },
 );
 
 // --- Tool: memory_feedback ---
 
-server.tool(
+server.registerTool(
   "memory_feedback",
-  "Report whether a retrieved memory was helpful. Positive feedback makes memories easier to find next time. Negative feedback lets them fade. Call this after using memories from memory_read.",
   {
-    atom_ids: z
-      .array(z.string())
-      .min(1)
-      .describe("IDs of memories to give feedback on (from memory_read results)"),
-    outcome: z
-      .number()
-      .min(-1)
-      .max(1)
-      .describe("How helpful was this? 1.0 = very helpful, 0 = neutral, -1.0 = harmful/wrong"),
+    description:
+      "Report whether a retrieved memory was helpful. Positive feedback makes memories easier to find next time across all tools. Negative feedback lets them fade. Call this after using memories from memory_read.",
+    inputSchema: {
+      atom_ids: z
+        .array(z.string())
+        .min(1)
+        .describe("IDs of memories to give feedback on (from memory_read results)"),
+      outcome: z
+        .number()
+        .min(-1)
+        .max(1)
+        .describe("How helpful was this? 1.0 = very helpful, 0 = neutral, -1.0 = harmful/wrong"),
+    },
+    annotations: {
+      title: "Rate Memory Helpfulness",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
   },
   async ({ atom_ids, outcome }) => {
     const result = await apiFetch("/memory/feedback", {
@@ -205,15 +259,25 @@ server.tool(
         },
       ],
     };
-  }
+  },
 );
 
 // --- Tool: memory_stats ---
 
-server.tool(
+server.registerTool(
   "memory_stats",
-  "Get memory statistics — how many memories are stored, which domains exist, average quality scores. Useful for understanding the current state of memory.",
-  {},
+  {
+    description:
+      "Get memory statistics — how many memories are stored, which domains exist, average quality scores. These memories are shared with all AI tools the user has connected to Mnemoverse. Useful for understanding the current state of memory.",
+    inputSchema: {},
+    annotations: {
+      title: "Memory Statistics",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+  },
   async () => {
     const result = await apiFetch("/memory/stats");
 
@@ -235,7 +299,7 @@ server.tool(
     ].join("\n");
 
     return { content: [{ type: "text" as const, text }] };
-  }
+  },
 );
 
 // --- Start ---


### PR DESCRIPTION
## Summary

Adds `src/configs/source.json` + `scripts/generate-configs.mjs` so that **one edit propagates to all 9 distribution channel configs** automatically. Eliminates the maintenance burden of keeping Cursor / VS Code / Windsurf / Claude Desktop / Claude Code / Smithery / Official MCP Registry configs in sync by hand.

Closes #5.

## Architecture

\`\`\`
src/configs/source.json  ← THE source of truth (edit only this)
        ↓
scripts/generate-configs.mjs  ← runs on prebuild
        ↓
9 generated artifacts:
├── docs/configs/cursor.json (mcpServers format — also Claude Desktop, Windsurf)
├── docs/configs/vscode.json (servers format — VS Code uses different key)
├── docs/configs/cursor-deep-link.txt (cursor://...)
├── docs/configs/vscode-deep-link.txt (vscode:mcp/install)
├── docs/configs/claude-code-cli.sh (claude mcp add ...)
├── smithery.yaml (Smithery.ai)
├── server.json (Official MCP Registry → auto-syncs to PulseMCP, Glama, MCP.so)
\`\`\`

## Verification

\`\`\`bash
npm run generate:configs  # writes all 9 artifacts
npm run verify:configs    # CI: regenerate + diff (fail if drifted)
npm run build             # prebuild auto-runs generate:configs
\`\`\`

Drift detection tested — modifying any generated file by hand → \`verify:configs\` exits 1.

## Tool annotations (Claude Connectors prep)

Migrated from deprecated \`server.tool()\` to \`server.registerTool()\` to add tool annotations required by [Claude Connectors Directory submission policy](https://support.claude.com/en/articles/12922490-remote-mcp-server-submission-guide):

| Tool | readOnlyHint | destructiveHint | idempotentHint | openWorldHint |
|------|--------------|-----------------|----------------|---------------|
| memory_write | false | false | false | true |
| memory_read | **true** | false | **true** | true |
| memory_feedback | false | false | false | true |
| memory_stats | **true** | false | **true** | true |

## 25K token cap (Claude Connectors requirement)

Added \`capResult()\` helper that truncates results to 24K tokens (chars/4 ≈ 96K chars) with a notice. Applied to \`memory_read\` (the only tool that can return arbitrary data).

## Cross-tool memory upsell

Added cross-tool sync mention to all 4 tool descriptions per docs#12. Now when an AI calls \`memory_write\`, the description tells it that "memories you store are also accessible from Claude, ChatGPT, Cursor, VS Code, and any other AI tool the user connects."

This teaches the model about the universal memory layer concept naturally.

## mcpName field

Added \`mcpName: "io.github.mnemoverse/mcp-memory-server"\` to package.json. Required by [Official MCP Registry](https://registry.modelcontextprotocol.io) for ownership verification.

## Why this matters

Before: every channel addition multiplied maintenance burden. Adding a new tool / changing args = edit 9 files by hand → drift → broken installs.

After: edit \`source.json\` → \`npm run build\` → all 9 artifacts updated. CI guarantees no drift.

## Test plan

- [x] \`npm run generate:configs\` produces all 9 artifacts
- [x] \`npm run verify:configs\` passes when in sync
- [x] \`npm run verify:configs\` fails when artifacts modified by hand
- [x] \`npm run build\` succeeds (TypeScript + prebuild generator)
- [x] dist/index.js contains all annotations (registerTool calls)
- [ ] After merge: publish v0.2.0 to npm
- [ ] After merge: submit to Smithery, Official MCP Registry
- [ ] After merge: deep links work in real Cursor/VS Code (manual test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)