### PR TITLE
chore(server.json): upgrade schema 2025-09-29 → 2025-12-11

### DIFF
--- a/scripts/generate-configs.mjs
+++ b/scripts/generate-configs.mjs
@@ -293,12 +293,26 @@ function rewriteReadme(currentReadme, freshBlock) {
  * Official MCP Registry server.json.
  *
  * https://registry.modelcontextprotocol.io/
- * Schema: https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json
+ * Schema: https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json
+ *
+ * The canonical shape was verified empirically by running `mcp-publisher init`
+ * in a sandbox and matching its output. Key differences vs the older
+ * 2025-09-29 schema: registryName → registryType, packages[0].name →
+ * packages[0].identifier, new required `transport` object, dropped
+ * runtimeArguments (the registry runtime builds its own launch command
+ * from identifier + version), and environmentVariables entries gained a
+ * `format` field.
+ *
+ * The `@latest` pin we use in docs/configs/* does NOT belong here — that
+ * is for direct JSON-snippet installs where users stay on the bleeding
+ * edge. Registry-installed clients get the exact pinned version from
+ * server.json.version and we re-publish on each npm release to advance
+ * them.
  */
 function genServerJson() {
   return {
     $schema:
-      "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+      "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
     name: "io.github.mnemoverse/mcp-memory-server",
     description: source.description,
     repository: {
@@ -308,14 +322,17 @@ function genServerJson() {
     version: PACKAGE_VERSION,
     packages: [
       {
-        registryName: source.package.registry,
-        name: source.package.name,
+        registryType: source.package.registry,
+        identifier: source.package.name,
         version: PACKAGE_VERSION,
-        runtimeArguments: source.args.slice(1), // skip "-y"
+        transport: {
+          type: "stdio",
+        },
         environmentVariables: Object.entries(source.env).map(([key, meta]) => ({
           name: key,
           description: meta.description,
           isRequired: meta.required ?? false,
+          format: "string",
           isSecret: meta.secret ?? false,
         })),
       },

--- a/server.json
+++ b/server.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.mnemoverse/mcp-memory-server",
   "description": "Persistent memory for AI agents — write once, recall anywhere across all your AI tools",
   "repository": {
@@ -9,17 +9,18 @@
   "version": "0.3.0",
   "packages": [
     {
-      "registryName": "npm",
-      "name": "@mnemoverse/mcp-memory-server",
+      "registryType": "npm",
+      "identifier": "@mnemoverse/mcp-memory-server",
       "version": "0.3.0",
-      "runtimeArguments": [
-        "@mnemoverse/mcp-memory-server@latest"
-      ],
+      "transport": {
+        "type": "stdio"
+      },
       "environmentVariables": [
         {
           "name": "MNEMOVERSE_API_KEY",
           "description": "Your Mnemoverse API key (starts with mk_live_). Get one free at https://console.mnemoverse.com",
           "isRequired": true,
+          "format": "string",
           "isSecret": true
         }
       ]


### PR DESCRIPTION
Prerequisite for **Phase 1.3 — submit to the Official MCP Registry** (\`registry.modelcontextprotocol.io\`).

## Why

The Registry [quickstart](https://modelcontextprotocol.io/registry/quickstart) uses schema version \`2025-12-11\` as of today. Our \`server.json\` generator was emitting the older \`2025-09-29\` shape, which would still publish but drifts from canonical. Aligning to the current schema now means no surprises at \`mcp-publisher publish\` time and clean forward compat.

## How I verified the canonical shape

Ran \`mcp-publisher init\` in a sandbox with a stub package.json matching ours and diffed the output against our \`server.json\`. That plus the \`validate\` subcommand (new in \`mcp-publisher\` 1.5.0) gives a round-trip check:

\`\`\`
$ mcp-publisher validate
Validating against https://registry.modelcontextprotocol.io...
✅ server.json is valid
\`\`\`

## Schema changes (inside \`packages[0]\`)

| Before (2025-09-29) | After (2025-12-11) |
| --- | --- |
| \`registryName: "npm"\` | \`registryType: "npm"\` |
| \`name: "@mnemoverse/..."\` | \`identifier: "@mnemoverse/..."\` |
| (no transport field) | \`transport: { type: "stdio" }\` (required) |
| \`runtimeArguments: ["@name@latest"]\` | dropped — see below |
| \`environmentVariables[].{name,description,isRequired,isSecret}\` | same + \`format: "string"\` |

### Why \`runtimeArguments\` is gone

The canonical \`mcp-publisher init\` output does NOT include \`runtimeArguments\` at all — the registry runtime builds its own launch command from \`identifier + version\`. The \`-y @mnemoverse/mcp-memory-server@latest\` pin we use in \`docs/configs/*\` is for a DIFFERENT install path: direct JSON-snippet installs (Cursor \`.cursor/mcp.json\`, Claude Desktop config, etc.) where users want the bleeding-edge release. Those snippets are untouched by this PR.

Registry-installed clients get the exact pinned version from \`server.json.version\`, and we re-publish to the Registry on each npm release to advance them. That is the intended behavior of the Registry metadata model.

## Files touched

- \`scripts/generate-configs.mjs\`: \`genServerJson()\` rewritten for the new shape (+ a header comment explaining the non-obvious parts)
- \`server.json\`: regenerated (single-source-of-truth pipeline did the write — we never hand-edit this file, per CONTRIBUTING.md)

That's the complete diff. No other artifacts change — \`docs/configs/*\`, \`smithery.yaml\`, README install block, markdown partials all stay identical because this upgrade only affects the Registry manifest.

## Drift gate

\`verify-configs.yml\` (our new CI gate from PR #11) runs against this shape going forward. Drift check exit 0 locally and on the pre-push hook.