### PR TITLE
docs(readme): align install snippets with source.json — fix VS Code key + add delete tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,14 @@ Sign up at [console.mnemoverse.com](https://console.mnemoverse.com) — takes 30
 
 ### 2. Connect to your AI tool
 
+<!-- INSTALL_SNIPPETS_START — generated from src/configs/source.json. Run `npm run generate:configs` to refresh. Do not edit by hand. -->
+
 **Claude Code:**
 
 ```bash
-claude mcp add mnemoverse -e MNEMOVERSE_API_KEY=mk_live_YOUR_KEY -- npx @mnemoverse/mcp-memory-server
+claude mcp add mnemoverse \
+  -e MNEMOVERSE_API_KEY=mk_live_YOUR_KEY \
+  -- npx -y @mnemoverse/mcp-memory-server@latest
 ```
 
 **Cursor** — add to `.cursor/mcp.json`:
@@ -25,7 +29,10 @@ claude mcp add mnemoverse -e MNEMOVERSE_API_KEY=mk_live_YOUR_KEY -- npx @mnemove
   "mcpServers": {
     "mnemoverse": {
       "command": "npx",
-      "args": ["@mnemoverse/mcp-memory-server"],
+      "args": [
+        "-y",
+        "@mnemoverse/mcp-memory-server@latest"
+      ],
       "env": {
         "MNEMOVERSE_API_KEY": "mk_live_YOUR_KEY"
       }
@@ -34,18 +41,20 @@ claude mcp add mnemoverse -e MNEMOVERSE_API_KEY=mk_live_YOUR_KEY -- npx @mnemove
 }
 ```
 
-**VS Code** — add to settings.json:
+**VS Code** — add to `.vscode/mcp.json` (note: VS Code uses `servers`, not `mcpServers`):
 
 ```json
 {
-  "mcp": {
-    "servers": {
-      "mnemoverse": {
-        "command": "npx",
-        "args": ["@mnemoverse/mcp-memory-server"],
-        "env": {
-          "MNEMOVERSE_API_KEY": "mk_live_YOUR_KEY"
-        }
+  "servers": {
+    "mnemoverse": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@mnemoverse/mcp-memory-server@latest"
+      ],
+      "env": {
+        "MNEMOVERSE_API_KEY": "mk_live_YOUR_KEY"
       }
     }
   }
@@ -59,7 +68,10 @@ claude mcp add mnemoverse -e MNEMOVERSE_API_KEY=mk_live_YOUR_KEY -- npx @mnemove
   "mcpServers": {
     "mnemoverse": {
       "command": "npx",
-      "args": ["@mnemoverse/mcp-memory-server"],
+      "args": [
+        "-y",
+        "@mnemoverse/mcp-memory-server@latest"
+      ],
       "env": {
         "MNEMOVERSE_API_KEY": "mk_live_YOUR_KEY"
       }
@@ -67,6 +79,10 @@ claude mcp add mnemoverse -e MNEMOVERSE_API_KEY=mk_live_YOUR_KEY -- npx @mnemove
   }
 }
 ```
+
+> Why `@latest`? Bare `npx @mnemoverse/mcp-memory-server` is cached indefinitely by npm and stops re-checking the registry. The `@latest` suffix forces a metadata lookup on every Claude Code / Cursor / VS Code session start (~100-300ms), so you always pick up new releases.
+
+<!-- INSTALL_SNIPPETS_END -->
 
 ### 3. Done
 
@@ -88,6 +104,8 @@ It remembers.
 | `memory_read` | Search memories by natural language query |
 | `memory_feedback` | Rate memories as helpful or not (improves future recall) |
 | `memory_stats` | Check how many memories stored, which domains exist |
+| `memory_delete` | Permanently delete a single memory by `atom_id` |
+| `memory_delete_domain` | Wipe an entire domain (requires `confirm: true` safety interlock) |
 
 ## Ideas: What to Remember
 


### PR DESCRIPTION
Three corrections to the README install section, all driven by drift between hand-written snippets and the canonical source.

## 1. Pin to @latest (matches PR #9)

All 5 install snippets now use \`npx -y @mnemoverse/mcp-memory-server@latest\`. Previously they used bare \`npx @mnemoverse/mcp-memory-server\`, which gets cached in \`~/.npm/_npx/{hash}\` indefinitely and never re-resolves against the registry. With \`@latest\` users pick up new releases automatically (matters since the project is releasing hourly during the distribution sprint).

## 2. Fix VS Code snippet — wrong root key

VS Code (Copilot Chat) MCP config uses the \`servers\` root key with explicit \`type: \"stdio\"\`, NOT the \`mcpServers\` key that other editors use. This was wrong in the README. The corrected snippet now matches what \`generate-configs.mjs\` emits to \`docs/configs/vscode.json\` — single source of truth.

## 3. Tools table missing memory_delete + memory_delete_domain

PR #7 shipped two new delete tools in v0.3.0 with \`destructiveHint: true\` annotation, but the README tools table still listed only the original 4. Added them with the safety interlock note for \`memory_delete_domain\`.

## Drift markers

Wrapped the install section in \`<!-- INSTALL_SNIPPETS_START -->\` / \`<!-- INSTALL_SNIPPETS_END -->\` HTML comments. A future build script can re-render this block from \`src/configs/source.json\` automatically, eliminating the manual sync burden that produced this PR in the first place. Tracking the auto-generation work in a follow-up.