### PR TITLE
docs(readme): align MCP registry URL to /v0/servers (match docs + facts registry)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/@mnemoverse/mcp-memory-server.svg?color=cb3837&label=npm)](https://www.npmjs.com/package/@mnemoverse/mcp-memory-server)
 [![npm downloads](https://img.shields.io/npm/dm/@mnemoverse/mcp-memory-server.svg?color=blue&label=downloads)](https://www.npmjs.com/package/@mnemoverse/mcp-memory-server)
-[![MCP Registry](https://img.shields.io/badge/MCP_Registry-listed-0ea5e9)](https://registry.modelcontextprotocol.io/v0.1/servers?search=mnemoverse)
+[![MCP Registry](https://img.shields.io/badge/MCP_Registry-listed-0ea5e9)](https://registry.modelcontextprotocol.io/v0/servers?search=mnemoverse)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![Research: SLoD arXiv](https://img.shields.io/badge/Research-arXiv%3A2603.08965-b31b1b)](https://arxiv.org/abs/2603.08965)
 
@@ -231,7 +231,7 @@ The same API key works across all tools. Write a memory in Claude Code — read 
 - [Console (get API key)](https://console.mnemoverse.com)
 - [GitHub](https://github.com/mnemoverse/mcp-memory-server)
 - [Releases](https://github.com/mnemoverse/mcp-memory-server/releases)
-- [MCP Registry entry](https://registry.modelcontextprotocol.io/v0.1/servers?search=mnemoverse)
+- [MCP Registry entry](https://registry.modelcontextprotocol.io/v0/servers?search=mnemoverse)
 - [Contributing](CONTRIBUTING.md)
 
 ## Privacy


### PR DESCRIPTION
## What

Aligns the MCP Registry URL in `README.md` from the `/v0.1/servers` path to `/v0/servers`, matching the de-facto convention used everywhere else in the ecosystem:

- `mnemoverse-docs/data/facts.json` (`mcp.registry`) uses `/v0`
- 4 docs pages reference `/v0`

This is **internal version-string drift, not a broken link** — both `https://registry.modelcontextprotocol.io/v0/servers?search=mnemoverse` and the `/v0.1/...` variant currently return HTTP 200. The change is pure convention-alignment so all surfaces cite a single consistent path.

**Lines changed (2):**
- L5 — MCP Registry badge link
- L234 — "MCP Registry entry" link under resources

## 🎯 Reviewer-voice

- **Confirm scope is exactly the registry-URL path.** The only diff is `/v0.1/servers` → `/v0/servers` on the two registry links. Please verify there is **no package-version churn** (the npm package version `0.3.x` and any schema dates are untouched). `git diff` shows `1 file changed, 2 insertions(+), 2 deletions(-)`.
- **Both endpoints are live.** `/v0` and `/v0.1` both return 200, so nothing functionally breaks either way — this PR exists solely to make the README agree with `facts.json` and the docs pages. If you'd rather flip the *other* direction (docs → `/v0.1`), that's a separate call; this PR follows the existing-standard convention (`/v0`).

## ✅ Self-review checklist

- [x] Only `README.md` modified; no other tracked file dirty before branching
- [x] Branch cut from `origin/main`
- [x] Exactly 2 lines changed, both the registry URL version path
- [x] No change to npm package version (`0.3.x`) or schema/date strings
- [x] `grep v0.1` over README now returns zero matches
- [x] Target path `/v0/servers` matches `facts.json` `mcp.registry` + docs pages
- [ ] Reviewer confirms convention direction (`/v0`, not `/v0.1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated MCP Registry references in the README with current registry path URLs for the badge and dedicated link section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->