### PR TITLE
chore(dx): .gitattributes eol=lf + declare zod dependency

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Normalize all text files to LF in the repo AND on checkout.
+# scripts/generate-configs.mjs emits LF; without eol=lf, Windows checkouts get
+# CRLF and every `npm run build` shows phantom drift on the generated files.
+* text=auto eol=lf
+
+# Binary assets — never touch line endings.
+*.png binary
+*.ico binary
+*.mcpb binary

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.3.5",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.12.1"
+        "@modelcontextprotocol/sdk": "^1.12.1",
+        "zod": "^4.3.6"
       },
       "bin": {
         "mcp-memory-server": "dist/index.js"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
   },
   "homepage": "https://mnemoverse.com/docs/api/mcp-server",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.12.1"
+    "@modelcontextprotocol/sdk": "^1.12.1",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "typescript": "^5.8.3",


### PR DESCRIPTION
Two repo-hygiene fixes flagged during the distribution sprint:

1. **`.gitattributes` (`* text=auto eol=lf`)** — generator emits LF, so Windows checkouts got CRLF and every `npm run build` showed phantom drift on generated files. Now LF everywhere.
2. **`zod` → `dependencies` (`^4.3.6`)** — `src/index.ts` imports `zod` directly but it was only present transitively via `@modelcontextprotocol/sdk`. Now declared.

Verified: `tsc --noEmit` clean; content drift-check passes (the only local diff was CRLF, which item 1 fixes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added repository configuration to standardize line endings across all text files and preserve binary asset integrity.
  * Added a new dependency to enhance data validation capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->