### PR TITLE
feat(docker): add Dockerfile (Docker MCP Catalog + self-host)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+dist
+dist-mcpb
+*.mcpb
+.git
+.github
+docs
+*.md
+icon.png

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# syntax=docker/dockerfile:1
+#
+# Container image for the Mnemoverse Memory MCP server (stdio).
+# Used by the Docker MCP Catalog / Toolkit and for self-hosted `docker run -i`.
+# The server reads its API key from the MNEMOVERSE_API_KEY env var.
+
+# ─── build stage: compile TypeScript → dist/ ──────────────────────────────────
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+# Compile TypeScript directly (the repo's `npm run build` also regenerates
+# distribution configs via a prebuild hook that needs README/docs — irrelevant
+# to the runtime image, so we run tsc straight).
+RUN npx tsc
+
+# ─── runtime stage: prod deps + compiled output only ─────────────────────────
+FROM node:20-alpine
+ENV NODE_ENV=production
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev && npm cache clean --force
+COPY --from=build /app/dist ./dist
+
+# MCP stdio server — Claude / Docker MCP Toolkit run it with `-i` and pipe stdio.
+ENTRYPOINT ["node", "dist/index.js"]


### PR DESCRIPTION
Adds a multi-stage `Dockerfile` + `.dockerignore`.

**Validated locally:** `docker build` succeeds; `docker run` (no key) exits with the expected `MNEMOVERSE_API_KEY required` message.

**Why:** prerequisite for listing in the **Docker MCP Catalog / Toolkit** (their registry builds the image from this Dockerfile in the source repo) — closes the one channel where Mem0 has presence and we don't. Also enables self-hosted `docker run -i`.

**Next (after merge):** PR to `docker/mcp-registry` with `servers/mnemoverse/server.yaml` pointing at this repo + commit.

Trivial, no runtime-code changes.