### PR TITLE
release: v0.4.2

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "mnemoverse-memory",
   "display_name": "Mnemoverse Memory",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Hosted memory for AI agents that learns and forgets — one key across Claude, Cursor & ChatGPT.",
   "long_description": "Mnemoverse gives your AI assistant long-term memory that persists across sessions and across tools. Store preferences, decisions, and lessons with memory_write; recall them by natural-language search with memory_read. The same memory is shared everywhere you use your Mnemoverse API key — Claude, Cursor, VS Code, and any MCP client. Requires a free API key from https://console.mnemoverse.com.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mnemoverse/mcp-memory-server",
-  "version": "0.3.8",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mnemoverse/mcp-memory-server",
-      "version": "0.3.8",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mnemoverse/mcp-memory-server",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Hosted persistent memory for AI agents that learns which facts help and lets the rest fade — one key across Claude Code, Cursor, VS Code & ChatGPT, no infra to run",
   "type": "module",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -9,12 +9,12 @@
     "source": "github",
     "id": "1207193530"
   },
-  "version": "0.4.1",
+  "version": "0.4.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mnemoverse/mcp-memory-server",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## What

Version-propagation release: `package.json` 0.4.1 → 0.4.2 + regenerated distribution artifacts (`manifest.json`, `server.json`, lockfile). **No behavioral change** — same shape as #45.

## Why now

Glama's release pipeline is stuck: their Recent Releases stop at 0.3.10 (2026-06-18) while test builds stay green (latest `019f23ce…` builds v0.4.1 HEAD successfully, all 6 tools listed). npm/MCP Registry/GitHub releases for 0.4.0 and 0.4.1 shipped normally. This release is a controlled probe: a fresh version through the standard pipeline to observe whether Glama auto-ingests it — plus it keeps every first-party surface moving while the admin-side diagnosis (browser-agent brief, 2026-07-02) runs.

## Review focus (attack surfaces)

- **Version sync**: the ONLY semantic change is the version string — verify it propagated to all four files and nowhere else (`git diff` should show 6± lines).
- **Generated artifacts**: `npm run verify:configs` must pass (19/19 in sync) — CI runs it; local run passed.
- **No stray content**: no source/tool/schema changes should be present.

## Self-review checklist

- [x] `npm run verify:configs` — 19/19 artifacts in sync
- [x] `npm run build` (tsc) — clean
- [x] Local stdio smoke: `initialize` → `serverInfo 0.4.2`, `tools/list` → 6 tools
- [x] Diff limited to version propagation (4 files, 6 insertions / 6 deletions)
- [x] `check:release-sync` DRIFT on 'GitHub release v0.4.1' is expected pre-tag state; resolves once the `v0.4.2` tag triggers release.yml

## After merge

Tag `v0.4.2` on main → release.yml publishes npm + MCP Registry (OIDC) + GitHub release. Then watch Glama's next scheduled test build for auto-ingest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)