### PR TITLE
docs(blurbs): lead public metadata with the wedge (learns & forgets, hosted, neutral)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![Research: SLoD arXiv](https://img.shields.io/badge/Research-arXiv%3A2603.08965-b31b1b)](https://arxiv.org/abs/2603.08965)
 
-Shared AI memory across Claude, Cursor, VS Code, ChatGPT, and any MCP client. Write once, recall anywhere.
+Hosted memory for AI agents that learns and forgets. Feedback reranks the facts that help; recall fades by recency. One API key works across Claude, Cursor, VS Code, ChatGPT, and any MCP client.
 
-Your agent remembers everything — across sessions, projects, and tools. One API key, one memory, everywhere.
+Memory that persists across sessions, projects, and tools — and improves with use. Hosted, so there's no infrastructure to run, and not locked to a single cloud.
 
 ## Quick Start
 

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "mnemoverse-memory",
   "display_name": "Mnemoverse Memory",
   "version": "0.3.8",
-  "description": "Persistent long-term memory for AI agents — semantic recall across Claude, Cursor, ChatGPT & MCP.",
+  "description": "Hosted memory for AI agents that learns and forgets — feedback reranks what helps; recall across Claude, Cursor, ChatGPT & any MCP client.",
   "long_description": "Mnemoverse gives your AI assistant long-term memory that persists across sessions and across tools. Store preferences, decisions, and lessons with memory_write; recall them by natural-language search with memory_read. The same memory is shared everywhere you use your Mnemoverse API key — Claude, Cursor, VS Code, and any MCP client. Requires a free API key from https://console.mnemoverse.com.",
   "author": {
     "name": "Mnemoverse",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mnemoverse/mcp-memory-server",
   "version": "0.3.8",
-  "description": "MCP server for Mnemoverse Memory API — persistent AI memory across Claude Code, Cursor, VS Code, and any MCP client",
+  "description": "Hosted persistent memory for AI agents that learns which facts help and lets the rest fade — one key across Claude Code, Cursor, VS Code & ChatGPT, no infra to run",
   "type": "module",
   "bin": {
     "mcp-memory-server": "./dist/index.js"
@@ -40,7 +40,10 @@
     "persistent-memory",
     "shared-memory",
     "cross-tool",
-    "model-context-protocol"
+    "model-context-protocol",
+    "hosted-memory",
+    "forgetting",
+    "vendor-neutral"
   ],
   "author": "Mnemoverse <hello@mnemoverse.com>",
   "license": "MIT",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.mnemoverse/mcp-memory-server",
   "title": "Mnemoverse Memory",
-  "description": "Persistent long-term memory for AI agents — semantic recall across Claude, Cursor, ChatGPT & MCP.",
+  "description": "Hosted memory for AI agents that learns and forgets — feedback reranks what helps; recall across Claude, Cursor, ChatGPT & any MCP client.",
   "websiteUrl": "https://mnemoverse.com",
   "repository": {
     "url": "https://github.com/mnemoverse/mcp-memory-server",

--- a/src/configs/source.json
+++ b/src/configs/source.json
@@ -3,7 +3,7 @@
   "name": "mnemoverse",
   "displayName": "Mnemoverse Memory",
   "title": "Mnemoverse Memory",
-  "description": "Persistent long-term memory for AI agents — semantic recall across Claude, Cursor, ChatGPT & MCP.",
+  "description": "Hosted memory for AI agents that learns and forgets — feedback reranks what helps; recall across Claude, Cursor, ChatGPT & any MCP client.",
   "websiteUrl": "https://mnemoverse.com",
   "type": "stdio",
   "command": "npx",


### PR DESCRIPTION
## Why

Our public blurbs all led with the commoditized *"semantic recall / shared across Claude·Cursor·ChatGPT"* line — the exact claim **Mem0's OpenMemory MCP** and a dozen registered memory servers already make, so it doesn't differentiate us. Re-lead with the confirmed wedge: **memory that learns and forgets**, hosted, vendor-neutral.

## What

- **package.json** `description` → wedge; `keywords` += `hosted-memory`, `forgetting`, `vendor-neutral`
- **server.json** `description` → wedge (the MCP-registry listing)
- **README** opening tagline → wedge (this is the paragraph **Glama scrapes** for its listing — the only lever for that surface)

## Honesty guard (important)

"Learns and forgets" is grounded **only** in committed capability: the `memory_feedback` (+1/-1) valence rerank + recency-graded recall. I deliberately did **not** write "Hebbian", a decay rate, "100x", or any number, and used **none** of the killed ghost words (spatial / GPU-native / hyperbolic / worldview). "Hosted / vendor-neutral / no infra" is positioning, no named competitor.

## Reviewer-voice — where to attack

- **No version bump** — this is metadata-only. The npm publish / MCP-registry republish that make these live are **separate gated actions**, and the registry may need a version bump at publish time (your call: 0.3.9?). → confirm you don't want the bump in this PR.
- **`release.yml` exists** — if it auto-publishes on merge-to-main, then **merging this PR = publishing**. Please verify the release trigger before merge so a blurb change doesn't ship npm/registry unintentionally. → this is the gated step.
- **JSON validity** — `package.json` + `server.json` both parse clean (verified). → confirm.
- **GitHub About + topics** are NOT in this PR (they're a direct repo-settings edit, instant-live) — batched separately for your go.

## Self-review checklist

- [x] package.json + server.json valid JSON (verified)
- [x] No ghost words, no fabricated numbers, no "Hebbian"-as-claim
- [x] Wedge grounded in committed capability (memory_feedback + recency)
- [x] Version intentionally unchanged (metadata-only)
- [ ] Merge gated — and merge may trigger release.yml publish (verify first)

## 🔴 Public surface
Merge (and any resulting npm/registry publish) = your explicit go. Holding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)