### PR TITLE
chore(glama): add glama.json (enable Glama indexing + claim)

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["izgorodin"]
+}


### PR DESCRIPTION
Adds `glama.json` so Glama can index and score this server.

**Why:** Glama does not auto-index org-owned repos (`github.com/mnemoverse/...`) without a `glama.json` listing maintainers. Once on `main`, a maintainer runs the Claim flow at glama.ai to trigger indexing + the quality score (TDQS + coherence; MIT = license grade A).

**Unblocks:** the `glama-badge-check` bot note on our [awesome-mcp-servers PR](https://github.com/punkpeye/awesome-mcp-servers/pull/7163) — the Glama badge 404s until the server is indexed.

Trivial config; safe to merge on sight.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added server manifest configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->