### PR TITLE
feat: memory_delete + memory_delete_domain tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mnemoverse/mcp-memory-server",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "MCP server for Mnemoverse Memory API — persistent AI memory across Claude Code, Cursor, VS Code, and any MCP client",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mnemoverse/mcp-memory-server",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "MCP server for Mnemoverse Memory API — persistent AI memory across Claude Code, Cursor, VS Code, and any MCP client",
   "type": "module",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/mnemoverse/mcp-memory-server",
     "source": "github"
   },
-  "version": "0.2.0",
+  "version": "0.3.0",
   "packages": [
     {
       "registryName": "npm",
       "name": "@mnemoverse/mcp-memory-server",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "runtimeArguments": [
         "@mnemoverse/mcp-memory-server"
       ],

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/mnemoverse/mcp-memory-server",
     "source": "github"
   },
-  "version": "0.1.1",
+  "version": "0.2.0",
   "packages": [
     {
       "registryName": "npm",
       "name": "@mnemoverse/mcp-memory-server",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "runtimeArguments": [
         "@mnemoverse/mcp-memory-server"
       ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ function capResult(text: string): string {
 
 const server = new McpServer({
   name: "mnemoverse-memory",
-  version: "0.2.0",
+  version: "0.3.0",
 });
 
 // --- Tool: memory_write ---
@@ -299,6 +299,111 @@ server.registerTool(
     ].join("\n");
 
     return { content: [{ type: "text" as const, text }] };
+  },
+);
+
+// --- Tool: memory_delete ---
+
+server.registerTool(
+  "memory_delete",
+  {
+    description:
+      "Permanently delete a single memory by its atom_id. Use when the user explicitly asks to forget something specific, or when you stored a wrong fact that needs correcting. The deletion is irreversible — the memory is gone for good. For broad cleanup of an entire topic, prefer memory_delete_domain.",
+    inputSchema: {
+      atom_id: z
+        .string()
+        .min(1)
+        .describe(
+          "The atom_id of the memory to delete (from memory_read results — each item has an id)",
+        ),
+    },
+    annotations: {
+      title: "Delete a Memory",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+  },
+  async ({ atom_id }) => {
+    const result = await apiFetch(`/memory/atoms/${encodeURIComponent(atom_id)}`, {
+      method: "DELETE",
+    });
+
+    const r = result as { deleted?: boolean; atom_id?: string };
+
+    if (r.deleted === false) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `No memory found with id ${atom_id}.`,
+          },
+        ],
+      };
+    }
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Deleted memory ${atom_id}.`,
+        },
+      ],
+    };
+  },
+);
+
+// --- Tool: memory_delete_domain ---
+
+server.registerTool(
+  "memory_delete_domain",
+  {
+    description:
+      "Permanently delete ALL memories in a given domain. Use when the user wants to clean up an entire topic — e.g., 'forget everything about project X' or 'wipe my benchmark experiments'. The deletion is irreversible. List domains first with memory_stats to confirm the exact name. Refuse to call this without an explicit user request — it is much more destructive than memory_delete.",
+    inputSchema: {
+      domain: z
+        .string()
+        .min(1)
+        .max(200)
+        .describe(
+          "The domain namespace to wipe (e.g., 'project:old', 'experiments-2025'). Must match exactly.",
+        ),
+      confirm: z
+        .literal(true)
+        .describe(
+          "Must be exactly true to proceed. Acts as a safety interlock against accidental invocation.",
+        ),
+    },
+    annotations: {
+      title: "Delete an Entire Memory Domain",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+  },
+  async ({ domain, confirm }) => {
+    if (confirm !== true) {
+      throw new Error(
+        "memory_delete_domain requires confirm=true as a safety interlock.",
+      );
+    }
+
+    const result = await apiFetch(`/memory/domain/${encodeURIComponent(domain)}`, {
+      method: "DELETE",
+    });
+
+    const r = result as { deleted: number; domain: string };
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Deleted ${r.deleted} ${r.deleted === 1 ? "memory" : "memories"} from domain "${r.domain}".`,
+        },
+      ],
+    };
   },
 );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ function capResult(text: string): string {
 
 const server = new McpServer({
   name: "mnemoverse-memory",
-  version: "0.1.1",
+  version: "0.2.0",
 });
 
 // --- Tool: memory_write ---


### PR DESCRIPTION
## Why

MCP users could write to memory infinitely but had **no way to clean up** through MCP. Any cleanup required dropping out to the REST API + raw API key + curl, which is friction the rest of Mnemoverse hides.

I discovered this while dogfooding our own production memory yesterday: 307 leftover LoCoMo benchmark atoms in domain ` locomo-full` and no MCP-native way to delete them. I had to use ` curl -X DELETE` directly. Every other MCP user hits the same wall.

## What changed

Two new tools, both surfaced from already-live REST endpoints in mnemoverse-core:

### ` memory_delete(atom_id)`

Delete a single memory by ID. Maps to ` DELETE /api/v1/memory/atoms/{atom_id}`.

\`\`\`ts
{
  name: \"memory_delete\",
  description: \"Permanently delete a single memory by its atom_id. Use when the user explicitly asks to forget something specific, or when you stored a wrong fact that needs correcting. The deletion is irreversible — the memory is gone for good. For broad cleanup of an entire topic, prefer memory_delete_domain.\",
  inputSchema: { atom_id: z.string().min(1) },
  annotations: {
    title: \"Delete a Memory\",
    destructiveHint: true,    // important — clients warn the user
    idempotentHint: true,
  }
}
\`\`\`

### ` memory_delete_domain(domain, confirm)`

Delete every memory in a domain namespace. Maps to ` DELETE /api/v1/memory/domain/{domain}`.

\`\`\`ts
{
  name: \"memory_delete_domain\",
  description: \"Permanently delete ALL memories in a given domain. Use when the user wants to clean up an entire topic — e.g., 'forget everything about project X' or 'wipe my benchmark experiments'. The deletion is irreversible. List domains first with memory_stats to confirm the exact name. Refuse to call this without an explicit user request — it is much more destructive than memory_delete.\",
  inputSchema: {
    domain: z.string().min(1).max(200),
    confirm: z.literal(true),  // safety interlock
  },
  annotations: {
    destructiveHint: true,
    idempotentHint: true,
  }
}
\`\`\`

The ` confirm: true` literal is a **safety interlock** against accidental invocation by overzealous agents. The description tells the model to refuse without an explicit user request, and the schema enforces it via Zod ` z.literal(true)`.

## Why this is safe

- Both endpoints already exist and have been live in core for a while.
- The handlers in core enforce per-tenant isolation — a user with API key X can only delete their own atoms.
- ` destructiveHint: true` triggers MCP clients (Claude Desktop, Cursor) to surface a confirmation dialog to the user.
- The ` confirm` interlock for domain delete is belt-and-suspenders.

## Version bump

` 0.2.0 → 0.3.0` — additive tools, no breaking changes. ` server.json` regenerated by ` npm run prebuild`.

## Test plan

Local Claude Desktop test (after merge + npm publish):

1. Update Claude Desktop config to point at the new version
2. Restart Claude Desktop
3. Ask: \"What memories do I have about the LoCoMo benchmark? List them.\" → ` memory_read`
4. Ask: \"Forget the third one.\" → ` memory_delete` (with destructive confirm dialog)
5. Ask: \"Now wipe the whole locomo-full domain.\" → ` memory_delete_domain` (with destructive confirm + interlock)
6. Verify with ` memory_stats` that count dropped

## Reviewer checklist

- [ ] Both tools have ` destructiveHint: true` in annotations
- [ ] ` memory_delete_domain` requires ` confirm=true` (Zod literal)
- [ ] Descriptions tell the model when to refuse
- [ ] REST endpoint paths match core (` /memory/atoms/{id}`, ` /memory/domain/{name}`)
- [ ] Error responses are user-friendly (e.g., \"No memory found with id ...\" instead of raw API error)
- [ ] Version bumped in package.json + server.json + server name

## Companion work

This PR is part of the post-launch hardening track for the Mnemoverse SaaS:
- mnemoverse-core#98 (state machine, merged)
- mnemoverse-core#99 (grace expiration cron)
- mnemoverse-core#100 (memory export endpoint)
- mnemoverse-core#101 (enterprise leads table)
- mnemoverse-portal#22 (Stripe signature gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)