### PR TITLE
docs(readme): add Glama quality badge (A grade)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![MCP Registry](https://img.shields.io/badge/MCP_Registry-listed-0ea5e9)](https://registry.modelcontextprotocol.io/v0/servers?search=mnemoverse)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![Research: SLoD arXiv](https://img.shields.io/badge/Research-arXiv%3A2603.08965-b31b1b)](https://arxiv.org/abs/2603.08965)
+[![Glama quality](https://glama.ai/mcp/servers/mnemoverse/mcp-memory-server/badges/score.svg)](https://glama.ai/mcp/servers/mnemoverse/mcp-memory-server)
 
 Hosted memory for AI agents that learns and forgets. Feedback reranks the facts that help; recall fades by recency. One API key works across Claude, Cursor, VS Code, ChatGPT, and any MCP client.
 


### PR DESCRIPTION
Glama scores the server **A** across license/quality/maintenance (no security warnings). Adds the dynamic Glama score badge to the README badge row, next to npm/Registry/MIT/arXiv. Auto-updates with the live score. 🤖 Generated with [Claude Code](https://claude.com/claude-code)