### PR TITLE
release: v0.3.3 — metadata + Registry SEO polish (audit tier 2)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Mnemoverse
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -154,7 +154,10 @@ The same API key works across all tools. Write a memory in Claude Code — read 
 - [API Reference](https://mnemoverse.com/docs/api/reference)
 - [Console (get API key)](https://console.mnemoverse.com)
 - [GitHub](https://github.com/mnemoverse/mcp-memory-server)
+- [Releases](https://github.com/mnemoverse/mcp-memory-server/releases)
+- [MCP Registry entry](https://registry.modelcontextprotocol.io/v0.1/servers?search=mnemoverse)
+- [Contributing](CONTRIBUTING.md)
 
 ## License
 
-MIT
+[MIT](LICENSE) © Mnemoverse

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mnemoverse/mcp-memory-server",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "MCP server for Mnemoverse Memory API — persistent AI memory across Claude Code, Cursor, VS Code, and any MCP client",
   "type": "module",
   "bin": {
@@ -8,6 +8,12 @@
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "package.json"
+  ],
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
@@ -23,10 +29,15 @@
     "mcp",
     "memory",
     "ai",
+    "ai-agent",
     "claude",
     "cursor",
+    "vscode",
+    "chatgpt",
     "mnemoverse",
     "persistent-memory",
+    "shared-memory",
+    "cross-tool",
     "model-context-protocol"
   ],
   "author": "Mnemoverse <hello@mnemoverse.com>",

--- a/scripts/generate-configs.mjs
+++ b/scripts/generate-configs.mjs
@@ -310,14 +310,45 @@ function rewriteReadme(currentReadme, freshBlock) {
  * them.
  */
 function genServerJson() {
+  // Build env vars, conditionally including `default` so absence stays absent
+  // (registry schema validates types strictly — sending "default": undefined
+  // in JSON is different from omitting the key).
+  const environmentVariables = Object.entries(source.env).map(([key, meta]) => {
+    const entry = {
+      name: key,
+      description: meta.description,
+      isRequired: meta.required ?? false,
+      format: "string",
+      isSecret: meta.secret ?? false,
+    };
+    if (meta.placeholder) {
+      // `default` is the 2025-12-11 field for an example/placeholder value
+      // that clients can surface in their config UI.
+      entry.default = meta.placeholder;
+    }
+    return entry;
+  });
+
   return {
     $schema:
       "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
     name: "io.github.mnemoverse/mcp-memory-server",
+    // `title` is the human-friendly display label shown in registry UIs —
+    // without it the UI falls back to the reverse-DNS name which is unreadable.
+    title: source.title || source.displayName,
     description: source.description,
+    // `websiteUrl` surfaces separately from `repository.url` in registry UIs,
+    // giving a second, distinct clickthrough (landing page vs source code).
+    ...(source.websiteUrl ? { websiteUrl: source.websiteUrl } : {}),
     repository: {
       url: source.metadata.repository,
       source: "github",
+      // `id` is GitHub's numeric repository ID — an anti-resurrection trust
+      // marker. Even if the repo is deleted and recreated at the same URL,
+      // the new id would differ and clients can detect the swap.
+      ...(source.metadata.repositoryId
+        ? { id: String(source.metadata.repositoryId) }
+        : {}),
     },
     version: PACKAGE_VERSION,
     packages: [
@@ -328,13 +359,7 @@ function genServerJson() {
         transport: {
           type: "stdio",
         },
-        environmentVariables: Object.entries(source.env).map(([key, meta]) => ({
-          name: key,
-          description: meta.description,
-          isRequired: meta.required ?? false,
-          format: "string",
-          isSecret: meta.secret ?? false,
-        })),
+        environmentVariables,
       },
     ],
   };

--- a/server.json
+++ b/server.json
@@ -1,17 +1,20 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.mnemoverse/mcp-memory-server",
-  "description": "Shared AI memory across Claude, Cursor, VS Code, ChatGPT. Write once, recall anywhere.",
+  "title": "Mnemoverse Memory",
+  "description": "Persistent memory across Claude, Cursor, ChatGPT, VS Code. Importance scoring, linked recall.",
+  "websiteUrl": "https://mnemoverse.com",
   "repository": {
     "url": "https://github.com/mnemoverse/mcp-memory-server",
-    "source": "github"
+    "source": "github",
+    "id": "1207193530"
   },
-  "version": "0.3.2",
+  "version": "0.3.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mnemoverse/mcp-memory-server",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "transport": {
         "type": "stdio"
       },
@@ -21,7 +24,8 @@
           "description": "Your Mnemoverse API key (starts with mk_live_). Get one free at https://console.mnemoverse.com",
           "isRequired": true,
           "format": "string",
-          "isSecret": true
+          "isSecret": true,
+          "default": "mk_live_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
         }
       ]
     }

--- a/src/configs/source.json
+++ b/src/configs/source.json
@@ -2,13 +2,16 @@
   "$comment": "SINGLE SOURCE OF TRUTH for all distribution channel configs. Edit this file → run `npm run generate:configs` → all 9+ artifacts regenerate. CI verifies committed artifacts match source.",
   "name": "mnemoverse",
   "displayName": "Mnemoverse Memory",
-  "description": "Shared AI memory across Claude, Cursor, VS Code, ChatGPT. Write once, recall anywhere.",
+  "title": "Mnemoverse Memory",
+  "description": "Persistent memory across Claude, Cursor, ChatGPT, VS Code. Importance scoring, linked recall.",
+  "websiteUrl": "https://mnemoverse.com",
   "type": "stdio",
   "command": "npx",
   "args": ["-y", "@mnemoverse/mcp-memory-server@latest"],
   "env": {
     "MNEMOVERSE_API_KEY": {
       "value": "mk_live_YOUR_KEY",
+      "placeholder": "mk_live_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
       "description": "Your Mnemoverse API key (starts with mk_live_). Get one free at https://console.mnemoverse.com",
       "required": true,
       "secret": true
@@ -21,6 +24,7 @@
   "metadata": {
     "homepage": "https://mnemoverse.com/docs/api/mcp-server",
     "repository": "https://github.com/mnemoverse/mcp-memory-server",
+    "repositoryId": 1207193530,
     "license": "MIT",
     "author": "Mnemoverse",
     "tags": ["memory", "persistent", "ai-agents", "cross-tool", "oauth"]


### PR DESCRIPTION
Second and final patch from the 5-agent audit. v0.3.2 shipped the six P1 code bugs; this patch ships all ten P2/P3 metadata and SEO findings. **Zero runtime code change** — the only file under \`src/\` that moves is the source-of-truth JSON that drives the generator.

This is also the **second change-shape test** of the automated release pipeline: v0.3.2 exercised code-only, v0.3.3 exercises metadata-only.

## What changed

### 1. LICENSE file (new)
Agent 3 flagged: package.json claimed MIT but there was no LICENSE text in the repo. Added standard MIT license text, © 2026 Mnemoverse. Bundled in the tarball via the new \`files\` field.

### 2. package.json \`files\` field — **tarball 54% smaller**

Before: 27 files / 22.8 kB compressed / 76.1 kB unpacked
After:  **6 files / 10.3 kB compressed / 31.3 kB unpacked**

\`\`\`json
"files": ["dist", "README.md", "LICENSE", "package.json"]
\`\`\`

Stops shipping \`src/\`, \`scripts/\`, \`docs/configs/\`, \`docs/snippets/\`, \`.github/\`, \`CONTRIBUTING.md\`, \`smithery.yaml\`, \`server.json\`, \`tsconfig.json\`, \`llms.txt\` — all dev-only surface runtime installers never touch.

### 3. package.json keywords
Added \`ai-agent\`, \`vscode\`, \`chatgpt\`, \`shared-memory\`, \`cross-tool\` per Agent 4 competitive SEO analysis.

### 4. \`src/configs/source.json\` — four new fields
Agent 4 diffed our Registry manifest against 10 direct competitors. Four high-impact additions:

| Field | Why |
| --- | --- |
| \`title: "Mnemoverse Memory"\` | 60% of competitors populate this. Without it registry UIs show our reverse-DNS name \`io.github.mnemoverse/mcp-memory-server\`. |
| \`websiteUrl: "https://mnemoverse.com"\` | Separate clickthrough from \`repository.url\`. Only **1 of 10** competitors uses this field. |
| \`metadata.repositoryId: 1207193530\` | GitHub's numeric repo ID. Anti-resurrection trust marker — if the repo is deleted and recreated at the same URL, the id changes and clients detect the swap. Only DanielGuru's repomemory currently uses it. |
| \`env.MNEMOVERSE_API_KEY.placeholder\` | Maps to the registry schema's \`default\` field. Clients use it to pre-fill config UI with an example value. Was only in description text before. |

### 5. New description
\`\`\`
Before: Shared AI memory across Claude, Cursor, VS Code, ChatGPT. Write once, recall anywhere.        (86 chars)
After:  Persistent memory across Claude, Cursor, ChatGPT, VS Code. Importance scoring, linked recall. (95 chars)
\`\`\`

Front-loads the search term ("persistent memory") and names TWO unique differentiators — \`importance scoring\` and \`linked recall\` — that no other memory server in the Registry mentions. The previous description was poetic ("Write once, recall anywhere") but keyword-poor.

### 6. \`scripts/generate-configs.mjs\` — \`genServerJson()\` extended
Emits \`title\`, \`websiteUrl\` (conditionally), \`repository.id\` (conditionally, stringified), and \`environmentVariables[].default\` (conditionally from the source \`placeholder\`). All additions are conditional — absence in source.json stays absence in server.json, no \`undefined\` leakage.

### 7. README polish
- \`[Releases]\` link → GitHub releases page
- \`[MCP Registry entry]\` link → direct search-through URL
- \`[Contributing]\` link → CONTRIBUTING.md
- License line changed from plain "MIT" to \`[MIT](LICENSE)\` with © attribution

## Verified

- \`mcp-publisher validate\` → "✅ server.json is valid" — the new fields pass registry schema check.
- \`npm run verify:configs\` → all 15 artifacts in sync.
- \`npm run build\` → clean.
- \`npm pack\` → 6 files / 10.3 kB compressed / 31.3 kB unpacked — **54% smaller compressed, 78% fewer files**.
- Sandbox install + stdio initialize → \`serverInfo.version == "0.3.3"\`, all 6 tools present.

## Diff summary

\`\`\`
LICENSE                      |  21 +++++ (new)
README.md                    |   5 ++++-
package.json                 |  13 ++++++++++++-
scripts/generate-configs.mjs |  39 ++++++++++++++++++++++++++++++++-------
server.json                  |  14 +++++++++-----
src/configs/source.json      |   6 +++++-
\`\`\`

Six files, 83 insertions, 15 deletions. Every change is minimal and independently reviewable.

## Post-merge test plan

After merge, \`git tag v0.3.3 && git push origin v0.3.3\` triggers the automated release.yml pipeline for the second time. Expected run time: ~2 min. This validates that the pipeline handles metadata-only releases (no code change) as cleanly as it handled v0.3.2's code-only release.