### PR TITLE
ci(release): release-sync drift check across public surfaces (closes #31)

### DIFF
--- a/.github/workflows/release-sync-check.yml
+++ b/.github/workflows/release-sync-check.yml
@@ -23,6 +23,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Read-only check — no git ops after checkout, so don't leave the token
+          # in .git/config. (SHA-pinning the actions is a repo-wide policy choice;
+          # kept at @v4 to match release.yml / verify-configs.yml until that's done.)
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version: "20"

--- a/.github/workflows/release-sync-check.yml
+++ b/.github/workflows/release-sync-check.yml
@@ -1,0 +1,33 @@
+name: release-sync check
+
+# Issue #31: confirm every first-party public surface (npm, the Official MCP
+# Registry, the GitHub release) is still tracking package.json#version — so a
+# half-landed release (e.g. npm published but the registry publish failed) can't
+# drift silently and make directories read us as unmaintained.
+#
+# Runs on a schedule (not on every push — a release needs a moment to propagate,
+# and we don't want a false red right after tagging) plus manual dispatch.
+# A red run = drift; open release.yml and re-run the missing leg.
+
+on:
+  schedule:
+    - cron: "0 7 * * *" # daily 07:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: release-sync
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      # No install: the check is pure fetch (Node 18+ global fetch), no deps.
+      - name: Check public surfaces track the release
+        run: npm run check:release-sync
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "start": "node dist/index.js",
     "generate:configs": "node scripts/generate-configs.mjs",
     "verify:configs": "node scripts/generate-configs.mjs --check",
+    "check:release-sync": "node scripts/check-release-sync.mjs",
     "install-hooks": "node scripts/install-hooks.mjs",
     "prebuild": "npm run generate:configs",
     "prepublishOnly": "npm run build",

--- a/scripts/check-release-sync.mjs
+++ b/scripts/check-release-sync.mjs
@@ -58,8 +58,11 @@ async function checkNpm() {
 }
 
 async function checkRegistry() {
+  // limit=100 keeps every version snapshot of our (single) server on one page —
+  // we have <20 versions, so this sidesteps cursor pagination for any realistic
+  // count without a follow-the-cursor loop.
   const j = await getJson(
-    "https://registry.modelcontextprotocol.io/v0/servers?search=mnemoverse",
+    "https://registry.modelcontextprotocol.io/v0/servers?search=mnemoverse&limit=100",
   );
   // The API returns every version snapshot as a separate entry; each carries a
   // server doc + a _meta with the registry's isLatest flag.

--- a/scripts/check-release-sync.mjs
+++ b/scripts/check-release-sync.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+/**
+ * release-sync check (issue #31).
+ *
+ * Confirms every FIRST-PARTY public surface we publish to is tracking the
+ * current release — i.e. matches `package.json#version` (the source of truth the
+ * release pipeline fans out from). A silent drift here means a release half-
+ * landed (e.g. npm published but the registry publish failed), which is exactly
+ * the failure mode that makes a directory mark us "unmaintained".
+ *
+ * First-party surfaces (we publish; gated → a mismatch FAILS the check):
+ *   - npm                     registry.npmjs.org  → dist-tags.latest
+ *   - Official MCP Registry   registry.modelcontextprotocol.io → latest version
+ *                             (+ the hosted `remotes` endpoint must be present)
+ *   - GitHub release          api.github.com → releases/latest tag
+ *
+ * Downstream surfaces (PulseMCP / Glama / VS Code gallery) AUTO-INGEST from the
+ * registry on their own schedule, so they're reported FOR INFO ONLY — never gated
+ * (a lag there is expected, not a drift we caused).
+ *
+ * Usage: `node scripts/check-release-sync.mjs` (no deps; needs Node 18+ fetch).
+ * Exit 0 = all first-party surfaces in sync; exit 1 = drift or unreachable.
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const PKG = JSON.parse(
+  readFileSync(fileURLToPath(new URL("../package.json", import.meta.url)), "utf8"),
+);
+const EXPECTED = PKG.version;
+const NPM_NAME = "@mnemoverse/mcp-memory-server";
+const REGISTRY_NAME = "io.github.mnemoverse/mcp-memory-server";
+const GH_REPO = "mnemoverse/mcp-memory-server";
+
+const TIMEOUT_MS = 20_000;
+
+async function getJson(url, headers = {}) {
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      signal: ctrl.signal,
+      headers: { "user-agent": "mnemoverse-release-sync-check", ...headers },
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return await res.json();
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+const norm = (v) => (v ?? "").toString().replace(/^v/, "").trim();
+
+async function checkNpm() {
+  const j = await getJson(`https://registry.npmjs.org/${NPM_NAME}/latest`);
+  return { version: norm(j.version) };
+}
+
+async function checkRegistry() {
+  const j = await getJson(
+    "https://registry.modelcontextprotocol.io/v0/servers?search=mnemoverse",
+  );
+  // The API returns every version snapshot as a separate entry; each carries a
+  // server doc + a _meta with the registry's isLatest flag.
+  const isLatest = (entry) =>
+    entry?._meta?.["io.modelcontextprotocol.registry/official"]?.isLatest ??
+    entry?._meta?.isLatest ??
+    false;
+  const mine = (j.servers ?? j).filter((e) => (e.server ?? e).name === REGISTRY_NAME);
+  if (mine.length === 0) throw new Error(`server ${REGISTRY_NAME} not found in registry`);
+  const chosen =
+    mine.find(isLatest) ??
+    [...mine].sort((a, b) =>
+      norm((b.server ?? b).version).localeCompare(norm((a.server ?? a).version), undefined, {
+        numeric: true,
+      }),
+    )[0];
+  const srv = chosen.server ?? chosen;
+  const hasRemote = Array.isArray(srv.remotes) && srv.remotes.length > 0;
+  return { version: norm(srv.version), extra: hasRemote ? "remote ✓" : "remote MISSING" };
+}
+
+async function checkGithubRelease() {
+  const headers = process.env.GITHUB_TOKEN
+    ? { authorization: `Bearer ${process.env.GITHUB_TOKEN}` }
+    : {};
+  const j = await getJson(`https://api.github.com/repos/${GH_REPO}/releases/latest`, headers);
+  return { version: norm(j.tag_name) };
+}
+
+function line(name, status, version, extra = "") {
+  const v = version ? `v${version}`.padEnd(10) : "—".padEnd(10);
+  return `  ${name.padEnd(24)} ${v} ${status}${extra ? `  (${extra})` : ""}`;
+}
+
+async function main() {
+  console.log(`release-sync check — expected v${EXPECTED} (package.json)\n`);
+  const firstParty = [
+    ["npm", checkNpm],
+    ["Official MCP Registry", checkRegistry],
+    ["GitHub release", checkGithubRelease],
+  ];
+
+  let drift = false;
+  for (const [name, fn] of firstParty) {
+    try {
+      const { version, extra } = await fn();
+      const ok = version === EXPECTED && extra !== "remote MISSING";
+      if (!ok) drift = true;
+      const status = version === EXPECTED ? (extra === "remote MISSING" ? "✗ remote missing" : "✓") : `✗ DRIFT (have v${version || "?"})`;
+      console.log(line(name, status, version, extra && extra !== "remote MISSING" ? extra : ""));
+    } catch (err) {
+      drift = true;
+      console.log(line(name, `✗ unreachable: ${err.message}`, null));
+    }
+  }
+
+  console.log(
+    "\n  (note) downstream surfaces — PulseMCP / Glama / VS Code gallery — auto-ingest from the registry on their own schedule; not gated here.",
+  );
+
+  if (drift) {
+    console.error(`\nDRIFT: at least one first-party surface is not tracking v${EXPECTED}. Investigate the release pipeline (release.yml).`);
+    process.exit(1);
+  }
+  console.log(`\nAll first-party surfaces in sync at v${EXPECTED}.`);
+}
+
+main().catch((err) => {
+  console.error("check-release-sync failed:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Why

**Closes #31.** The release fan-out (`release.yml`) already works end-to-end — `v0.4.0` just exercised npm + Official MCP Registry (now carrying the hosted `remotes` endpoint) + GitHub release. What was missing is the **verification half**: a check that catches a *half-landed* release (e.g. npm published but the registry publish failed) before a directory reads the drift as "unmaintained."

## What

- **`scripts/check-release-sync.mjs`** — compares the three **first-party** surfaces we publish to against `package.json#version`:
  - **npm** dist-tag `latest`
  - **Official MCP Registry** latest version (+ asserts the hosted `remotes` endpoint is present)
  - **GitHub** latest release tag

  Any mismatch / unreachable → **exit 1** with a per-surface report. Downstream surfaces (PulseMCP / Glama / VS Code gallery) auto-ingest from the registry, so they're noted but **not gated** (a lag there is expected, not our drift). Pure Node `fetch`, no deps.
- **`.github/workflows/release-sync-check.yml`** — daily (07:00 UTC) + `workflow_dispatch`. Deliberately **not** on push (a release needs a moment to propagate; avoids a false red right after tagging). `permissions: contents: read`.
- **`package.json`** — `check:release-sync` for local runs.

## Verification
- Passes against the **live** state (npm / registry / GitHub release all `v0.4.0`, remote present) — exit 0.
- **TDD-proven**: temporarily bumping `package.json` to a version no surface has → reports DRIFT on all three + **exit 1**.
- `verify:configs` (19/19 in sync) + `build` still clean.

## Reviewer-voice
- **Registry `isLatest` parse**: the API returns every version snapshot; the script picks the `_meta…isLatest` entry, falling back to the highest semver. Worth a glance the fallback is sound if the flag shape ever changes.
- **No push trigger** is intentional (propagation lag). Say if you'd rather also run it post-release with a delay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated release consistency check that runs daily and can also be started manually.
  * Added a new command to verify that the published version stays aligned across major public release surfaces.

* **Bug Fixes**
  * Helps catch incomplete or mismatched releases earlier by flagging version drift and reporting when a release source is unreachable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->