### PR TITLE
feat(registry): publish the hosted remote endpoint (mcp.mnemoverse.com/mcp) alongside npm

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "mnemoverse-memory",
   "display_name": "Mnemoverse Memory",
-  "version": "0.3.10",
+  "version": "0.4.0",
   "description": "Hosted memory for AI agents that learns and forgets — one key across Claude, Cursor & ChatGPT.",
   "long_description": "Mnemoverse gives your AI assistant long-term memory that persists across sessions and across tools. Store preferences, decisions, and lessons with memory_write; recall them by natural-language search with memory_read. The same memory is shared everywhere you use your Mnemoverse API key — Claude, Cursor, VS Code, and any MCP client. Requires a free API key from https://console.mnemoverse.com.",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mnemoverse/mcp-memory-server",
-  "version": "0.3.10",
+  "version": "0.4.0",
   "description": "Hosted persistent memory for AI agents that learns which facts help and lets the rest fade — one key across Claude Code, Cursor, VS Code & ChatGPT, no infra to run",
   "type": "module",
   "bin": {

--- a/scripts/generate-configs.mjs
+++ b/scripts/generate-configs.mjs
@@ -431,6 +431,11 @@ function genServerJson() {
         environmentVariables,
       },
     ],
+    // The hosted remote endpoint (e.g. mcp.mnemoverse.com/mcp), published
+    // alongside the npm `packages` entry so registry consumers can discover the
+    // one-click-OAuth path, not just the local npx install. Emitted only when
+    // `source.remotes` is present; OAuth-protected remotes carry no headers.
+    ...(source.remotes ? { remotes: source.remotes } : {}),
   };
 }
 

--- a/server.json
+++ b/server.json
@@ -9,12 +9,12 @@
     "source": "github",
     "id": "1207193530"
   },
-  "version": "0.3.10",
+  "version": "0.4.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mnemoverse/mcp-memory-server",
-      "version": "0.3.10",
+      "version": "0.4.0",
       "transport": {
         "type": "stdio"
       },
@@ -36,6 +36,12 @@
           "default": "https://core.mnemoverse.com/api/v1"
         }
       ]
+    }
+  ],
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.mnemoverse.com/mcp"
     }
   ]
 }

--- a/src/configs/source.json
+++ b/src/configs/source.json
@@ -28,6 +28,10 @@
     "registry": "npm",
     "name": "@mnemoverse/mcp-memory-server"
   },
+  "$comment_remotes": "The HOSTED remote endpoint — one-click OAuth, no API key to paste. OAuth-protected, so NO headers block here: clients negotiate auth via the MCP OAuth flow (RFC 9728 discovery at /.well-known/oauth-protected-resource/mcp) at connect time. This is the registry counterpart of the npx/mk_live `package` path above; consumers pick whichever they prefer.",
+  "remotes": [
+    { "type": "streamable-http", "url": "https://mcp.mnemoverse.com/mcp" }
+  ],
   "metadata": {
     "homepage": "https://mnemoverse.com/docs/api/mcp-server",
     "repository": "https://github.com/mnemoverse/mcp-memory-server",


### PR DESCRIPTION
## Why

The official MCP registry entry `io.github.mnemoverse/mcp-memory-server` (latest `v0.3.10`) has only ever advertised the **npm/stdio package**. The hosted, one-click-OAuth remote — **`mcp.mnemoverse.com/mcp`**, deployed + working — was **invisible** to the canonical discovery source and everything that mirrors it (Glama auto-ingests the registry). Agents discovering us via the catalog were routed to self-host, never to the endpoint. This is the **highest-leverage discoverability** fix (from the landing audit's follow-up).

## What

`server.json` is **generated** (the release CI gates on `verify:configs` drift), so this is a **source patch**, not a hand-edit:

- **`src/configs/source.json`** — add a `remotes` block: `streamable-http` → `https://mcp.mnemoverse.com/mcp`. OAuth-protected → **no `headers`** (clients negotiate auth via the MCP OAuth flow / RFC 9728 discovery at connect time; that's the npx/`mk_live` path's job, not the remote's).
- **`scripts/generate-configs.mjs`** — `genServerJson()` now emits `remotes` alongside `packages` when `source.remotes` is set.
- **`package.json`** — `0.3.10` → `0.4.0` (additive feature). `src/index.ts` + the generator both read the version from `package.json`, so one bump propagates.
- **`server.json` + `manifest.json`** — regenerated; `verify:configs` confirms **19/19** artifacts in sync.

The registry stores immutable versioned snapshots, so this publishes a **new** version (0.4.0) carrying **both** the npm package and the remote; old versions stay in history. Keeps the owned `io.github.mnemoverse/*` namespace (publish is GitHub-OIDC in CI — no PAT/DNS).

## ⚠️ Merging this does NOT publish
The release workflow fires **only on a `v0.4.0` tag push** (→ npm publish + `mcp-publisher publish`). That tag is the **single irreversible public step** and is **held for Eduard's explicit go** per the workspace public-surface gate. Everything here is reversible up to the tag.

## Verification (mirrors the release CI gate)
`npm ci` + `npm run generate:configs` + `npm run verify:configs` (✅ 19/19 in sync) + `npm run build` — all clean locally.

## Reviewer-voice
- **Schema**: `remotes[].type: "streamable-http"` + `url` per the 2025-12-11 server schema; no `headers` is intentional (OAuth). Worth a glance the registry accepts it on publish (a `--dry-run` is available pre-tag).
- **Semver**: chose `0.4.0` (feature). Say if you'd rather `0.3.11`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a hosted remote connection endpoint in the extension/server configuration.
  * Remote access is now included in the published server package details.

* **Chores**
  * Bumped the release version to **0.4.0** across package and manifest metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->