### PR TITLE
release: v0.3.9 — wedge-led public metadata

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "mnemoverse-memory",
   "display_name": "Mnemoverse Memory",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Hosted memory for AI agents that learns and forgets — feedback reranks what helps; recall across Claude, Cursor, ChatGPT & any MCP client.",
   "long_description": "Mnemoverse gives your AI assistant long-term memory that persists across sessions and across tools. Store preferences, decisions, and lessons with memory_write; recall them by natural-language search with memory_read. The same memory is shared everywhere you use your Mnemoverse API key — Claude, Cursor, VS Code, and any MCP client. Requires a free API key from https://console.mnemoverse.com.",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mnemoverse/mcp-memory-server",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Hosted persistent memory for AI agents that learns which facts help and lets the rest fade — one key across Claude Code, Cursor, VS Code & ChatGPT, no infra to run",
   "type": "module",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -9,12 +9,12 @@
     "source": "github",
     "id": "1207193530"
   },
-  "version": "0.3.8",
+  "version": "0.3.9",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mnemoverse/mcp-memory-server",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Version bump to publish the wedge blurbs (merged in #37) to **npm + the MCP registry**. The description/keywords changed at 0.3.8 but npm/registry only surface it on a new release.

- `0.3.8 → 0.3.9` (metadata-only, no code change)
- regenerated `server.json` + `manifest.json` from `source.json` → all 19 artifacts in sync (`verify:configs` passes)
- after merge: `git tag v0.3.9 && git push origin v0.3.9` triggers `release.yml` → npm publish + mcp-publisher (registry) + GH release

Authorized by Eduard (explicit go on the publish batch). Tag step is the actual publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)