### PR TITLE
fix(auth): lazy API-key check → server starts key-free (unblocks Glama quality score)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,13 +20,13 @@ const API_KEY = process.env.MNEMOVERSE_API_KEY || "";
 // Approximate token count = chars / 4. Cap at 24,000 tokens to leave headroom under the 25K limit.
 const MAX_RESULT_CHARS = 24_000 * 4;
 
-if (!API_KEY) {
-  console.error(
-    "Error: MNEMOVERSE_API_KEY environment variable is required.\n" +
-      "Get your free key at https://console.mnemoverse.com",
-  );
-  process.exit(1);
-}
+// The API key is validated lazily — inside apiFetch, on the first tool call —
+// rather than at startup. This lets the server START WITHOUT a key so that
+// `tools/list` and other introspection work key-free. MCP directories and
+// registries (e.g. Glama) boot the server to enumerate and score its tools,
+// and clients may browse capabilities before sign-in; a startup exit on a
+// missing key blocks all of that. A tool *invocation* without a key returns a
+// clear, actionable error instead (see apiFetch).
 
 /**
  * Fetch from the Mnemoverse core API with authentication.
@@ -45,6 +45,12 @@ async function apiFetch<T = unknown>(
   path: string,
   options: RequestInit = {},
 ): Promise<T> {
+  if (!API_KEY) {
+    throw new Error(
+      "MNEMOVERSE_API_KEY is required for this operation. Get a free key at " +
+        "https://console.mnemoverse.com and set it in your MCP client config.",
+    );
+  }
   const res = await fetch(`${API_URL}${path}`, {
     ...options,
     headers: {


### PR DESCRIPTION
## Root cause (why the Glama score was stuck)
`src/index.ts` did `process.exit(1)` at startup when `MNEMOVERSE_API_KEY` was unset. Glama's quality evaluation **boots the server and calls `tools/list`** to score Tool Definition Quality (70%) + Server Coherence (30%) — both static analyses of the tool definitions. With the startup exit, Glama booted the server, it died immediately, Glama got no tools → score stayed **"not tested"**. (The "53% / 58%" everyone saw is Glama **profile-completeness**, not the quality score — hence the confusion; the v1.0.0 Glama release never enabled scoring because the booted server kept exiting.)

## Fix
Move the key requirement from a startup exit to a **lazy check inside `apiFetch`** (the only consumer of the key):
- server **starts without a key** and serves `tools/list` key-free;
- a tool **invocation** without a key returns a clear error ("get a free key at console.mnemoverse.com") instead of crashing.

## Proof (smoke test)
With `MNEMOVERSE_API_KEY` unset: server stays up, `tools/list` returns **all 6 tools**. That's exactly what Glama needs to score the (improved, #32) descriptions.
```
tools/list (keyless) → memory_write, memory_read, memory_feedback, memory_stats, memory_delete, memory_delete_domain  (6)
```

## Why this is right beyond Glama
- Introspection-without-auth is the expected MCP pattern (registries/directories + clients browse capabilities before sign-in).
- Aligns with the upcoming keyless / OAuth direction (#3).
- `tsc` compiles clean.

## Release chain (after merge)
Cut **v0.3.7** (tag push → release.yml → npm + MCP Registry + GitHub release) → then a fresh **Glama release** whose build now boots + lists tools → **quality score computes** → unblocks awesome-mcp-servers #7163's score requirement.

## 🎯 Reviewer-voice
- Confirm a tool call with NO key now returns the graceful `apiFetch` error (not a crash) — the only behavior change beyond "starts key-free".
- Confirm nothing else read `API_KEY` at module load (it didn't — `apiFetch` is the sole consumer).

## ✅ Self-review
- [x] tsc clean · [x] smoke-tested keyless tools/list = 6 tools · [x] tool-without-key errors gracefully · [x] scoped to src/index.ts · [x] no fabricated claims

🤖 Generated with [Claude Code](https://claude.com/claude-code)