### PR TITLE
chore(release): bump to 0.5.0 — ships the rooms MCP tools (#50)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "mnemoverse-memory",
   "display_name": "Mnemoverse Memory",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Hosted memory for AI agents that learns and forgets — one key across Claude, Cursor & ChatGPT.",
   "long_description": "Mnemoverse gives your AI assistant long-term memory that persists across sessions and across tools. Store preferences, decisions, and lessons with memory_write; recall them by natural-language search with memory_read. The same memory is shared everywhere you use your Mnemoverse API key — Claude, Cursor, VS Code, and any MCP client. Requires a free API key from https://console.mnemoverse.com.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mnemoverse/mcp-memory-server",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mnemoverse/mcp-memory-server",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mnemoverse/mcp-memory-server",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Hosted persistent memory for AI agents that learns which facts help and lets the rest fade — one key across Claude Code, Cursor, VS Code & ChatGPT, no infra to run",
   "type": "module",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -9,12 +9,12 @@
     "source": "github",
     "id": "1207193530"
   },
-  "version": "0.4.2",
+  "version": "0.5.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mnemoverse/mcp-memory-server",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## What

Bumps `mcp-memory-server` **0.4.2 → 0.5.0** so the room MCP tools land in the **published** package.

## Why (the gap)

#50 (`memory_create_room` / `memory_invite_to_room` / `memory_join_room`) merged **after** the v0.4.2 tag but was **never released** — npm and the MCP registry still serve **0.4.2 without the room tools**. Merging code ≠ shipping it. This bump closes that.

## How

- `npm version 0.5.0 --no-git-tag-version` + `npm run generate:configs` → propagated to `package.json`, `manifest.json`, `server.json` (×2). `verify:configs` ✓ (all 19 artifacts in sync).
- Minor bump (new feature, backward-compatible).

## Release flow (founder-gated)

Merging this does **not** publish. Publishing happens when a maintainer pushes the tag: `git tag v0.5.0 && git push origin v0.5.0` → `release.yml` runs `npm publish` + `mcp-publisher publish`. The `release-sync-check` DRIFT warning is expected until that tag ships (npm/registry still 0.4.2); it's a scheduled check, not a PR gate.

## Part of the rooms rollout

The stdio half of shipping rooms — pairs with mcp-remote #23 (hosted connector tools), core #377 (`/rooms/join`), portal #104 (`/join`), docs #243.