### PR TITLE
feat(discovery): memory_list_rooms + vault_list (self-find rooms & secrets)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -83,17 +83,20 @@ async function apiFetch<T = unknown>(
  * result stays well-formed. Otherwise an emoji or non-BMP character at the
  * boundary can produce a lone surrogate and corrupt downstream JSON encoding.
  */
-function capResult(text: string): string {
+function capResult(
+  text: string,
+  moreHint = "Use a more specific query or smaller top_k to see all results.",
+): string {
   if (text.length <= MAX_RESULT_CHARS) return text;
   let truncated = text.slice(0, MAX_RESULT_CHARS - 200);
   const lastCode = truncated.charCodeAt(truncated.length - 1);
   if (lastCode >= 0xd800 && lastCode <= 0xdbff) {
     truncated = truncated.slice(0, -1);
   }
-  return (
-    truncated +
-    `\n\n[…truncated to fit 25K token limit. Use a more specific query or smaller top_k to see all results.]`
-  );
+  // `moreHint` lets no-input tools (the discovery lists) give accurate truncation
+  // guidance instead of the read-tool default (which points at query/top_k controls a
+  // repeated no-arg call cannot use). Existing callers keep the default message.
+  return `${truncated}\n\n[…truncated to fit the 25K token limit. ${moreHint}]`;
 }
 
 /**
@@ -730,7 +733,10 @@ server.registerTool(
     // through the same guard defensively.
     const lines = list.map((r) => {
       const name = safeInline(r?.name) || "(unnamed room)";
-      const address = safeInline(r?.address);
+      const roomId = safeInline(r?.room_id);
+      // Always surface the canonical address: fall back to xroom:<room_id> when the server
+      // omits `address`, so the domain guidance this tool promises is never silently dropped.
+      const address = safeInline(r?.address) || (roomId ? `xroom:${roomId}` : "");
       const role = safeInline(r?.role);
       const scope = safeInline(r?.scope);
       const archived = r?.archived ? " [archived]" : "";
@@ -739,7 +745,12 @@ server.registerTool(
     });
     const text = `Your shared rooms (${list.length}):\n${lines.join("\n")}`;
     return {
-      content: [{ type: "text" as const, text: capResult(text) }],
+      content: [
+        {
+          type: "text" as const,
+          text: capResult(text, "The room list was truncated — some rooms are not shown."),
+        },
+      ],
     };
   },
 );
@@ -789,7 +800,12 @@ server.registerTool(
       `Your Vault secrets (${list.length}) — alias and purpose only, never the value:\n` +
       lines.join("\n");
     return {
-      content: [{ type: "text" as const, text: capResult(text) }],
+      content: [
+        {
+          type: "text" as const,
+          text: capResult(text, "The secret list was truncated — some secrets are not shown."),
+        },
+      ],
     };
   },
 );

--- a/src/index.ts
+++ b/src/index.ts
@@ -685,6 +685,115 @@ server.registerTool(
   },
 );
 
+// --- Tool: memory_list_rooms ---
+
+server.registerTool(
+  "memory_list_rooms",
+  {
+    description:
+      "List the shared memory rooms you can use — the ones you OWN plus the ones you've JOINED — each with the address to pass as `domain` on memory_write / memory_read. Use this to RE-FIND a room in a new session (e.g. 'what rooms do I have?', 'resume the room with Olya') instead of having to create or re-join it.",
+    inputSchema: {},
+    annotations: {
+      title: "List rooms",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+  },
+  async () => {
+    const rooms = await apiFetch<
+      Array<{
+        room_id?: string;
+        name?: string;
+        address?: string;
+        role?: string;
+        scope?: string;
+        archived?: boolean;
+      }>
+    >("/memory/rooms");
+    const list = Array.isArray(rooms) ? rooms : [];
+    if (list.length === 0) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text:
+              "You have no shared rooms yet. Create one with memory_create_room, " +
+              "or join one with memory_join_room using an invite code.",
+          },
+        ],
+      };
+    }
+    // Room name is OWNER-chosen and surfaced to THIS assistant — sanitize it (CN-032),
+    // like memory_join_room already does. address/role/scope are server-shaped but pass
+    // through the same guard defensively.
+    const lines = list.map((r) => {
+      const name = safeInline(r?.name) || "(unnamed room)";
+      const address = safeInline(r?.address);
+      const role = safeInline(r?.role);
+      const scope = safeInline(r?.scope);
+      const archived = r?.archived ? " [archived]" : "";
+      const use = address ? ` — use domain="${address}"` : "";
+      return `- "${name}" (${role}${scope ? `, ${scope}` : ""})${archived}${use}`;
+    });
+    const text = `Your shared rooms (${list.length}):\n${lines.join("\n")}`;
+    return {
+      content: [{ type: "text" as const, text: capResult(text) }],
+    };
+  },
+);
+
+// --- Tool: vault_list ---
+
+server.registerTool(
+  "vault_list",
+  {
+    description:
+      "List the secrets stored in your Mnemoverse Vault — by ALIAS and purpose only; the secret VALUE is never returned or shown to you. Use this to DISCOVER which secret to use (e.g. the user says 'use my GitHub token' — find its alias here) before a tool that consumes it. Only YOUR account's secrets are listed.",
+    inputSchema: {},
+    annotations: {
+      title: "List vault secrets",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+  },
+  async () => {
+    const r = await apiFetch<{
+      secrets?: Array<{
+        alias?: string;
+        context?: string;
+        created_at?: string;
+        concepts?: string[];
+      }>;
+    }>("/vault/secrets");
+    const list = Array.isArray(r?.secrets) ? r.secrets : [];
+    if (list.length === 0) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: "No secrets are stored in your Vault yet.",
+          },
+        ],
+      };
+    }
+    const lines = list.map((s) => {
+      const alias = safeInline(s?.alias) || "(no alias)";
+      const context = safeInline(s?.context);
+      return context ? `- ${alias} — ${context}` : `- ${alias}`;
+    });
+    const text =
+      `Your Vault secrets (${list.length}) — alias and purpose only, never the value:\n` +
+      lines.join("\n");
+    return {
+      content: [{ type: "text" as const, text: capResult(text) }],
+    };
+  },
+);
+
 // --- Start ---
 
 async function main() {


### PR DESCRIPTION
## Summary
Two read-only discovery tools so a fresh session can RE-FIND what it already has, in the ONE memory MCP the user already connects:
- **`memory_list_rooms`** — owned + joined rooms with their `xroom:<id>` addresses + role (calls `GET /memory/rooms`).
- **`vault_list`** — the account's Vault secrets by **alias + purpose only, never the value**, only the caller's own org (calls `GET /vault/secrets`).

## Design
Part of the **single-facade** consolidation: the memory MCP is the one server users connect; discovery (rooms + secrets) is open-safe — authenticated HTTP GETs to core, no crypto, no core internals — so it lives natively here. The Vault value-arrival crypto (`vault_use` / `create_secret_capture`) stays a **separate closable capability** loaded optionally in a later increment; the open server is never contaminated with it.

## What changed
- `src/index.ts`: both tools, no-input, `readOnlyHint:true` + `openWorldHint:true` (local convention). Owner-chosen room names pass `safeInline` (CN-032). Value-free by construction (vault_list renders only alias/context).

## Testing (CI mirrored locally)
- Smoke: `tools/list` shows both with `readOnlyHint:true`. `verify:configs` (19 artifacts in sync) + `check:release-sync` green. `npm run build` (tsc) green.

## Notes
- Requires the companion core routes `GET /memory/rooms` + `GET /vault/secrets` (PRs on mnemoverse-core). Works with the existing `MNEMOVERSE_API_KEY` — discovery needs no extra env.
- A version bump + npm publish is a separate, deliberate step (new tools ⇒ a serious new version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a tool to list shared memory rooms, including each room’s name and usage guidance.
  * Added a tool to list stored vault secrets by alias and context.
  * Clear messages are now provided when no rooms or secrets are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->