### PR TITLE
release: v0.3.1 — UX polish + better registry discoverability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
 node_modules/
 dist/
 .env
+
+# mcp-publisher CLI stores JWTs for the Official MCP Registry in the
+# current working directory. NEVER commit these — they are live
+# credentials that grant publish rights to io.github.mnemoverse/*.
+.mcpregistry_github_token
+.mcpregistry_registry_token
+
+# Local test artifacts
+*.tgz

--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # @mnemoverse/mcp-memory-server
 
-Persistent AI memory for Claude Code, Cursor, VS Code, and any MCP client.
+[![npm version](https://img.shields.io/npm/v/@mnemoverse/mcp-memory-server.svg?color=cb3837&label=npm)](https://www.npmjs.com/package/@mnemoverse/mcp-memory-server)
+[![npm downloads](https://img.shields.io/npm/dm/@mnemoverse/mcp-memory-server.svg?color=blue&label=downloads)](https://www.npmjs.com/package/@mnemoverse/mcp-memory-server)
+[![MCP Registry](https://img.shields.io/badge/MCP_Registry-listed-0ea5e9)](https://registry.modelcontextprotocol.io/v0.1/servers?search=mnemoverse)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 
-Your agent remembers everything — across sessions, projects, and tools. One memory, everywhere.
+Shared AI memory across Claude, Cursor, VS Code, ChatGPT, and any MCP client. Write once, recall anywhere.
+
+Your agent remembers everything — across sessions, projects, and tools. One API key, one memory, everywhere.
 
 ## Quick Start
 
@@ -84,17 +89,23 @@ claude mcp add mnemoverse \
 
 <!-- INSTALL_SNIPPETS_END -->
 
-### 3. Done
+> ⚠️ **Restart your AI client** after editing the config. MCP servers are only picked up on client startup.
 
-Your AI now has persistent memory. Try:
+### 3. Try it — 30 seconds to verify it works
 
-> "Remember that I prefer Railway for deployments"
+Paste this in your AI chat:
 
-Then in a new session:
+> **"Remember that my favourite TypeScript framework is Hono, and please call `memory_write` to save it."**
 
-> "Where should I deploy this?"
+Your agent should call `memory_write` and confirm the memory was stored.
 
-It remembers.
+Then open a **new chat / new session** (this is the whole point — memory survives restarts), and ask:
+
+> **"What's my favourite TypeScript framework?"**
+
+Your agent should call `memory_read`, find the entry, and answer "Hono". If it does — you're wired up. Write whatever you want next.
+
+If it doesn't remember: check that the client was fully restarted and the config has your real `mk_live_...` key, not the placeholder.
 
 ## Tools
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mnemoverse/mcp-memory-server",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "MCP server for Mnemoverse Memory API — persistent AI memory across Claude Code, Cursor, VS Code, and any MCP client",
   "type": "module",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -1,17 +1,17 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.mnemoverse/mcp-memory-server",
-  "description": "Persistent memory for AI agents — write once, recall anywhere across all your AI tools",
+  "description": "Shared AI memory across Claude, Cursor, VS Code, ChatGPT. Write once, recall anywhere.",
   "repository": {
     "url": "https://github.com/mnemoverse/mcp-memory-server",
     "source": "github"
   },
-  "version": "0.3.0",
+  "version": "0.3.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mnemoverse/mcp-memory-server",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "transport": {
         "type": "stdio"
       },

--- a/src/configs/source.json
+++ b/src/configs/source.json
@@ -2,7 +2,7 @@
   "$comment": "SINGLE SOURCE OF TRUTH for all distribution channel configs. Edit this file → run `npm run generate:configs` → all 9+ artifacts regenerate. CI verifies committed artifacts match source.",
   "name": "mnemoverse",
   "displayName": "Mnemoverse Memory",
-  "description": "Persistent memory for AI agents — write once, recall anywhere across all your AI tools",
+  "description": "Shared AI memory across Claude, Cursor, VS Code, ChatGPT. Write once, recall anywhere.",
   "type": "stdio",
   "command": "npx",
   "args": ["-y", "@mnemoverse/mcp-memory-server@latest"],

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ function capResult(text: string): string {
 
 const server = new McpServer({
   name: "mnemoverse-memory",
-  version: "0.3.0",
+  version: "0.3.1",
 });
 
 // --- Tool: memory_write ---


### PR DESCRIPTION
## Why

After publishing v0.3.0 to the Official MCP Registry we walked the full user journey as a fresh developer ("Alexey") and found three frictions that we can fix in under an hour:

1. **Generic description** in \`src/configs/source.json\` — we ranked at **position #70 of 100+** "memory for AI agents" entries in the registry search, buried between \`com.letta/memory-mcp\`, \`io.github.DanielGuru/repomemory\`, \`io.github.DeusData/codebase-memory-mcp\`, etc. Our description had nothing specific to differentiate us.
2. **README had no visual trust signals** (no badges) and no explicit "did it work?" test sequence after install.
3. **No restart-your-client warning** after config paste — MCP-specific knowledge that not all new users have.

## Fixes

### \`src/configs/source.json\` (drives \`server.json\` via the generator)

\`description\` rewritten to front-load the SEO-relevant differentiator:

> **Before:** \`Persistent memory for AI agents — write once, recall anywhere across all your AI tools\`
> **After:**  \`Shared AI memory across Claude, Cursor, VS Code, ChatGPT. Write once, recall anywhere.\`

Client names up front beat generic phrases in registry search. 86 chars, under the 100-char schema limit. Validates against \`registry.modelcontextprotocol.io\` via \`mcp-publisher validate\`.

### \`README.md\`

- **Badges** at the top: npm version, monthly downloads, MCP Registry listed, MIT license
- **Tagline** updated to match the new source-of-truth description
- **"Try it — 30 seconds to verify it works"** section added with an explicit 3-step test: say a specific fact to store, open a new chat, ask it back. Addresses "how do I know it worked" gap
- **Restart warning** between the install snippets and the try section because MCP servers only pick up config changes on client startup, and new users don't always know that

### Version bump

- \`package.json\`: 0.3.0 → 0.3.1
- \`src/index.ts\`: \`version: "0.3.0"\` → \`"0.3.1"\` (serverInfo reported over MCP handshake)
- \`server.json\`: regenerated — picks up the new description and version through the single-source-of-truth pipeline

### \`.gitignore\` — security fix (unrelated to the above but shipped together)

\`mcp-publisher login github\` stores JWT credentials in two files in the current working directory: \`.mcpregistry_github_token\` and \`.mcpregistry_registry_token\`. This is a CLI anti-pattern (secrets should live in \`~/.config/mcp-publisher/\`, not \`\$cwd\`) but it is what the tool does as of 1.5.0. Added explicit entries to \`.gitignore\` so they can never be accidentally staged. This was caught by \`git add -A\` during local release prep — amended before push, verified across the full reflog.

## Not in scope

- **console.mnemoverse.com sign-up flow**: verified manually by Eduard, reported as "one click, simple, works great" — no changes needed.
- **SEO ranking in the registry**: not directly controllable. The better description earns some clickthroughs via the client names in search results.
- **Stars / social proof**: the repo is brand new, stars will come from real usage. Not a code change.
- **Landing page with "Add to Cursor" deep link buttons**: separate task in \`mnemoverse-docs\` (Phase B).

## Verification done

- \`mcp-publisher validate\` → "✅ server.json is valid"
- \`npm run verify:configs\` → "All 15 artifacts in sync with source.json"
- \`npm run build\` → clean
- \`npm pack\` + sandbox install + stdio initialize handshake → \`serverInfo.version\` reports \`"0.3.1"\`
- Pre-push hook on this PR's push ran the drift check and passed before hitting GitHub