### PR TITLE
docs(readme): friendly star CTA in the header

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Hosted memory for AI agents that learns and forgets. Feedback reranks the facts 
 
 Memory that persists across sessions, projects, and tools — and improves with use. Hosted, so there's no infrastructure to run, and not locked to a single cloud.
 
+> ⭐ If Mnemoverse saves you from re-explaining context to your agents, [star the repo](https://github.com/mnemoverse/mcp-memory-server). It helps other builders find it.
+
 ## Quick Start
 
 ### 1. Get a free API key


### PR DESCRIPTION
Adds one line to the README header inviting a GitHub star, with the honest reason (helps other builders discover it + surfaces us in the MCP directories, which rank/filter by stars).

- Placed right after the value prop, before Quick Start.
- Plain text CTA, not a badge. **Deliberately no live star-count shield yet** — at 3 stars a count badge would advertise the weakness; add it once we clear ~30-50.
- No claims, no numbers. Existing content untouched.

Part of the MCP-server star campaign (discovery push): low stars currently suppress our ranking in MCP directories + eligibility for "best AI memory tools" listicles. This is the repo-surface piece.

Review + merge at your call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the top of the project readme with a new call-to-action linking to the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->