### PR TITLE
release: v0.3.7 (lazy API-key — unblocks Glama scoring)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "mnemoverse-memory",
   "display_name": "Mnemoverse Memory",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Persistent long-term memory for AI agents — semantic recall across Claude, Cursor, ChatGPT & MCP.",
   "long_description": "Mnemoverse gives your AI assistant long-term memory that persists across sessions and across tools. Store preferences, decisions, and lessons with memory_write; recall them by natural-language search with memory_read. The same memory is shared everywhere you use your Mnemoverse API key — Claude, Cursor, VS Code, and any MCP client. Requires a free API key from https://console.mnemoverse.com.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mnemoverse/mcp-memory-server",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mnemoverse/mcp-memory-server",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mnemoverse/mcp-memory-server",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "MCP server for Mnemoverse Memory API — persistent AI memory across Claude Code, Cursor, VS Code, and any MCP client",
   "type": "module",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -9,12 +9,12 @@
     "source": "github",
     "id": "1207193530"
   },
-  "version": "0.3.6",
+  "version": "0.3.7",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mnemoverse/mcp-memory-server",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Bump 0.3.6→0.3.7 + regenerated server.json/manifest. Ships #34 (server starts key-free → Glama build can enumerate tools → quality score computes). verify:configs ✓, tsc ✓. After merge: tag `v0.3.7` (your publish step) → release.yml fans out → then cut a fresh Glama release (browser brief incoming) → score finally computes. 🤖 Generated with Claude Code