### PR TITLE
fix(memory_delete): handle deleted-count instead of boolean

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -330,9 +330,11 @@ server.registerTool(
       method: "DELETE",
     });
 
-    const r = result as { deleted?: boolean; atom_id?: string };
+    // Core API returns { deleted: <count>, atom_id }. count == 0 means
+    // the atom didn't exist (or was already removed). count >= 1 means it was deleted.
+    const r = result as { deleted: number; atom_id?: string };
 
-    if (r.deleted === false) {
+    if (!r.deleted) {
       return {
         content: [
           {


### PR DESCRIPTION
## Bug

`memory_delete` returns "Deleted memory ..." even when the atom does not exist (or was already removed).

## Root cause

Core API contract: `DELETE /memory/atoms/{id}` returns `{deleted: <count>, atom_id}` where `deleted` is an **integer** (0 = nothing matched, ≥1 = removed). The MCP wrapper asserted the response as `{ deleted?: boolean }` and checked `r.deleted === false`, which never matches for count `0`. So the "no atom found" branch was dead code.

## Fix

4-line change in [src/index.ts:333](src/index.ts#L333). Type the response as `{ deleted: number }` and use a truthiness check (`!r.deleted`) — `0` is the only falsy count, anything ≥1 is a real delete.

## Verification

### 1. Reproduced against production via raw curl

```
DELETE /memory/atoms/{existing}    → {"deleted":1,"atom_id":"..."}
DELETE /memory/atoms/{same again}  → {"deleted":0,"atom_id":"..."}   ← bug surface
DELETE /memory/atoms/not-a-uuid    → HTTP 400 {"detail":"Invalid atom_id"}
```

### 2. End-to-end through MCP stdio after fix

```
✓ initialize                                       → mnemoverse-memory@0.3.0
✓ tools/list (expect 6 tools)                      → all 6 present
✓ memory_write (test atom)                         → Stored, ID returned
✓ memory_read (find the atom)                      → 73% relevance, 80ms
✓ memory_delete (existing atom)                    → "Deleted memory ..."
✓ memory_delete (same atom again — regression)     → "No memory found ..." ← FIX VERIFIED
✓ memory_delete_domain (cleanup, confirm:true)     → "Deleted 0 memories from domain ..."
```

`memory_delete_domain` was already correct (it types `deleted` as `number` and uses it numerically). Only the single-atom variant was broken.

## Risk

Zero — pure bug fix, no API/contract change, no new dependencies. The dead `if (r.deleted === false)` branch becomes live; the previously-always-taken "Deleted memory" branch only fires on real deletes.

## Why before publish

We are about to ship `0.3.0` to npm. Without this fix, every Claude Desktop / Cursor user who tries to delete an already-removed atom will see a false success message. Trivial to fix now, awkward to patch as `0.3.1` after the fact.