### PR TITLE
release: v0.3.10 — registry description ≤100 (fix v0.3.9 registry publish)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,8 +2,8 @@
   "manifest_version": "0.3",
   "name": "mnemoverse-memory",
   "display_name": "Mnemoverse Memory",
-  "version": "0.3.9",
-  "description": "Hosted memory for AI agents that learns and forgets — feedback reranks what helps; recall across Claude, Cursor, ChatGPT & any MCP client.",
+  "version": "0.3.10",
+  "description": "Hosted memory for AI agents that learns and forgets — one key across Claude, Cursor & ChatGPT.",
   "long_description": "Mnemoverse gives your AI assistant long-term memory that persists across sessions and across tools. Store preferences, decisions, and lessons with memory_write; recall them by natural-language search with memory_read. The same memory is shared everywhere you use your Mnemoverse API key — Claude, Cursor, VS Code, and any MCP client. Requires a free API key from https://console.mnemoverse.com.",
   "author": {
     "name": "Mnemoverse",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mnemoverse/mcp-memory-server",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "Hosted persistent memory for AI agents that learns which facts help and lets the rest fade — one key across Claude Code, Cursor, VS Code & ChatGPT, no infra to run",
   "type": "module",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -2,19 +2,19 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.mnemoverse/mcp-memory-server",
   "title": "Mnemoverse Memory",
-  "description": "Hosted memory for AI agents that learns and forgets — feedback reranks what helps; recall across Claude, Cursor, ChatGPT & any MCP client.",
+  "description": "Hosted memory for AI agents that learns and forgets — one key across Claude, Cursor & ChatGPT.",
   "websiteUrl": "https://mnemoverse.com",
   "repository": {
     "url": "https://github.com/mnemoverse/mcp-memory-server",
     "source": "github",
     "id": "1207193530"
   },
-  "version": "0.3.9",
+  "version": "0.3.10",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mnemoverse/mcp-memory-server",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "transport": {
         "type": "stdio"
       },

--- a/src/configs/source.json
+++ b/src/configs/source.json
@@ -3,7 +3,7 @@
   "name": "mnemoverse",
   "displayName": "Mnemoverse Memory",
   "title": "Mnemoverse Memory",
-  "description": "Hosted memory for AI agents that learns and forgets — feedback reranks what helps; recall across Claude, Cursor, ChatGPT & any MCP client.",
+  "description": "Hosted memory for AI agents that learns and forgets — one key across Claude, Cursor & ChatGPT.",
   "websiteUrl": "https://mnemoverse.com",
   "type": "stdio",
   "command": "npx",


### PR DESCRIPTION
v0.3.9 published to **npm** fine, but the **MCP Registry** publish failed: `422 body.description expected length <= 100` (ours was 138). npm is immutable → fix-forward to 0.3.10 with a **94-char** registry description (sourced in `source.json` → `server.json`). Wedge intact, just shorter for the registry cap. npm description (no cap) keeps the richer wedge line. Tag v0.3.10 after merge re-runs the full release. 🤖 Generated with [Claude Code](https://claude.com/claude-code)