### PR TITLE
chore: add .gitattributes (normalize line endings to LF)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,23 @@
+# Normalize line endings: store LF in the repo, check out LF on every OS.
+# Prevents Windows (core.autocrlf=true) from producing phantom CRLF diffs.
+* text=auto eol=lf
+
+# Binary assets — never normalize
+*.png  binary
+*.jpg  binary
+*.jpeg binary
+*.gif  binary
+*.ico  binary
+*.webp binary
+*.woff  binary
+*.woff2 binary
+*.ttf  binary
+*.otf  binary
+*.pdf  binary
+*.zip  binary
+*.gz   binary
+
+# Scripts that must keep specific endings
+*.sh  text eol=lf
+*.bat text eol=crlf
+*.cmd text eol=crlf


### PR DESCRIPTION
## Why
The whole workspace runs with `core.autocrlf=true` (Git-for-Windows default) and this repo has **no `.gitattributes`**. That combo produces *phantom* CRLF diffs on Windows — files show as `modified` with zero content change.

## What
Adds a single root `.gitattributes`:
- `* text=auto eol=lf` — store LF in-repo, check out LF on every OS (kills the autocrlf churn).
- binary assets marked `binary` (never normalized).
- `*.sh` pinned LF; `*.bat`/`*.cmd` pinned CRLF.

## Scope / safety
- **Additive, one file.** No `git add --renormalize` — existing blobs untouched until next edit, so no mass-rewrite diff.
- Part of a workspace-wide rollout (same file to every unguarded mnemoverse repo).

## 🎯 Reviewer-voice
- Confirm no `.sh` needs CRLF and no `.bat`/`.cmd` needs LF here.
- If this repo intentionally commits CRLF files, flag it — `eol=lf` would flip them on next touch.

## ✅ Self-review
- [x] One file, root `.gitattributes`
- [x] No renormalize (no existing-file churn)
- [x] LF for shell, CRLF for bat/cmd, binaries excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized repository line-ending configuration to ensure consistency across different platforms and prevent unintended diff artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->