### PR TITLE
feat(release): automate npm + MCP Registry publish via OIDC on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,138 @@
+name: release
+
+# Automated release pipeline for @mnemoverse/mcp-memory-server.
+#
+# Trigger: push a semver tag `vX.Y.Z` to main (e.g. `git tag v0.3.2 && git push origin v0.3.2`).
+#
+# What this workflow does, in order:
+#   1. Checks that the tag's version matches package.json#version (catches "forgot to bump" mistakes).
+#   2. npm ci + npm run build (prebuild regenerates every generated artifact from source.json).
+#   3. npm run verify:configs — drift check, fails fast if anything is out of sync with source.json.
+#   4. npm publish — uses a repo-scoped automation token stored in the NPM_TOKEN secret.
+#   5. Installs mcp-publisher CLI (Linux amd64 bottle from the releases bucket).
+#   6. mcp-publisher login github-oidc — uses GitHub Actions' OIDC token, NO stored PAT.
+#   7. mcp-publisher publish — uploads the freshly-generated server.json to registry.modelcontextprotocol.io.
+#   8. gh release create — posts a GitHub release with auto-generated notes.
+#
+# Why OIDC instead of a PAT:
+# The GitHub OIDC provider issues a short-lived JWT that the MCP Registry trusts on the basis
+# of the repo's owner (mnemoverse) and branch/tag claim. No long-lived secret sits in the repo.
+# Prereq: `permissions: id-token: write` on the job, and the authenticating user's org
+# membership (izgorodin in mnemoverse) must be public — already done.
+#
+# Prerequisite secrets you must add at repo Settings > Secrets and variables > Actions:
+#   - NPM_TOKEN — npm automation token from npmjs.com/settings/{org}/tokens/granular-access-tokens/new
+#                 (select "Automation", grant publish access to @mnemoverse/mcp-memory-server).
+#
+# To release:
+#   1. Bump version in package.json + src/index.ts on main (keep them in sync).
+#   2. `npm run generate:configs` to propagate the new version to server.json.
+#   3. Commit, push to main (through PR, drift CI passes).
+#   4. `git tag v$(node -p "require('./package.json').version")`.
+#   5. `git push origin v0.x.y`.
+# The workflow does the rest.
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v0.3.2). Must already exist."
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      # contents:write — needed to create the GitHub release.
+      # id-token:write — required by `mcp-publisher login github-oidc`.
+      contents: write
+      id-token: write
+
+    steps:
+      - name: Checkout tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Verify tag matches package.json#version
+        run: |
+          set -euo pipefail
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          TAG_VERSION="${TAG#v}"
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          echo "tag:         $TAG"
+          echo "tag version: $TAG_VERSION"
+          echo "pkg version: $PKG_VERSION"
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag $TAG (version $TAG_VERSION) does not match package.json version $PKG_VERSION"
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build (runs generate:configs via prebuild)
+        run: npm run build
+
+      - name: Verify no drift between source.json and generated artifacts
+        run: npm run verify:configs
+
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Install mcp-publisher CLI
+        run: |
+          set -euo pipefail
+          curl -sSL \
+            "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" \
+            | tar xz mcp-publisher
+          ./mcp-publisher --help
+
+      - name: Authenticate with MCP Registry via GitHub OIDC
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to Official MCP Registry
+        run: ./mcp-publisher publish
+
+      - name: Verify the registry entry shows the new version
+        run: |
+          set -euo pipefail
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          VERSION="${TAG#v}"
+          echo "Waiting a few seconds for the registry to propagate..."
+          sleep 3
+          RESULT="$(curl -sS "https://registry.modelcontextprotocol.io/v0.1/servers/io.github.mnemoverse%2Fmcp-memory-server/versions/$VERSION")"
+          echo "$RESULT" | python3 -m json.tool
+          echo "$RESULT" | python3 -c "
+          import sys, json
+          d = json.load(sys.stdin)
+          srv = d['server']
+          assert srv['version'] == '$VERSION', f\"registry version {srv['version']} != $VERSION\"
+          print(f'✓ Registry shows {srv[\"name\"]}@{srv[\"version\"]}')
+          "
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.inputs.tag || github.ref_name }}
+          name: ${{ github.event.inputs.tag || github.ref_name }}
+          generate_release_notes: true
+          body: |
+            Published via automated release pipeline (`.github/workflows/release.yml`).
+
+            - npm: https://www.npmjs.com/package/@mnemoverse/mcp-memory-server
+            - MCP Registry: https://registry.modelcontextprotocol.io/v0.1/servers?search=mnemoverse
+
+            Full changelog below.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,9 +103,13 @@ The generator is **idempotent**: running it twice in a row produces zero changes
 
 `package.json#version` → `src/index.ts#version` (server name reported to MCP clients) → `server.json#version` (Official MCP Registry).
 
-Today these are bumped manually and kept in sync by hand. If they drift, the generator's drift check on `server.json` will catch it (because `server.json` is generated from `package.json#version`).
+These are bumped manually in the first two files and propagated by the generator to the third. If they drift, the drift check on `server.json` catches it on every PR.
 
-When releasing:
+### Automated release pipeline
+
+Releases are automated by [`.github/workflows/release.yml`](.github/workflows/release.yml). You bump the version on `main`, push a semver tag, and the workflow does the rest: npm publish, MCP Registry publish (via GitHub OIDC — no stored PAT), GitHub release.
+
+The workflow is triggered by any tag matching `v*` pushed to the repo. To release:
 
 ```bash
 # 1. Bump version in package.json
@@ -117,19 +121,55 @@ $EDITOR src/index.ts
 # 3. Regenerate (this updates server.json to match)
 npm run generate:configs
 
-# 4. Build and run e2e
+# 4. Build and run any local checks you want before tagging
 npm run build
-# ... live e2e against production ...
+npm run verify:configs
 
-# 5. Commit, tag, push, publish
-git add -A && git commit -m "chore: release vX.Y.Z"
-git tag -a vX.Y.Z -m "..."
-git push origin main vX.Y.Z
-npm publish
-gh release create vX.Y.Z --notes "..."
+# 5. PR + squash-merge to main (drift CI runs on the PR)
+git checkout -b release/vX.Y.Z
+git add -A && git commit -m "release: vX.Y.Z"
+git push -u origin release/vX.Y.Z
+gh pr create --fill && gh pr merge --squash --delete-branch
+git checkout main && git pull --ff-only
+
+# 6. Tag main and push the tag
+git tag -a vX.Y.Z -m "vX.Y.Z"
+git push origin vX.Y.Z
 ```
 
-A future PR will templatize `src/index.ts#version` so `package.json` is the only place to edit it.
+That push fires [`.github/workflows/release.yml`](.github/workflows/release.yml), which:
+
+1. Verifies the tag matches `package.json#version` (belt and suspenders).
+2. Runs `npm ci && npm run build` (which also runs `generate:configs` via `prebuild`).
+3. Runs `npm run verify:configs` for drift.
+4. `npm publish` using the `NPM_TOKEN` secret.
+5. Installs `mcp-publisher` from its Linux amd64 release bottle.
+6. Authenticates to the Registry via `mcp-publisher login github-oidc` — this uses GitHub Actions' OIDC identity token. **No long-lived PAT is stored anywhere.** The prerequisite is that the authenticating GitHub account's membership in the `mnemoverse` org be **public** (already the case for `izgorodin`).
+7. `mcp-publisher publish` uploads the freshly-generated `server.json`.
+8. Verifies the registry entry via a direct curl against the public API.
+9. Creates a GitHub release with auto-generated notes.
+
+If any step fails, the release is aborted — nothing partial gets published. You can re-push the same tag after fixing the issue.
+
+### One-time setup for the workflow
+
+A single secret must be added at [Settings → Secrets → Actions](https://github.com/mnemoverse/mcp-memory-server/settings/secrets/actions):
+
+| Secret | How to get it |
+| ------ | ------------- |
+| `NPM_TOKEN` | [npmjs.com → Settings → Access Tokens → Generate New Token](https://www.npmjs.com/settings/mnemoverse/tokens/granular-access-tokens/new) → **Automation** token, scope: publish to `@mnemoverse/mcp-memory-server`. |
+
+Nothing else. GitHub OIDC provides the MCP Registry credential at run time, so we do not store an `MCP_GITHUB_TOKEN` secret at all.
+
+### Manual trigger
+
+If you need to re-run the pipeline for a tag that was already pushed (e.g. the workflow was added after the tag), use `workflow_dispatch`:
+
+```bash
+gh workflow run release.yml -f tag=v0.3.1
+```
+
+Or click **Run workflow** on the Actions tab and enter the tag.
 
 ## Testing changes locally
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,15 @@
 #!/usr/bin/env node
 
+import { createRequire } from "node:module";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
+
+// Version is read at runtime from package.json so there is exactly one place
+// to bump on each release. Works both from `dist/` during local dev and from
+// `node_modules/@mnemoverse/mcp-memory-server/dist/` after an npm install.
+const require = createRequire(import.meta.url);
+const pkg = require("../package.json") as { version: string };
 
 const API_URL =
   process.env.MNEMOVERSE_API_URL || "https://core.mnemoverse.com/api/v1";
@@ -59,7 +66,7 @@ function capResult(text: string): string {
 
 const server = new McpServer({
   name: "mnemoverse-memory",
-  version: "0.3.1",
+  version: pkg.version,
 });
 
 // --- Tool: memory_write ---


### PR DESCRIPTION
You asked: _"а сделай это в сиай чтобы мы просто пушили и оно само ок?"_ — yes, here it is.

## What this PR adds

### 1. [\`.github/workflows/release.yml\`](.github/workflows/release.yml) (new)

Tag-triggered release pipeline. You push \`vX.Y.Z\`, everything else is automatic:

| Step | What happens |
| ---- | ------------ |
| 1 | Checkout the tag |
| 2 | **Verify** tag version equals \`package.json#version\` — catches "forgot to bump" |
| 3 | \`npm ci && npm run build\` (prebuild runs generate:configs) |
| 4 | \`npm run verify:configs\` — drift gate |
| 5 | \`npm publish --access public\` using \`NPM_TOKEN\` |
| 6 | Install \`mcp-publisher\` from its Linux amd64 release bottle |
| 7 | \`mcp-publisher login github-oidc\` — uses GitHub Actions OIDC token, **no stored PAT** |
| 8 | \`mcp-publisher publish\` uploads the freshly-generated server.json |
| 9 | Curl the public API to verify the new version is there |
| 10 | \`softprops/action-gh-release@v2\` creates the GitHub release |

Follows the canonical workflow from [modelcontextprotocol.io/registry/github-actions](https://modelcontextprotocol.io/registry/github-actions), OIDC variant.

### 2. [\`src/index.ts\`](src/index.ts#L9-L14) — version now read from package.json at runtime

Previously we had to bump the literal \`"0.3.1"\` in two places. Now it reads via:

\`\`\`ts
const require = createRequire(import.meta.url);
const pkg = require("../package.json") as { version: string };
// ... new McpServer({ name: "mnemoverse-memory", version: pkg.version })
\`\`\`

Verified locally — \`node dist/index.js\` over stdio returns \`serverInfo.version == "0.3.1"\` (from package.json) with zero edits to src/index.ts.

### 3. [\`CONTRIBUTING.md\`](CONTRIBUTING.md) — release section rewritten

- Documents the new \`bump → PR → merge → tag → push\` flow.
- Explains why \`NPM_TOKEN\` is the only secret needed.
- Explicitly notes we do NOT store an \`MCP_GITHUB_TOKEN\` — OIDC handles it.
- Includes the \`workflow_dispatch\` manual-trigger path for re-running the pipeline.

## What you need to do, one time

Add one repo secret. Takes ~2 minutes:

1. Go to [npmjs.com → Settings → Granular Access Tokens](https://www.npmjs.com/settings/mnemoverse/tokens/granular-access-tokens/new).
2. Create a new token:
   - Name: \`mcp-memory-server-ci\`
   - Type: **Automation**
   - Packages and scopes: \`@mnemoverse/mcp-memory-server\`, **Read and write**.
   - Expiration: 1 year (or whatever you prefer)
3. Copy the token value.
4. Go to [Settings → Secrets → Actions](https://github.com/mnemoverse/mcp-memory-server/settings/secrets/actions).
5. **New repository secret**:
   - Name: \`NPM_TOKEN\`
   - Value: (paste)
6. Save.

Nothing else. No PAT, no GitHub token, no DNS key. OIDC is handled by GitHub Actions directly — it works because your membership in the \`mnemoverse\` org is already public (we did that for the Device Flow in the v0.3.0 release).

## What we do NOT need

- **MCP_GITHUB_TOKEN** — not needed. OIDC replaces it.
- **Releases publishing via Device Flow** — no more browser prompts. The CLI tool saves its JWT to \`\$cwd\` (a known anti-pattern we gitignored in v0.3.1), but CI never uses that codepath.

## First test plan

1. Merge this PR.
2. On main, cut a one-line patch as v0.3.2 (e.g. tiny README tweak), bump versions, push tag.
3. Watch the Actions run at https://github.com/mnemoverse/mcp-memory-server/actions
4. Verify registry shows v0.3.2 after green.
5. Done — future releases are just \`git tag; git push\`.

If the OIDC step fails (unlikely but possible if the Registry's OIDC claim check differs for org-owned repos), fallback to \`github-pat\` variant — ~5-min change to the workflow.

## Verification done locally

- \`node dist/index.js\` handshake → \`serverInfo.version: "0.3.1"\` (from package.json, not the hardcoded string).
- \`npm run build\` → clean, no drift.
- Pre-push hook on this PR's push ran drift check → passed.