### PR TITLE
release: v0.3.6 (tool-description TDQS + zod dep; first release in 2 weeks)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "mnemoverse-memory",
   "display_name": "Mnemoverse Memory",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Persistent long-term memory for AI agents — semantic recall across Claude, Cursor, ChatGPT & MCP.",
   "long_description": "Mnemoverse gives your AI assistant long-term memory that persists across sessions and across tools. Store preferences, decisions, and lessons with memory_write; recall them by natural-language search with memory_read. The same memory is shared everywhere you use your Mnemoverse API key — Claude, Cursor, VS Code, and any MCP client. Requires a free API key from https://console.mnemoverse.com.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mnemoverse/mcp-memory-server",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mnemoverse/mcp-memory-server",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mnemoverse/mcp-memory-server",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "MCP server for Mnemoverse Memory API — persistent AI memory across Claude Code, Cursor, VS Code, and any MCP client",
   "type": "module",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -9,12 +9,12 @@
     "source": "github",
     "id": "1207193530"
   },
-  "version": "0.3.5",
+  "version": "0.3.6",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mnemoverse/mcp-memory-server",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## What
Version bump **0.3.5 → 0.3.6** + regenerated metadata. Cuts a release after 2 weeks (last stable v0.3.5 on 2026-05-31 — the maintenance card flags release recency).

## Ships (already merged to main since v0.3.5)
- **#32** — 6 MCP tool descriptions rewritten as behavioural directives (Glama TDQS + agent proactivity)
- **#28** — `zod` declared as a direct dependency (was transitive-only — latent consumer-install bug) + workspace `.gitattributes` (eol=lf)

## This PR (mechanical only)
- `package.json` + `package-lock.json`: 0.3.5 → 0.3.6
- `server.json` + `manifest.json`: regenerated from the new version (`npm run generate:configs`)
- `verify:configs` ✓ (all 19 artifacts in sync) · `tsc` builds clean · no `src/` logic change

## Release flow (after merge)
Tag `v0.3.6` on main → `release.yml` fans out: **npm publish → Official MCP Registry (OIDC) → GitHub release**. Downstream (PulseMCP / VS Code Gallery / Glama metadata) auto-ingests. Enables a fresh **Glama release** to re-score the improved tool descriptions (moves the 53%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package version from 0.3.5 to 0.3.6 across configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->