### PR TITLE
feat(auth): keyless OAuth (loopback PKCE) — stop requiring an API key [BLOCKED on AS client registration]

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   ],
   "scripts": {
     "build": "tsc",
+    "test": "tsc && node --test test/*.test.mjs",
     "dev": "tsc --watch",
     "start": "node dist/index.js",
     "generate:configs": "node scripts/generate-configs.mjs",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "test": "tsc && node --test test/*.test.mjs",
+    "test": "tsc && node --test",
     "dev": "tsc --watch",
     "start": "node dist/index.js",
     "generate:configs": "node scripts/generate-configs.mjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { createRequire } from "node:module";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
+import { getAccessToken } from "./oauth.js";
 
 // Version is read at runtime from package.json so there is exactly one place
 // to bump on each release. Works both from `dist/` during local dev and from
@@ -20,13 +21,14 @@ const API_KEY = process.env.MNEMOVERSE_API_KEY || "";
 // Approximate token count = chars / 4. Cap at 24,000 tokens to leave headroom under the 25K limit.
 const MAX_RESULT_CHARS = 24_000 * 4;
 
-// The API key is validated lazily — inside apiFetch, on the first tool call —
-// rather than at startup. This lets the server START WITHOUT a key so that
-// `tools/list` and other introspection work key-free. MCP directories and
-// registries (e.g. Glama) boot the server to enumerate and score its tools,
-// and clients may browse capabilities before sign-in; a startup exit on a
-// missing key blocks all of that. A tool *invocation* without a key returns a
-// clear, actionable error instead (see apiFetch).
+// Auth is resolved lazily — inside apiFetch, on the first tool call — never at
+// startup. This lets the server START WITHOUT credentials so that `tools/list`
+// and other introspection work auth-free. MCP directories and registries (e.g.
+// Glama) boot the server to enumerate and score its tools, and clients may
+// browse capabilities before sign-in; a startup exit would block all of that.
+// On the first tool *invocation*: an explicit MNEMOVERSE_API_KEY is used if
+// set; otherwise the server runs a keyless OAuth browser sign-in and caches the
+// token (see oauth.ts). No key to paste in the common case.
 
 /**
  * Fetch from the Mnemoverse core API with authentication.
@@ -45,17 +47,18 @@ async function apiFetch<T = unknown>(
   path: string,
   options: RequestInit = {},
 ): Promise<T> {
-  if (!API_KEY) {
-    throw new Error(
-      "MNEMOVERSE_API_KEY is required for this operation. Get a free key at " +
-        "https://console.mnemoverse.com and set it in your MCP client config.",
-    );
-  }
+  // Auth resolution: an explicit API key wins (CI, headless, self-host); with
+  // no key we fall back to keyless OAuth — a one-time browser sign-in, then a
+  // cached + silently-refreshed token in ~/.mnemoverse. getAccessToken throws a
+  // clear error if sign-in fails or times out.
+  const authHeaders: Record<string, string> = API_KEY
+    ? { "X-Api-Key": API_KEY }
+    : { Authorization: `Bearer ${await getAccessToken()}` };
   const res = await fetch(`${API_URL}${path}`, {
     ...options,
     headers: {
       "Content-Type": "application/json",
-      "X-Api-Key": API_KEY,
+      ...authHeaders,
       ...((options.headers as Record<string, string>) || {}),
     },
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,8 +58,11 @@ async function apiFetch<T = unknown>(
     ...options,
     headers: {
       "Content-Type": "application/json",
-      ...authHeaders,
+      // Caller headers first, auth headers LAST: Content-Type stays
+      // overridable, but Authorization / X-Api-Key always win — a caller
+      // (or future user-influenced input) must not clobber auth.
       ...((options.headers as Record<string, string>) || {}),
+      ...authHeaders,
     },
   });
 

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -15,10 +15,15 @@
 // (well-known shows only authorization_code + refresh_token), which is why we
 // use the loopback flow rather than RFC 8628 device code.
 
-import { createServer } from "node:http";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { randomBytes, createHash } from "node:crypto";
 import { spawn } from "node:child_process";
-import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import {
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  chmodSync,
+} from "node:fs";
 import { homedir, platform } from "node:os";
 import { join } from "node:path";
 
@@ -31,7 +36,13 @@ const TOKEN_FILE = join(TOKEN_DIR, "tokens.json");
 // Refresh a little before real expiry to avoid racing the clock.
 const EXPIRY_SKEW_MS = 60_000;
 // Give the human time to complete the browser sign-in before giving up.
-const AUTH_TIMEOUT_MS = 5 * 60_000;
+const AUTH_TIMEOUT_MS =
+  Number(process.env.MNEMOVERSE_AUTH_TIMEOUT_MS) || 5 * 60_000;
+
+const DONE_HTML =
+  "<html><body style='font-family:sans-serif'>Mnemoverse: sign-in complete — you can close this tab.</body></html>";
+const FAIL_HTML =
+  "<html><body style='font-family:sans-serif'>Mnemoverse: sign-in could not be verified — you can close this tab and try again.</body></html>";
 
 interface Tokens {
   access_token: string;
@@ -44,27 +55,71 @@ interface Discovery {
   token_endpoint: string;
 }
 
-function b64url(buf: Buffer): string {
-  return buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+export function b64url(buf: Buffer): string {
+  return buf
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
 }
 
-function loadTokens(): Tokens | null {
+/**
+ * Endpoints from the discovery document are handed to `fetch()` AND to the OS
+ * browser launcher, so they must be trustworthy. Require https everywhere; allow
+ * http only for a loopback dev AS (127.0.0.1 / localhost). This blocks a
+ * poisoned or MITM'd discovery doc — or a hostile MNEMOVERSE_AUTH_URL — from
+ * redirecting the flow to an attacker origin or smuggling shell metacharacters.
+ */
+export function assertSafeEndpoint(u: string, name: string): string {
+  let parsed: URL;
   try {
-    return JSON.parse(readFileSync(TOKEN_FILE, "utf8")) as Tokens;
+    parsed = new URL(u);
+  } catch {
+    throw new Error(`OAuth discovery ${name} is not a valid URL`);
+  }
+  const loopback =
+    parsed.hostname === "127.0.0.1" || parsed.hostname === "localhost";
+  if (parsed.protocol !== "https:" && !(parsed.protocol === "http:" && loopback)) {
+    throw new Error(
+      `OAuth discovery ${name} must be https (got ${parsed.protocol}//${parsed.hostname})`,
+    );
+  }
+  return u;
+}
+
+// In-process cache so a hot stdio server doesn't readFileSync on every tool call.
+let memTokens: Tokens | null = null;
+
+function loadTokens(): Tokens | null {
+  if (memTokens) return memTokens;
+  try {
+    memTokens = JSON.parse(readFileSync(TOKEN_FILE, "utf8")) as Tokens;
+    return memTokens;
   } catch {
     return null;
   }
 }
 
 function saveTokens(t: Tokens): void {
-  mkdirSync(TOKEN_DIR, { recursive: true });
-  // 0o600 — tokens are secrets; keep them owner-only where the OS honors it.
+  // 0o700 dir + 0o600 file: tokens are secrets, kept owner-only where the OS
+  // honors POSIX modes. On Windows the mode is largely ignored — the file then
+  // relies on the user-profile ACL (recommend full-disk encryption; see README).
+  mkdirSync(TOKEN_DIR, { recursive: true, mode: 0o700 });
+  try {
+    if (platform() !== "win32") chmodSync(TOKEN_DIR, 0o700);
+  } catch {
+    /* best effort — tighten a pre-existing loose dir; ignore if not permitted */
+  }
   writeFileSync(TOKEN_FILE, JSON.stringify(t, null, 2), { mode: 0o600 });
+  memTokens = t;
 }
 
 let discoveryCache: Discovery | null = null;
 async function discover(): Promise<Discovery> {
   if (discoveryCache) return discoveryCache;
+  // Validate the (user-overridable) base before fetching from it, so a hostile
+  // MNEMOVERSE_AUTH_URL can't point discovery at a non-https origin.
+  assertSafeEndpoint(AUTH_BASE, "MNEMOVERSE_AUTH_URL");
   const res = await fetch(`${AUTH_BASE}/.well-known/oauth-authorization-server`);
   if (!res.ok) {
     throw new Error(`OAuth discovery failed (${res.status}) at ${AUTH_BASE}`);
@@ -73,19 +128,53 @@ async function discover(): Promise<Discovery> {
   if (!meta.authorization_endpoint || !meta.token_endpoint) {
     throw new Error("OAuth discovery missing authorization/token endpoint");
   }
+  assertSafeEndpoint(meta.authorization_endpoint, "authorization_endpoint");
+  assertSafeEndpoint(meta.token_endpoint, "token_endpoint");
   discoveryCache = meta;
   return meta;
 }
 
+/**
+ * Build the OS browser-launch command WITHOUT a shell, so the URL (with its '&'
+ * query separators and %xx escapes) is passed as a single argv element and is
+ * never tokenized. The old `cmd /c start "" <url>` truncated the URL at the
+ * first '&' on Windows AND let `&command` segments execute — a functional break
+ * plus a local command-injection vector. `rundll32 url.dll,FileProtocolHandler`
+ * receives the URL as a single argv element with NO shell involved; the auth URL
+ * is percent-encoded (no spaces or shell metacharacters), so it reaches the
+ * default handler intact.
+ */
+export function browserCommand(
+  p: NodeJS.Platform,
+  url: string,
+): { cmd: string; args: string[] } {
+  if (p === "win32") {
+    return { cmd: "rundll32", args: ["url.dll,FileProtocolHandler", url] };
+  }
+  if (p === "darwin") return { cmd: "open", args: [url] };
+  return { cmd: "xdg-open", args: [url] };
+}
+
 function openBrowser(url: string): void {
-  const p = platform();
-  const cmd = p === "darwin" ? "open" : p === "win32" ? "cmd" : "xdg-open";
-  const args = p === "win32" ? ["/c", "start", "", url] : [url];
+  const { cmd, args } = browserCommand(platform(), url);
   try {
     spawn(cmd, args, { stdio: "ignore", detached: true }).unref();
   } catch {
-    /* fall back to the printed URL below */
+    /* the URL is also printed to stderr as a fallback */
   }
+}
+
+/**
+ * Interactive browser sign-in is only viable when a human + browser are present.
+ * In CI / headless, skip it and fail fast with an actionable message rather than
+ * hang for AUTH_TIMEOUT_MS. NB: a stdio MCP server's streams are pipes (not
+ * TTYs) even under Claude Desktop, so we gate on explicit env — NOT `isTTY`,
+ * which would false-negative on the common desktop case.
+ */
+function browserSignInAvailable(): boolean {
+  if (process.env.MNEMOVERSE_NO_BROWSER) return false;
+  if (process.env.CI) return false;
+  return true;
 }
 
 async function exchange(
@@ -98,7 +187,20 @@ async function exchange(
     body: new URLSearchParams(body).toString(),
   });
   if (!res.ok) {
-    throw new Error(`OAuth token exchange failed (${res.status}): ${await res.text()}`);
+    // Do not splice the raw upstream body into an error that reaches the MCP
+    // client/logs (info-disclosure / log-injection surface). Read it only to
+    // detect the well-known invalid_client case, and bound its length.
+    const detail = (await res.text().catch(() => "")).slice(0, 300);
+    if (/invalid_client/i.test(detail)) {
+      throw new Error(
+        `OAuth client "${CLIENT_ID}" is not registered on the authorization ` +
+          `server (invalid_client). Keyless sign-in needs this public client ` +
+          `registered server-side. For now, set MNEMOVERSE_API_KEY — free key ` +
+          `at https://console.mnemoverse.com.`,
+      );
+    }
+    process.stderr.write(`[Mnemoverse] token endpoint error (${res.status})\n`);
+    throw new Error(`OAuth token exchange failed (${res.status})`);
   }
   const j = (await res.json()) as {
     access_token: string;
@@ -119,30 +221,47 @@ async function authorizeInteractive(d: Discovery): Promise<Tokens> {
   const state = b64url(randomBytes(16));
 
   return new Promise<Tokens>((resolve, reject) => {
-    const server = createServer((req, res) => {
+    // Single-shot: the first VALID callback wins; everything else (forged GETs,
+    // favicon probes, duplicates, late timeout) must not tear down a pending
+    // legitimate sign-in or double-exchange the single-use code.
+    let settled = false;
+    // Captured in the listen() callback below and reused verbatim in the token
+    // exchange so redirect_uri is byte-for-byte identical (OAuth exact-match) —
+    // never recomputed from server.address() after close() (which can be null).
+    let redirectUri = "";
+
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
       const url = new URL(req.url || "/", "http://127.0.0.1");
       if (url.pathname !== "/callback") {
         res.writeHead(404).end();
         return;
       }
-      const code = url.searchParams.get("code");
-      const returnedState = url.searchParams.get("state");
-      res.writeHead(200, { "Content-Type": "text/html" });
-      res.end(
-        "<html><body style='font-family:sans-serif'>Mnemoverse: sign-in complete — you can close this tab.</body></html>",
-      );
-      server.close();
-      clearTimeout(timer);
-      if (!code || returnedState !== state) {
-        reject(new Error("OAuth callback missing code or state mismatch"));
+      if (settled) {
+        res.writeHead(200, { "Content-Type": "text/html" }).end(DONE_HTML);
         return;
       }
-      const port = (server.address() as { port: number }).port;
+
+      const code = url.searchParams.get("code");
+      const returnedState = url.searchParams.get("state");
+      const host = (req.headers.host || "").split(":")[0];
+      const hostOk = host === "127.0.0.1" || host === "localhost";
+
+      // Validate BEFORE any teardown. An invalid/forged request gets a 400 and
+      // is otherwise IGNORED, so the real redirect can still arrive and win.
+      if (!code || returnedState !== state || !hostOk) {
+        res.writeHead(400, { "Content-Type": "text/html" }).end(FAIL_HTML);
+        return;
+      }
+
+      settled = true;
+      res.writeHead(200, { "Content-Type": "text/html" }).end(DONE_HTML);
+      server.close();
+      clearTimeout(timer);
       exchange(
         {
           grant_type: "authorization_code",
           code,
-          redirect_uri: `http://127.0.0.1:${port}/callback`,
+          redirect_uri: redirectUri,
           client_id: CLIENT_ID,
           code_verifier: verifier,
         },
@@ -150,14 +269,35 @@ async function authorizeInteractive(d: Discovery): Promise<Tokens> {
       ).then(resolve, reject);
     });
 
+    // A listen/socket failure (EADDRINUSE, EACCES, EMFILE, …) emits 'error';
+    // without this handler it would be unhandled and the Promise would hang.
+    server.on("error", (e: Error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      try {
+        server.close();
+      } catch {
+        /* already closing */
+      }
+      reject(new Error(`OAuth loopback server failed: ${e.message}`));
+    });
+
     const timer = setTimeout(() => {
-      server.close();
+      if (settled) return;
+      settled = true;
+      try {
+        server.close();
+      } catch {
+        /* already closing */
+      }
       reject(new Error("OAuth sign-in timed out — re-run the tool to try again"));
     }, AUTH_TIMEOUT_MS);
 
     server.listen(0, "127.0.0.1", () => {
-      const port = (server.address() as { port: number }).port;
-      const redirectUri = `http://127.0.0.1:${port}/callback`;
+      const addr = server.address();
+      const port = addr && typeof addr === "object" ? addr.port : 0;
+      redirectUri = `http://127.0.0.1:${port}/callback`;
       const authUrl =
         `${d.authorization_endpoint}?` +
         new URLSearchParams({
@@ -169,14 +309,21 @@ async function authorizeInteractive(d: Discovery): Promise<Tokens> {
           code_challenge: challenge,
           code_challenge_method: "S256",
         }).toString();
-      // stderr (not stdout — stdout is the MCP JSON-RPC channel).
+      // stderr (not stdout — stdout is the MCP JSON-RPC channel). Fallback-first
+      // wording: many stdio clients don't surface server stderr to the user, so
+      // the printed URL is the manual escape hatch if the browser doesn't open.
       process.stderr.write(
-        `\n[Mnemoverse] Sign in to connect memory — opening your browser:\n${authUrl}\n\n`,
+        `\n[Mnemoverse] Sign in to connect memory. If your browser doesn't ` +
+          `open automatically, paste this URL into it:\n${authUrl}\n\n`,
       );
       openBrowser(authUrl);
     });
   });
 }
+
+// Dedupe concurrent cold-cache sign-ins: parallel first tool calls share ONE
+// loopback server + browser tab + token write instead of racing N of them.
+let inflight: Promise<string> | null = null;
 
 /**
  * Return a valid OAuth access token, signing in or refreshing as needed.
@@ -187,29 +334,45 @@ export async function getAccessToken(): Promise<string> {
   if (cached && cached.expires_at > Date.now()) {
     return cached.access_token;
   }
+  if (inflight) return inflight;
 
-  const d = await discover();
+  inflight = (async () => {
+    const d = await discover();
 
-  if (cached?.refresh_token) {
-    try {
-      const refreshed = await exchange(
-        {
-          grant_type: "refresh_token",
-          refresh_token: cached.refresh_token,
-          client_id: CLIENT_ID,
-        },
-        d.token_endpoint,
-      );
-      // Some AS rotate refresh tokens; keep the old one if a new one isn't returned.
-      if (!refreshed.refresh_token) refreshed.refresh_token = cached.refresh_token;
-      saveTokens(refreshed);
-      return refreshed.access_token;
-    } catch {
-      // fall through to interactive sign-in
+    if (cached?.refresh_token) {
+      try {
+        const refreshed = await exchange(
+          {
+            grant_type: "refresh_token",
+            refresh_token: cached.refresh_token,
+            client_id: CLIENT_ID,
+          },
+          d.token_endpoint,
+        );
+        // Some AS rotate refresh tokens; keep the old one if none is returned.
+        if (!refreshed.refresh_token)
+          refreshed.refresh_token = cached.refresh_token;
+        saveTokens(refreshed);
+        return refreshed.access_token;
+      } catch {
+        // fall through to interactive sign-in
+      }
     }
-  }
 
-  const fresh = await authorizeInteractive(d);
-  saveTokens(fresh);
-  return fresh.access_token;
+    if (!browserSignInAvailable()) {
+      throw new Error(
+        "No API key set and interactive browser sign-in is unavailable " +
+          "(CI/headless). Set MNEMOVERSE_API_KEY — free key at " +
+          "https://console.mnemoverse.com.",
+      );
+    }
+
+    const fresh = await authorizeInteractive(d);
+    saveTokens(fresh);
+    return fresh.access_token;
+  })().finally(() => {
+    inflight = null;
+  });
+
+  return inflight;
 }

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -1,0 +1,215 @@
+// OAuth 2.1 (authorization-code + PKCE, loopback redirect) for the stdio server.
+//
+// WHY: the package used to REQUIRE a pasted `MNEMOVERSE_API_KEY`. This module
+// makes it keyless — on the first tool call without a key, it opens the user's
+// browser to sign in at auth.mnemoverse.com, catches the redirect on a loopback
+// port (RFC 8252), exchanges the code for tokens with PKCE, and caches them in
+// ~/.mnemoverse/tokens.json (refreshed silently thereafter). The API key stays
+// supported as a fallback (CI, headless, self-host).
+//
+// AS REQUIREMENT (auth.mnemoverse.com / better-auth): a PUBLIC OAuth client
+// (default id `mnemoverse-cli`) must be registered with a loopback redirect URI
+// pattern (http://127.0.0.1:*/callback) allowed. The hosted AS currently
+// host-allowlists DCR to claude.ai/claude.com, so this client must be
+// pre-registered server-side; the device_authorization grant is NOT offered
+// (well-known shows only authorization_code + refresh_token), which is why we
+// use the loopback flow rather than RFC 8628 device code.
+
+import { createServer } from "node:http";
+import { randomBytes, createHash } from "node:crypto";
+import { spawn } from "node:child_process";
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { homedir, platform } from "node:os";
+import { join } from "node:path";
+
+const AUTH_BASE =
+  process.env.MNEMOVERSE_AUTH_URL || "https://auth.mnemoverse.com/api/auth";
+const CLIENT_ID = process.env.MNEMOVERSE_OAUTH_CLIENT_ID || "mnemoverse-cli";
+const SCOPE = "openid profile email memory:read memory:write offline_access";
+const TOKEN_DIR = join(homedir(), ".mnemoverse");
+const TOKEN_FILE = join(TOKEN_DIR, "tokens.json");
+// Refresh a little before real expiry to avoid racing the clock.
+const EXPIRY_SKEW_MS = 60_000;
+// Give the human time to complete the browser sign-in before giving up.
+const AUTH_TIMEOUT_MS = 5 * 60_000;
+
+interface Tokens {
+  access_token: string;
+  refresh_token?: string;
+  expires_at: number; // epoch ms
+}
+
+interface Discovery {
+  authorization_endpoint: string;
+  token_endpoint: string;
+}
+
+function b64url(buf: Buffer): string {
+  return buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function loadTokens(): Tokens | null {
+  try {
+    return JSON.parse(readFileSync(TOKEN_FILE, "utf8")) as Tokens;
+  } catch {
+    return null;
+  }
+}
+
+function saveTokens(t: Tokens): void {
+  mkdirSync(TOKEN_DIR, { recursive: true });
+  // 0o600 — tokens are secrets; keep them owner-only where the OS honors it.
+  writeFileSync(TOKEN_FILE, JSON.stringify(t, null, 2), { mode: 0o600 });
+}
+
+let discoveryCache: Discovery | null = null;
+async function discover(): Promise<Discovery> {
+  if (discoveryCache) return discoveryCache;
+  const res = await fetch(`${AUTH_BASE}/.well-known/oauth-authorization-server`);
+  if (!res.ok) {
+    throw new Error(`OAuth discovery failed (${res.status}) at ${AUTH_BASE}`);
+  }
+  const meta = (await res.json()) as Discovery;
+  if (!meta.authorization_endpoint || !meta.token_endpoint) {
+    throw new Error("OAuth discovery missing authorization/token endpoint");
+  }
+  discoveryCache = meta;
+  return meta;
+}
+
+function openBrowser(url: string): void {
+  const p = platform();
+  const cmd = p === "darwin" ? "open" : p === "win32" ? "cmd" : "xdg-open";
+  const args = p === "win32" ? ["/c", "start", "", url] : [url];
+  try {
+    spawn(cmd, args, { stdio: "ignore", detached: true }).unref();
+  } catch {
+    /* fall back to the printed URL below */
+  }
+}
+
+async function exchange(
+  body: Record<string, string>,
+  tokenEndpoint: string,
+): Promise<Tokens> {
+  const res = await fetch(tokenEndpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams(body).toString(),
+  });
+  if (!res.ok) {
+    throw new Error(`OAuth token exchange failed (${res.status}): ${await res.text()}`);
+  }
+  const j = (await res.json()) as {
+    access_token: string;
+    refresh_token?: string;
+    expires_in?: number;
+  };
+  return {
+    access_token: j.access_token,
+    refresh_token: j.refresh_token,
+    expires_at: Date.now() + (j.expires_in ?? 3600) * 1000 - EXPIRY_SKEW_MS,
+  };
+}
+
+/** Run the interactive loopback authorization-code + PKCE flow. */
+async function authorizeInteractive(d: Discovery): Promise<Tokens> {
+  const verifier = b64url(randomBytes(32));
+  const challenge = b64url(createHash("sha256").update(verifier).digest());
+  const state = b64url(randomBytes(16));
+
+  return new Promise<Tokens>((resolve, reject) => {
+    const server = createServer((req, res) => {
+      const url = new URL(req.url || "/", "http://127.0.0.1");
+      if (url.pathname !== "/callback") {
+        res.writeHead(404).end();
+        return;
+      }
+      const code = url.searchParams.get("code");
+      const returnedState = url.searchParams.get("state");
+      res.writeHead(200, { "Content-Type": "text/html" });
+      res.end(
+        "<html><body style='font-family:sans-serif'>Mnemoverse: sign-in complete — you can close this tab.</body></html>",
+      );
+      server.close();
+      clearTimeout(timer);
+      if (!code || returnedState !== state) {
+        reject(new Error("OAuth callback missing code or state mismatch"));
+        return;
+      }
+      const port = (server.address() as { port: number }).port;
+      exchange(
+        {
+          grant_type: "authorization_code",
+          code,
+          redirect_uri: `http://127.0.0.1:${port}/callback`,
+          client_id: CLIENT_ID,
+          code_verifier: verifier,
+        },
+        d.token_endpoint,
+      ).then(resolve, reject);
+    });
+
+    const timer = setTimeout(() => {
+      server.close();
+      reject(new Error("OAuth sign-in timed out — re-run the tool to try again"));
+    }, AUTH_TIMEOUT_MS);
+
+    server.listen(0, "127.0.0.1", () => {
+      const port = (server.address() as { port: number }).port;
+      const redirectUri = `http://127.0.0.1:${port}/callback`;
+      const authUrl =
+        `${d.authorization_endpoint}?` +
+        new URLSearchParams({
+          response_type: "code",
+          client_id: CLIENT_ID,
+          redirect_uri: redirectUri,
+          scope: SCOPE,
+          state,
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+        }).toString();
+      // stderr (not stdout — stdout is the MCP JSON-RPC channel).
+      process.stderr.write(
+        `\n[Mnemoverse] Sign in to connect memory — opening your browser:\n${authUrl}\n\n`,
+      );
+      openBrowser(authUrl);
+    });
+  });
+}
+
+/**
+ * Return a valid OAuth access token, signing in or refreshing as needed.
+ * Cached → refreshed → interactive, in that order.
+ */
+export async function getAccessToken(): Promise<string> {
+  const cached = loadTokens();
+  if (cached && cached.expires_at > Date.now()) {
+    return cached.access_token;
+  }
+
+  const d = await discover();
+
+  if (cached?.refresh_token) {
+    try {
+      const refreshed = await exchange(
+        {
+          grant_type: "refresh_token",
+          refresh_token: cached.refresh_token,
+          client_id: CLIENT_ID,
+        },
+        d.token_endpoint,
+      );
+      // Some AS rotate refresh tokens; keep the old one if a new one isn't returned.
+      if (!refreshed.refresh_token) refreshed.refresh_token = cached.refresh_token;
+      saveTokens(refreshed);
+      return refreshed.access_token;
+    } catch {
+      // fall through to interactive sign-in
+    }
+  }
+
+  const fresh = await authorizeInteractive(d);
+  saveTokens(fresh);
+  return fresh.access_token;
+}

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -111,6 +111,12 @@ function saveTokens(t: Tokens): void {
     /* best effort — tighten a pre-existing loose dir; ignore if not permitted */
   }
   writeFileSync(TOKEN_FILE, JSON.stringify(t, null, 2), { mode: 0o600 });
+  try {
+    // `mode` only applies on file CREATION — re-tighten a pre-existing loose file.
+    if (platform() !== "win32") chmodSync(TOKEN_FILE, 0o600);
+  } catch {
+    /* best effort — same rationale as the dir chmod above */
+  }
   memTokens = t;
 }
 
@@ -156,6 +162,12 @@ export function browserCommand(
 }
 
 function openBrowser(url: string): void {
+  // Defense-in-depth for CodeQL's "uncontrolled command line": the URL is
+  // already built from https-validated endpoints (assertSafeEndpoint at
+  // discovery) and passed as a single argv element with NO shell — but
+  // re-assert here so a future call site can't hand a non-https string
+  // (or something dash-prefixed an opener could parse as a flag) to spawn.
+  assertSafeEndpoint(url, "browser sign-in URL");
   const { cmd, args } = browserCommand(platform(), url);
   try {
     spawn(cmd, args, { stdio: "ignore", detached: true }).unref();

--- a/test/oauth.test.mjs
+++ b/test/oauth.test.mjs
@@ -1,0 +1,68 @@
+// Unit tests for the security-critical pure helpers of the keyless OAuth flow.
+// Run against the COMPILED output (dist/) so we test exactly what ships.
+//   npm test   ->   tsc && node --test test/
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { browserCommand, b64url, assertSafeEndpoint } from "../dist/oauth.js";
+
+// The OAuth authorize URL is full of '&' query separators and %xx escapes. The
+// launcher must hand it to the OS as ONE argv element — never through a shell —
+// or Windows `cmd` both truncates it at the first '&' and executes `&segment`
+// as a command (the local-RCE regression this replaced).
+const URL_WITH_AMP =
+  "https://auth.mnemoverse.com/api/auth/oauth2/authorize?response_type=code&client_id=mnemoverse-cli&state=abc&code_challenge=xYz%2D_&scope=openid%20profile";
+
+test("browserCommand win32 uses rundll32 and passes the URL as a single argv (no cmd parsing)", () => {
+  const { cmd, args } = browserCommand("win32", URL_WITH_AMP);
+  assert.equal(cmd, "rundll32");
+  assert.equal(args.length, 2);
+  assert.equal(args[0], "url.dll,FileProtocolHandler");
+  // The whole URL — every '&' and %xx intact — is one element.
+  assert.equal(args[1], URL_WITH_AMP);
+  assert.ok(!args.some((a) => a === "/c" || a === "start"));
+});
+
+test("browserCommand darwin uses open with the URL as the only arg", () => {
+  const { cmd, args } = browserCommand("darwin", URL_WITH_AMP);
+  assert.equal(cmd, "open");
+  assert.deepEqual(args, [URL_WITH_AMP]);
+});
+
+test("browserCommand linux uses xdg-open with the URL as the only arg", () => {
+  const { cmd, args } = browserCommand("linux", URL_WITH_AMP);
+  assert.equal(cmd, "xdg-open");
+  assert.deepEqual(args, [URL_WITH_AMP]);
+});
+
+test("b64url is URL-safe and unpadded", () => {
+  assert.equal(b64url(Buffer.from("hi")), "aGk");
+  const out = b64url(Buffer.from([251, 255, 191, 0]));
+  assert.ok(!/[+/=]/.test(out), `expected no +,/,= in ${out}`);
+});
+
+test("assertSafeEndpoint accepts https and returns the url", () => {
+  const u = "https://auth.mnemoverse.com/api/auth/oauth2/token";
+  assert.equal(assertSafeEndpoint(u, "token_endpoint"), u);
+});
+
+test("assertSafeEndpoint allows http only for loopback (dev AS)", () => {
+  assert.doesNotThrow(() =>
+    assertSafeEndpoint("http://127.0.0.1:4000/token", "token_endpoint"),
+  );
+  assert.doesNotThrow(() =>
+    assertSafeEndpoint("http://localhost:4000/token", "token_endpoint"),
+  );
+});
+
+test("assertSafeEndpoint rejects http on a non-loopback host (MITM / poisoned discovery)", () => {
+  assert.throws(
+    () => assertSafeEndpoint("http://evil.example.com/token", "token_endpoint"),
+    /must be https/,
+  );
+});
+
+test("assertSafeEndpoint rejects non-http(s) schemes and junk", () => {
+  assert.throws(() => assertSafeEndpoint("ftp://x/y", "authorization_endpoint"));
+  assert.throws(() => assertSafeEndpoint("not a url", "authorization_endpoint"));
+});


### PR DESCRIPTION
## Summary
Make `@mnemoverse/mcp-memory-server` **keyless**. With no `MNEMOVERSE_API_KEY`, the stdio server now runs a one-time browser sign-in (OAuth 2.1 authorization-code + PKCE, **loopback redirect** RFC 8252), caches + silently refreshes the token in `~/.mnemoverse/tokens.json`, and calls core with `Authorization: Bearer`. **API key stays a fallback** (CI / headless / self-host) and wins when set. Server still starts auth-free (`tools/list` works); auth resolves lazily on the first tool call.

New: `src/oauth.ts`. Wired in `src/index.ts` (`apiFetch` auth resolution + comment). `tsc` builds clean.

## Why loopback (not device-code)
Verified against the live AS — `auth.mnemoverse.com/.well-known/oauth-authorization-server` advertises only `authorization_code` + `refresh_token` (**no `device_authorization_endpoint`**). So the loopback browser flow is the correct headless path.

## 🔴 BLOCKED — AS-side change required (verified, not assumed)
`GET …/oauth2/authorize?client_id=mnemoverse-cli&redirect_uri=http://127.0.0.1:PORT/callback` → **302 → `error=invalid_client` "client_id is required"**. The public CLI client is not registered.

**Needed in better-auth (auth service):** register a **public OAuth client** `mnemoverse-cli` (PKCE, **no secret**) with **loopback redirect `http://127.0.0.1:*/callback`** (and `http://localhost:*/callback`) allowed. The hosted AS host-allowlists DCR to `claude.ai`/`claude.com`, so this must be pre-registered server-side. This is a **sensitive auth change — founder-gated**, separate repo.

## Test plan (e2e gated on the AS change)
- [x] `tsc` builds; server starts auth-free; `tools/list` works keyless
- [x] No-key tool call triggers the OAuth flow (opens browser, starts loopback server)
- [ ] e2e: after AS registers `mnemoverse-cli`, full sign-in → token cached → write/read succeed *(blocked)*
- [ ] Refresh path (expired access token → silent refresh)
- [ ] API-key fallback unchanged

## 🎯 Reviewer-voice (security — please scrutinize before publish)
- PKCE: S256 challenge from a 32-byte verifier; `state` generated + verified on callback.
- Token at rest: `~/.mnemoverse/tokens.json`, written `0o600`.
- No token/secret to **stdout** (stdout = MCP JSON-RPC); sign-in URL goes to **stderr**.
- Loopback only on `127.0.0.1`, ephemeral port; callback validates `state` + closes server; 5-min timeout.

## Self-review
- [x] Client code complete + builds; **do NOT `npm publish`** until the AS client lands + e2e passes (this PR is draft)
- [x] Backward compatible (API key path unchanged)
- [ ] Full security sieve to run right before publish (when e2e is unblocked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for signing in without a manually supplied API key, including browser-based login and token reuse across sessions.
  * Added a test command to run type checking before the test suite.

* **Bug Fixes**
  * Improved request authentication handling so credentials are applied more consistently and cannot be accidentally overridden.
  * Added safer handling for sign-in links and local callback flow across supported platforms.

* **Tests**
  * Added coverage for authentication helpers and URL handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->