### PR TITLE
feat(fold): optionally fold the closed vault companion into the memory server (Inc2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   ],
   "scripts": {
     "build": "tsc",
+    "test": "npm run build && node --test test/vault-surface.test.mjs",
     "dev": "tsc --watch",
     "start": "node dist/index.js",
     "generate:configs": "node scripts/generate-configs.mjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { createRequire } from "node:module";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
+import { maybeRegisterVaultSurface } from "./vault-surface.js";
 
 // Version is read at runtime from package.json so there is exactly one place
 // to bump on each release. Works both from `dist/` during local dev and from
@@ -813,6 +814,10 @@ server.registerTool(
 // --- Start ---
 
 async function main() {
+  // Fold in the optional CLOSED vault companion (vault_use / create_secret_capture) BEFORE
+  // connecting the transport, so any vault tools are present for the client's tools/list. A
+  // missing companion or missing vault-env degrades to memory-only — it never blocks startup.
+  await maybeRegisterVaultSurface(server);
   const transport = new StdioServerTransport();
   await server.connect(transport);
 }

--- a/src/vault-surface.ts
+++ b/src/vault-surface.ts
@@ -191,6 +191,11 @@ function withRegistrationRollback(server: McpServer): {
   rollback: () => void;
 } {
   const handles: Array<{ remove: () => void }> = [];
+  // A timeout stops us WAITING on the companion but cannot CANCEL an in-flight async register()
+  // coroutine. If that coroutine resumes AFTER rollback (and after the transport connects) and
+  // registers a late tool, it would land a stray tool on the LIVE surface. This flag, set by
+  // rollback(), makes any post-rollback registration self-remove immediately so nothing lingers.
+  let aborted = false;
   const proxy = new Proxy(server, {
     get(target, prop, receiver) {
       if (prop === "registerTool") {
@@ -201,7 +206,16 @@ function withRegistrationRollback(server: McpServer): {
             ) => { remove?: () => void }
           )(...args);
           if (handle && typeof handle.remove === "function") {
-            handles.push(handle as { remove: () => void });
+            if (aborted) {
+              // Fold already failed + rolled back — a late registration must not persist.
+              try {
+                handle.remove();
+              } catch {
+                /* best-effort */
+              }
+            } else {
+              handles.push(handle as { remove: () => void });
+            }
           }
           return handle;
         };
@@ -213,8 +227,10 @@ function withRegistrationRollback(server: McpServer): {
   return {
     server: proxy as McpServer,
     // Remove in REVERSE registration order; best-effort — a remove() that throws must not mask the
-    // original failure or stop the rest of the rollback.
+    // original failure or stop the rest of the rollback. Setting `aborted` FIRST closes the race
+    // with a still-live coroutine that registers after this point.
     rollback: () => {
+      aborted = true;
       for (const handle of handles.splice(0).reverse()) {
         try {
           handle.remove();

--- a/src/vault-surface.ts
+++ b/src/vault-surface.ts
@@ -120,17 +120,27 @@ export async function maybeRegisterVaultSurface(
   try {
     mod = await withTimeout(importRegister(), timeoutMs, "vault companion import");
   } catch (err) {
+    // Distinguish three load failures (all fail OPEN — the server still starts memory-only):
+    //   - timed out            -> "timeout"
+    //   - genuinely not installed (module-not-found) -> "unavailable" (install it to enable USE)
+    //   - installed but broke while loading (syntax / native-addon / init error) -> "error"
+    // Collapsing the last two would log a misleading "not installed" for a broken install (Copilot #1).
     const timedOut = err instanceof TimeoutError;
+    const notFound = !timedOut && isModuleNotFound(err);
     console.error(
       timedOut
         ? "[mnemoverse-memory] Vault env is set but the @mnemoverse/mcp-vault companion did not " +
             `load within ${timeoutMs}ms — starting memory-only; the vault_use surface is ` +
             "unavailable this run."
-        : "[mnemoverse-memory] Vault env is set but the @mnemoverse/mcp-vault companion is not " +
-            "installed — the vault_use surface is unavailable. Install it alongside this server " +
-            `to enable using secrets without seeing them. (${asMessage(err)})`,
+        : notFound
+          ? "[mnemoverse-memory] Vault env is set but the @mnemoverse/mcp-vault companion is not " +
+              "installed — the vault_use surface is unavailable. Install it alongside this server " +
+              "to enable using secrets without seeing them."
+          : "[mnemoverse-memory] Vault env is set and the @mnemoverse/mcp-vault companion is present " +
+              "but FAILED TO LOAD (syntax / native-addon / init error) — starting memory-only; the " +
+              `vault_use surface is unavailable this run. (${asMessage(err)})`,
     );
-    return timedOut ? "timeout" : "unavailable";
+    return timedOut ? "timeout" : notFound ? "unavailable" : "error";
   }
 
   // Register through a rollback-recording proxy. If the companion registers some tools and THEN
@@ -270,4 +280,10 @@ function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
 
 function asMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+/** True iff `err` is a module-not-found (the companion is genuinely absent), vs a load/eval error. */
+function isModuleNotFound(err: unknown): boolean {
+  const code = (err as { code?: unknown } | null | undefined)?.code;
+  return code === "ERR_MODULE_NOT_FOUND" || code === "MODULE_NOT_FOUND";
 }

--- a/src/vault-surface.ts
+++ b/src/vault-surface.ts
@@ -1,0 +1,118 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+/**
+ * Optionally fold the CLOSED Vault capability (`@mnemoverse/mcp-vault`) into THIS open
+ * memory-server, so a user who connects ONE MCP also gets the "use a secret without ever
+ * seeing it" surface (`vault_use` / `create_secret_capture`) — WITHOUT this open server
+ * carrying any of the vault crypto itself.
+ *
+ * ## Why a guarded dynamic import (not a dependency)
+ *
+ * This package is MIT / public npm; the vault crypto and the core it talks to are CLOSED and
+ * stay that way. If we `import`ed the vault package normally it would become a hard dependency,
+ * and opening this server would drag the closed package (and its core coupling) into the open.
+ * So the fold is a **best-effort, guarded dynamic import of an OPTIONAL companion**:
+ *
+ *   - vault-env absent        → skip; server stays memory + rooms + discovery only  → "off"
+ *   - companion not installed  → skip gracefully; USE surface simply doesn't appear  → "unavailable"
+ *   - both present            → `registerVaultSurface(server, env)` adds the tools    → "live" | "scaffold"
+ *
+ * Fail-OPEN for the *server* (a missing or broken companion must never block memory), fail-CLOSED
+ * for the *secret* (the vault package itself decides live-vs-scaffold from the env; no env → no USE
+ * surface at all). Diagnostics go to **stderr** — stdout is the MCP stdio transport and must stay
+ * protocol-only.
+ *
+ * The module specifier is held in a `const` (not an inline literal) on purpose: TypeScript only
+ * resolves string-literal import specifiers, so this keeps the optional companion out of
+ * compile-time module resolution — there is deliberately no `@mnemoverse/mcp-vault` entry in this
+ * package's dependencies.
+ */
+export type VaultFoldStatus =
+  | "off"
+  | "unavailable"
+  | "live"
+  | "scaffold"
+  | "error";
+
+/**
+ * The three env vars the vault companion needs to run LIVE. All three gate whether we even probe
+ * for the companion — an operator enabling USE sets all of them (server URL + bearer token +
+ * on-device passphrase); anything less means the user has not opted into secret use.
+ */
+const VAULT_ENV_KEYS = [
+  "MNEMOVERSE_VAULT_SERVER_URL",
+  "MNEMOVERSE_VAULT_TOKEN",
+  "MNEMOVERSE_VAULT_PASSPHRASE",
+] as const;
+
+// Held in a const so tsc does not statically resolve it (see module doc): the companion is an
+// optional runtime dependency, never a package.json one.
+const VAULT_REGISTER_SPECIFIER = "@mnemoverse/mcp-vault/register";
+
+interface VaultRegisterModule {
+  registerVaultSurface?: (
+    server: McpServer,
+    env: NodeJS.ProcessEnv,
+  ) => "live" | "scaffold";
+}
+
+/**
+ * How the companion module is loaded. Production uses the guarded dynamic import; tests inject a
+ * fake (or throwing) importer to exercise every branch deterministically WITHOUT the closed
+ * companion present. Kept as the last parameter with a real default so callers never pass it.
+ */
+export type VaultRegisterImporter = () => Promise<VaultRegisterModule>;
+
+const defaultImporter: VaultRegisterImporter = () =>
+  import(VAULT_REGISTER_SPECIFIER) as Promise<VaultRegisterModule>;
+
+/**
+ * Attempt to fold the vault surface into `server`. Returns a status describing what happened;
+ * never throws — a failure here degrades the server to memory-only, it does not crash it.
+ */
+export async function maybeRegisterVaultSurface(
+  server: McpServer,
+  env: NodeJS.ProcessEnv = process.env,
+  importRegister: VaultRegisterImporter = defaultImporter,
+): Promise<VaultFoldStatus> {
+  // Gate on env FIRST — if the user hasn't opted into USE, don't even probe for the companion.
+  const missing = VAULT_ENV_KEYS.filter((k) => !env[k]);
+  if (missing.length > 0) {
+    return "off";
+  }
+
+  let mod: VaultRegisterModule;
+  try {
+    mod = await importRegister();
+  } catch (err) {
+    console.error(
+      "[mnemoverse-memory] Vault env is set but the @mnemoverse/mcp-vault companion is not " +
+        "installed — the vault_use surface is unavailable. Install it alongside this server to " +
+        `enable using secrets without seeing them. (${asMessage(err)})`,
+    );
+    return "unavailable";
+  }
+
+  if (typeof mod.registerVaultSurface !== "function") {
+    console.error(
+      "[mnemoverse-memory] @mnemoverse/mcp-vault/register did not export registerVaultSurface(); " +
+        "vault surface not folded.",
+    );
+    return "error";
+  }
+
+  try {
+    const mode = mod.registerVaultSurface(server, env);
+    console.error(`[mnemoverse-memory] Vault surface folded in (${mode}).`);
+    return mode;
+  } catch (err) {
+    console.error(
+      `[mnemoverse-memory] Failed to register the vault surface: ${asMessage(err)}`,
+    );
+    return "error";
+  }
+}
+
+function asMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/src/vault-surface.ts
+++ b/src/vault-surface.ts
@@ -15,21 +15,30 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
  *
  *   - vault-env absent        → skip; server stays memory + rooms + discovery only  → "off"
  *   - companion not installed  → skip gracefully; USE surface simply doesn't appear  → "unavailable"
- *   - both present            → `registerVaultSurface(server, env)` adds the tools    → "live" | "scaffold"
+ *   - companion load times out → skip; server still comes up memory-only            → "timeout"
+ *   - companion errors mid-fold → roll back its partial tools; memory-only          → "error" / "timeout"
+ *   - both present, healthy    → `registerVaultSurface(server, env)` adds the tools  → "live" | "scaffold"
  *
- * Fail-OPEN for the *server* (a missing or broken companion must never block memory), fail-CLOSED
- * for the *secret* (the vault package itself decides live-vs-scaffold from the env; no env → no USE
- * surface at all). Diagnostics go to **stderr** — stdout is the MCP stdio transport and must stay
- * protocol-only.
+ * Fail-OPEN for the *server* (a missing, broken, SLOW, or partially-registering companion must
+ * never crash or stall memory — see the bounded import, the awaited/validated return, and the
+ * registration rollback below), fail-CLOSED for the *secret* (the vault package itself decides
+ * live-vs-scaffold from the env; no env → no USE surface at all). Diagnostics go to **stderr** —
+ * stdout is the MCP stdio transport and must stay protocol-only.
  *
  * The module specifier is held in a `const` (not an inline literal) on purpose: TypeScript only
  * resolves string-literal import specifiers, so this keeps the optional companion out of
  * compile-time module resolution — there is deliberately no `@mnemoverse/mcp-vault` entry in this
  * package's dependencies.
+ *
+ * NOTE ON TRUST: the companion is loaded into the SAME tool surface, so a HOSTILE companion could
+ * in principle register a tool that shadows a core memory tool. The companion is our own closed
+ * package (trusted); this seam defends against a BROKEN/SLOW companion (crash/hang/partial fold),
+ * not a malicious one. Loading untrusted vault code is out of scope by design.
  */
 export type VaultFoldStatus =
   | "off"
   | "unavailable"
+  | "timeout"
   | "live"
   | "scaffold"
   | "error";
@@ -49,6 +58,13 @@ const VAULT_ENV_KEYS = [
 // optional runtime dependency, never a package.json one.
 const VAULT_REGISTER_SPECIFIER = "@mnemoverse/mcp-vault/register";
 
+// The companion pulls a native addon (@napi-rs/keyring) at load and, in a version-skewed or
+// broken build, could return a non-settling promise. Both the import AND the registration call
+// are bounded by this deadline: a companion phase that never settles must not stall the server,
+// because the fold is awaited BEFORE the transport connects. On timeout the server comes up
+// memory-only.
+const DEFAULT_COMPANION_TIMEOUT_MS = 10_000;
+
 interface VaultRegisterModule {
   registerVaultSurface?: (
     server: McpServer,
@@ -58,59 +74,182 @@ interface VaultRegisterModule {
 
 /**
  * How the companion module is loaded. Production uses the guarded dynamic import; tests inject a
- * fake (or throwing) importer to exercise every branch deterministically WITHOUT the closed
- * companion present. Kept as the last parameter with a real default so callers never pass it.
+ * fake (or throwing / never-resolving) importer to exercise every branch deterministically
+ * WITHOUT the closed companion present.
  */
 export type VaultRegisterImporter = () => Promise<VaultRegisterModule>;
+
+export interface VaultFoldOptions {
+  /** Override how the companion is loaded (default: guarded dynamic import). Tests inject fakes. */
+  importRegister?: VaultRegisterImporter;
+  /** Upper bound on EACH companion phase — import and registration (default {@link DEFAULT_COMPANION_TIMEOUT_MS}). */
+  companionTimeoutMs?: number;
+}
 
 const defaultImporter: VaultRegisterImporter = () =>
   import(VAULT_REGISTER_SPECIFIER) as Promise<VaultRegisterModule>;
 
 /**
  * Attempt to fold the vault surface into `server`. Returns a status describing what happened;
- * never throws — a failure here degrades the server to memory-only, it does not crash it.
+ * never throws and never hangs the caller — a failure, a slow/hung companion, OR a companion that
+ * registers some tools then fails all degrade the server to memory-only (rolling back any
+ * partial surface), they do not crash or stall startup.
  */
 export async function maybeRegisterVaultSurface(
   server: McpServer,
   env: NodeJS.ProcessEnv = process.env,
-  importRegister: VaultRegisterImporter = defaultImporter,
+  opts: VaultFoldOptions = {},
 ): Promise<VaultFoldStatus> {
+  const importRegister = opts.importRegister ?? defaultImporter;
+  const timeoutMs = opts.companionTimeoutMs ?? DEFAULT_COMPANION_TIMEOUT_MS;
+
   // Gate on env FIRST — if the user hasn't opted into USE, don't even probe for the companion.
-  const missing = VAULT_ENV_KEYS.filter((k) => !env[k]);
+  // Trim for the PRESENCE check so a whitespace-only value counts as absent (an env-templating
+  // accident like "  " must NOT probe the native-dep companion or register a surprise surface);
+  // the untrimmed value is still what we hand the companion, so a real passphrase that contains
+  // spaces is unaffected — only an entirely-blank value is treated as missing.
+  const missing = VAULT_ENV_KEYS.filter((k) => {
+    const v = env[k];
+    return v == null || v.trim() === "";
+  });
   if (missing.length > 0) {
     return "off";
   }
 
   let mod: VaultRegisterModule;
   try {
-    mod = await importRegister();
+    mod = await withTimeout(importRegister(), timeoutMs, "vault companion import");
   } catch (err) {
+    const timedOut = err instanceof TimeoutError;
     console.error(
-      "[mnemoverse-memory] Vault env is set but the @mnemoverse/mcp-vault companion is not " +
-        "installed — the vault_use surface is unavailable. Install it alongside this server to " +
-        `enable using secrets without seeing them. (${asMessage(err)})`,
+      timedOut
+        ? "[mnemoverse-memory] Vault env is set but the @mnemoverse/mcp-vault companion did not " +
+            `load within ${timeoutMs}ms — starting memory-only; the vault_use surface is ` +
+            "unavailable this run."
+        : "[mnemoverse-memory] Vault env is set but the @mnemoverse/mcp-vault companion is not " +
+            "installed — the vault_use surface is unavailable. Install it alongside this server " +
+            `to enable using secrets without seeing them. (${asMessage(err)})`,
     );
-    return "unavailable";
+    return timedOut ? "timeout" : "unavailable";
   }
 
-  if (typeof mod.registerVaultSurface !== "function") {
-    console.error(
-      "[mnemoverse-memory] @mnemoverse/mcp-vault/register did not export registerVaultSurface(); " +
-        "vault surface not folded.",
-    );
-    return "error";
-  }
-
+  // Register through a rollback-recording proxy. If the companion registers some tools and THEN
+  // fails (throws, times out, or returns a bad value), we remove the tools it already added so the
+  // client never sees a half-folded surface — the "degrade to memory-only" guarantee holds even
+  // for a mid-registration failure. `Promise.resolve(...)` normalizes a sync return AND an
+  // (unexpected, version-skewed) thenable return into one awaited value, so a rejecting or
+  // never-settling companion is caught/timed-out here instead of escaping into main()'s unguarded
+  // await (which would crash via process.exit or hang before connect). The property read + call
+  // are BOTH inside the try so even a throwing getter on `registerVaultSurface` degrades cleanly.
+  const { server: recordingServer, rollback } = withRegistrationRollback(server);
   try {
-    const mode = mod.registerVaultSurface(server, env);
+    const register = mod.registerVaultSurface;
+    if (typeof register !== "function") {
+      console.error(
+        "[mnemoverse-memory] @mnemoverse/mcp-vault/register did not export a registerVaultSurface() " +
+          "function; vault surface not folded.",
+      );
+      return "error";
+    }
+    const mode = await withTimeout(
+      Promise.resolve(register(recordingServer, env)),
+      timeoutMs,
+      "vault surface registration",
+    );
+    if (mode !== "live" && mode !== "scaffold") {
+      console.error(
+        `[mnemoverse-memory] @mnemoverse/mcp-vault/register returned an unexpected mode ` +
+          `(${String(mode)}); rolling back the partial vault surface.`,
+      );
+      rollback();
+      return "error";
+    }
     console.error(`[mnemoverse-memory] Vault surface folded in (${mode}).`);
     return mode;
   } catch (err) {
+    rollback();
+    const timedOut = err instanceof TimeoutError;
     console.error(
-      `[mnemoverse-memory] Failed to register the vault surface: ${asMessage(err)}`,
+      timedOut
+        ? `[mnemoverse-memory] Vault surface registration did not settle within ${timeoutMs}ms — ` +
+            "rolled back to memory-only."
+        : `[mnemoverse-memory] Failed to register the vault surface: ${asMessage(err)} — rolled ` +
+            "back to memory-only.",
     );
-    return "error";
+    return timedOut ? "timeout" : "error";
   }
+}
+
+/**
+ * Wrap `server` so every tool the companion registers is recorded, and can be removed as a group
+ * if the fold fails partway. The companion uses only `registerTool` (verified), but the proxy
+ * forwards ALL other access to the real server — methods are bound to the real target so internal
+ * private-field access uses the true `this`, not the proxy.
+ */
+function withRegistrationRollback(server: McpServer): {
+  server: McpServer;
+  rollback: () => void;
+} {
+  const handles: Array<{ remove: () => void }> = [];
+  const proxy = new Proxy(server, {
+    get(target, prop, receiver) {
+      if (prop === "registerTool") {
+        return (...args: unknown[]): unknown => {
+          const handle = (
+            target.registerTool as unknown as (
+              ...a: unknown[]
+            ) => { remove?: () => void }
+          )(...args);
+          if (handle && typeof handle.remove === "function") {
+            handles.push(handle as { remove: () => void });
+          }
+          return handle;
+        };
+      }
+      const value = Reflect.get(target, prop, receiver);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+  return {
+    server: proxy as McpServer,
+    // Remove in REVERSE registration order; best-effort — a remove() that throws must not mask the
+    // original failure or stop the rest of the rollback.
+    rollback: () => {
+      for (const handle of handles.splice(0).reverse()) {
+        try {
+          handle.remove();
+        } catch {
+          /* best-effort rollback */
+        }
+      }
+    },
+  };
+}
+
+class TimeoutError extends Error {}
+
+/**
+ * Resolve `p`, but reject with a {@link TimeoutError} if it has not settled within `ms`. The timer
+ * is `unref`ed so a still-pending `p` (e.g. a hung import) cannot by itself keep the process alive.
+ */
+function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new TimeoutError(`${label} timed out after ${ms}ms`));
+    }, ms);
+    // Node's setTimeout returns a Timeout object with unref(); guard for non-Node shims.
+    (timer as { unref?: () => void }).unref?.();
+    p.then(
+      (v) => {
+        clearTimeout(timer);
+        resolve(v);
+      },
+      (e) => {
+        clearTimeout(timer);
+        reject(e);
+      },
+    );
+  });
 }
 
 function asMessage(err: unknown): string {

--- a/test/vault-surface.test.mjs
+++ b/test/vault-surface.test.mjs
@@ -1,0 +1,114 @@
+// Behavioral tests for the optional vault-surface fold (Increment 2 of the single memory-MCP
+// facade). The seam decides whether the CLOSED @mnemoverse/mcp-vault companion gets folded into
+// THIS open server. We exercise every branch by INJECTING the importer, so the closed companion
+// never has to be present — the open CI stays green, and the fold logic is still fully covered.
+//
+// Run: npm test  (builds, then `node --test`). No test runner dependency — node:test is built in.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { maybeRegisterVaultSurface } from "../dist/vault-surface.js";
+
+const FULL_ENV = {
+  MNEMOVERSE_VAULT_SERVER_URL: "https://core.mnemoverse.com/api/v1",
+  MNEMOVERSE_VAULT_TOKEN: "tok_test",
+  MNEMOVERSE_VAULT_PASSPHRASE: "correct horse battery staple",
+};
+
+/** A minimal McpServer stand-in that records every tool the fold registers. */
+function spyServer() {
+  const registered = [];
+  return {
+    registered,
+    registerTool: (name) => {
+      registered.push(name);
+    },
+  };
+}
+
+/** An importer that fails the test if the seam ever calls it (used to prove the env gate). */
+function importerMustNotBeCalled() {
+  return () => {
+    throw new Error("importer should not be called when vault-env is absent");
+  };
+}
+
+test("off — no vault env: skips the companion entirely, registers nothing", async () => {
+  const server = spyServer();
+  const status = await maybeRegisterVaultSurface(
+    server,
+    {},
+    importerMustNotBeCalled(),
+  );
+  assert.equal(status, "off");
+  assert.deepEqual(server.registered, []);
+});
+
+test("off — partial vault env (missing passphrase): still gated off", async () => {
+  const server = spyServer();
+  const { MNEMOVERSE_VAULT_PASSPHRASE, ...partial } = FULL_ENV;
+  const status = await maybeRegisterVaultSurface(
+    server,
+    partial,
+    importerMustNotBeCalled(),
+  );
+  assert.equal(status, "off");
+  assert.deepEqual(server.registered, []);
+});
+
+test("unavailable — full env but companion not installed: degrades to memory-only", async () => {
+  const server = spyServer();
+  const status = await maybeRegisterVaultSurface(server, FULL_ENV, async () => {
+    const err = new Error("Cannot find package '@mnemoverse/mcp-vault'");
+    err.code = "ERR_MODULE_NOT_FOUND";
+    throw err;
+  });
+  assert.equal(status, "unavailable");
+  assert.deepEqual(server.registered, []);
+});
+
+test("error — companion present but exports no registerVaultSurface()", async () => {
+  const server = spyServer();
+  const status = await maybeRegisterVaultSurface(
+    server,
+    FULL_ENV,
+    async () => ({}),
+  );
+  assert.equal(status, "error");
+  assert.deepEqual(server.registered, []);
+});
+
+test("error — registerVaultSurface throws: caught, server not crashed", async () => {
+  const server = spyServer();
+  const status = await maybeRegisterVaultSurface(server, FULL_ENV, async () => ({
+    registerVaultSurface: () => {
+      throw new Error("boom during registration");
+    },
+  }));
+  assert.equal(status, "error");
+});
+
+test("live — companion folds its tools onto THIS server's surface", async () => {
+  const server = spyServer();
+  const status = await maybeRegisterVaultSurface(server, FULL_ENV, async () => ({
+    registerVaultSurface: (s) => {
+      s.registerTool("vault_use");
+      s.registerTool("create_secret_capture");
+      return "live";
+    },
+  }));
+  assert.equal(status, "live");
+  assert.deepEqual(server.registered, ["vault_use", "create_secret_capture"]);
+});
+
+test("scaffold — companion loads in fail-closed mode (env valid, transport not live)", async () => {
+  const server = spyServer();
+  const status = await maybeRegisterVaultSurface(server, FULL_ENV, async () => ({
+    registerVaultSurface: (s) => {
+      s.registerTool("vault_use");
+      return "scaffold";
+    },
+  }));
+  assert.equal(status, "scaffold");
+  assert.deepEqual(server.registered, ["vault_use"]);
+});

--- a/test/vault-surface.test.mjs
+++ b/test/vault-surface.test.mjs
@@ -1,7 +1,8 @@
 // Behavioral tests for the optional vault-surface fold (Increment 2 of the single memory-MCP
 // facade). The seam decides whether the CLOSED @mnemoverse/mcp-vault companion gets folded into
 // THIS open server. We exercise every branch by INJECTING the importer, so the closed companion
-// never has to be present — the open CI stays green, and the fold logic is still fully covered.
+// never has to be present — the open CI stays green, and the fold logic is fully covered,
+// including the robustness paths (hang, async reject, mid-registration failure) found in review.
 //
 // Run: npm test  (builds, then `node --test`). No test runner dependency — node:test is built in.
 
@@ -15,13 +16,25 @@ const FULL_ENV = {
   MNEMOVERSE_VAULT_PASSPHRASE: "correct horse battery staple",
 };
 
-/** A minimal McpServer stand-in that records every tool the fold registers. */
+/**
+ * A minimal McpServer stand-in that records the tools the fold registers and honors remove() so
+ * rollback is observable. `registered` reflects the CURRENT surface; `removed` is the rollback log.
+ */
 function spyServer() {
   const registered = [];
+  const removed = [];
   return {
     registered,
-    registerTool: (name) => {
+    removed,
+    registerTool(name) {
       registered.push(name);
+      return {
+        remove() {
+          removed.push(name);
+          const i = registered.indexOf(name);
+          if (i >= 0) registered.splice(i, 1);
+        },
+      };
     },
   };
 }
@@ -33,13 +46,13 @@ function importerMustNotBeCalled() {
   };
 }
 
+// --- env gate (fail-closed on opt-in) ------------------------------------------------------------
+
 test("off — no vault env: skips the companion entirely, registers nothing", async () => {
   const server = spyServer();
-  const status = await maybeRegisterVaultSurface(
-    server,
-    {},
-    importerMustNotBeCalled(),
-  );
+  const status = await maybeRegisterVaultSurface(server, {}, {
+    importRegister: importerMustNotBeCalled(),
+  });
   assert.equal(status, "off");
   assert.deepEqual(server.registered, []);
 });
@@ -47,68 +60,170 @@ test("off — no vault env: skips the companion entirely, registers nothing", as
 test("off — partial vault env (missing passphrase): still gated off", async () => {
   const server = spyServer();
   const { MNEMOVERSE_VAULT_PASSPHRASE, ...partial } = FULL_ENV;
-  const status = await maybeRegisterVaultSurface(
-    server,
-    partial,
-    importerMustNotBeCalled(),
-  );
+  const status = await maybeRegisterVaultSurface(server, partial, {
+    importRegister: importerMustNotBeCalled(),
+  });
   assert.equal(status, "off");
   assert.deepEqual(server.registered, []);
 });
 
+test("off — whitespace-only env values count as absent (env-templating accident)", async () => {
+  const server = spyServer();
+  const blank = {
+    MNEMOVERSE_VAULT_SERVER_URL: "   ",
+    MNEMOVERSE_VAULT_TOKEN: "\t",
+    MNEMOVERSE_VAULT_PASSPHRASE: "  ",
+  };
+  const status = await maybeRegisterVaultSurface(server, blank, {
+    importRegister: importerMustNotBeCalled(),
+  });
+  assert.equal(status, "off");
+  assert.deepEqual(server.registered, []);
+});
+
+// --- load failures (fail-open for the server) ----------------------------------------------------
+
 test("unavailable — full env but companion not installed: degrades to memory-only", async () => {
   const server = spyServer();
-  const status = await maybeRegisterVaultSurface(server, FULL_ENV, async () => {
-    const err = new Error("Cannot find package '@mnemoverse/mcp-vault'");
-    err.code = "ERR_MODULE_NOT_FOUND";
-    throw err;
+  const status = await maybeRegisterVaultSurface(server, FULL_ENV, {
+    importRegister: async () => {
+      const err = new Error("Cannot find package '@mnemoverse/mcp-vault'");
+      err.code = "ERR_MODULE_NOT_FOUND";
+      throw err;
+    },
   });
   assert.equal(status, "unavailable");
   assert.deepEqual(server.registered, []);
 });
 
+test("timeout — a never-settling import does not hang startup", async () => {
+  const server = spyServer();
+  const status = await maybeRegisterVaultSurface(server, FULL_ENV, {
+    importRegister: () => new Promise(() => {}), // never settles
+    companionTimeoutMs: 20,
+  });
+  assert.equal(status, "timeout");
+  assert.deepEqual(server.registered, []);
+});
+
+// --- bad companion shape (never throws out) ------------------------------------------------------
+
 test("error — companion present but exports no registerVaultSurface()", async () => {
   const server = spyServer();
-  const status = await maybeRegisterVaultSurface(
-    server,
-    FULL_ENV,
-    async () => ({}),
-  );
+  const status = await maybeRegisterVaultSurface(server, FULL_ENV, {
+    importRegister: async () => ({}),
+  });
   assert.equal(status, "error");
   assert.deepEqual(server.registered, []);
 });
 
-test("error — registerVaultSurface throws: caught, server not crashed", async () => {
+test("error — registerVaultSurface is a throwing getter: caught, server not crashed", async () => {
   const server = spyServer();
-  const status = await maybeRegisterVaultSurface(server, FULL_ENV, async () => ({
-    registerVaultSurface: () => {
-      throw new Error("boom during registration");
+  const mod = {};
+  Object.defineProperty(mod, "registerVaultSurface", {
+    get() {
+      throw new Error("hostile getter");
     },
-  }));
+  });
+  const status = await maybeRegisterVaultSurface(server, FULL_ENV, {
+    importRegister: async () => mod,
+  });
   assert.equal(status, "error");
+  assert.deepEqual(server.registered, []);
 });
+
+test("error — unexpected mode return: rolls back the partial surface", async () => {
+  const server = spyServer();
+  const status = await maybeRegisterVaultSurface(server, FULL_ENV, {
+    importRegister: async () => ({
+      registerVaultSurface: (s) => {
+        s.registerTool("vault_use");
+        return "partial"; // not "live" | "scaffold"
+      },
+    }),
+  });
+  assert.equal(status, "error");
+  assert.deepEqual(server.registered, []); // vault_use rolled back
+  assert.deepEqual(server.removed, ["vault_use"]);
+});
+
+// --- mid-registration failure rollback (degrade to memory-only) -----------------------------------
+
+test("error — sync throw AFTER registering a tool: rolled back", async () => {
+  const server = spyServer();
+  const status = await maybeRegisterVaultSurface(server, FULL_ENV, {
+    importRegister: async () => ({
+      registerVaultSurface: (s) => {
+        s.registerTool("vault_use");
+        throw new Error("boom after first tool");
+      },
+    }),
+  });
+  assert.equal(status, "error");
+  assert.deepEqual(server.registered, []);
+  assert.deepEqual(server.removed, ["vault_use"]);
+});
+
+test("error — ASYNC reject AFTER registering a tool: caught + rolled back (no crash)", async () => {
+  const server = spyServer();
+  const status = await maybeRegisterVaultSurface(server, FULL_ENV, {
+    importRegister: async () => ({
+      registerVaultSurface: async (s) => {
+        s.registerTool("vault_use");
+        throw new Error("async boom");
+      },
+    }),
+  });
+  assert.equal(status, "error");
+  assert.deepEqual(server.registered, []);
+  assert.deepEqual(server.removed, ["vault_use"]);
+});
+
+test("timeout — a never-settling registration is bounded + rolled back", async () => {
+  const server = spyServer();
+  const status = await maybeRegisterVaultSurface(server, FULL_ENV, {
+    importRegister: async () => ({
+      registerVaultSurface: (s) => {
+        s.registerTool("vault_use");
+        return new Promise(() => {}); // never settles
+      },
+    }),
+    companionTimeoutMs: 20,
+  });
+  assert.equal(status, "timeout");
+  assert.deepEqual(server.registered, []);
+  assert.deepEqual(server.removed, ["vault_use"]);
+});
+
+// --- happy paths ---------------------------------------------------------------------------------
 
 test("live — companion folds its tools onto THIS server's surface", async () => {
   const server = spyServer();
-  const status = await maybeRegisterVaultSurface(server, FULL_ENV, async () => ({
-    registerVaultSurface: (s) => {
-      s.registerTool("vault_use");
-      s.registerTool("create_secret_capture");
-      return "live";
-    },
-  }));
+  const status = await maybeRegisterVaultSurface(server, FULL_ENV, {
+    importRegister: async () => ({
+      registerVaultSurface: (s) => {
+        s.registerTool("vault_use");
+        s.registerTool("create_secret_capture");
+        return "live";
+      },
+    }),
+  });
   assert.equal(status, "live");
   assert.deepEqual(server.registered, ["vault_use", "create_secret_capture"]);
+  assert.deepEqual(server.removed, []); // nothing rolled back on success
 });
 
 test("scaffold — companion loads in fail-closed mode (env valid, transport not live)", async () => {
   const server = spyServer();
-  const status = await maybeRegisterVaultSurface(server, FULL_ENV, async () => ({
-    registerVaultSurface: (s) => {
-      s.registerTool("vault_use");
-      return "scaffold";
-    },
-  }));
+  const status = await maybeRegisterVaultSurface(server, FULL_ENV, {
+    importRegister: async () => ({
+      registerVaultSurface: (s) => {
+        s.registerTool("vault_use");
+        return "scaffold";
+      },
+    }),
+  });
   assert.equal(status, "scaffold");
   assert.deepEqual(server.registered, ["vault_use"]);
+  assert.deepEqual(server.removed, []);
 });

--- a/test/vault-surface.test.mjs
+++ b/test/vault-surface.test.mjs
@@ -195,6 +195,30 @@ test("timeout — a never-settling registration is bounded + rolled back", async
   assert.deepEqual(server.removed, ["vault_use"]);
 });
 
+test("timeout — a LATE registration after rollback self-removes (no stray live tool)", async () => {
+  const server = spyServer();
+  const status = await maybeRegisterVaultSurface(server, FULL_ENV, {
+    importRegister: async () => ({
+      registerVaultSurface: (s) => {
+        s.registerTool("vault_use");
+        // A slow coroutine that resumes AFTER the deadline and registers a late tool through the
+        // still-live recording proxy — the exact race the aborted flag closes.
+        setTimeout(() => {
+          s.registerTool("create_secret_capture");
+        }, 40);
+        return new Promise(() => {}); // never settles -> times out at 20ms -> rollback
+      },
+    }),
+    companionTimeoutMs: 20,
+  });
+  assert.equal(status, "timeout");
+  // Wait past the late registration (40ms) so we observe the post-rollback path.
+  await new Promise((r) => setTimeout(r, 80));
+  assert.deepEqual(server.registered, []); // nothing lingers on the live surface
+  assert.ok(server.removed.includes("vault_use")); // rolled back
+  assert.ok(server.removed.includes("create_secret_capture")); // late tool self-removed
+});
+
 // --- happy paths ---------------------------------------------------------------------------------
 
 test("live — companion folds its tools onto THIS server's surface", async () => {

--- a/test/vault-surface.test.mjs
+++ b/test/vault-surface.test.mjs
@@ -21,18 +21,21 @@ const FULL_ENV = {
  * rollback is observable. `registered` reflects the CURRENT surface; `removed` is the rollback log.
  */
 function spyServer() {
-  const registered = [];
-  const removed = [];
   return {
-    registered,
-    removed,
+    registered: [],
+    removed: [],
+    // Reads `this` ON PURPOSE: if the rollback proxy ever calls registerTool without binding `this`
+    // to the server (a bare `fn(...args)` call), `this.registered` is undefined and this THROWS —
+    // turning the proxy's call semantics into a real regression test (Copilot #3), instead of a
+    // closed-over array that would pass even with a dropped `this`.
     registerTool(name) {
-      registered.push(name);
+      this.registered.push(name);
+      const self = this;
       return {
         remove() {
-          removed.push(name);
-          const i = registered.indexOf(name);
-          if (i >= 0) registered.splice(i, 1);
+          self.removed.push(name);
+          const i = self.registered.indexOf(name);
+          if (i >= 0) self.registered.splice(i, 1);
         },
       };
     },
@@ -93,6 +96,18 @@ test("unavailable — full env but companion not installed: degrades to memory-o
     },
   });
   assert.equal(status, "unavailable");
+  assert.deepEqual(server.registered, []);
+});
+
+test("error — companion present but FAILS TO LOAD (not a not-found): degrades to memory-only", async () => {
+  const server = spyServer();
+  // A load/eval failure that is NOT module-not-found (e.g. a syntax or native-addon init error).
+  const status = await maybeRegisterVaultSurface(server, FULL_ENV, {
+    importRegister: async () => {
+      throw new SyntaxError("Unexpected token while evaluating @mnemoverse/mcp-vault");
+    },
+  });
+  assert.equal(status, "error", "a broken install is 'error', not misreported as 'unavailable'");
   assert.deepEqual(server.registered, []);
 });
 


### PR DESCRIPTION
## What

Increment 2 of the MCP facade consolidation: the open memory server can now optionally **fold** the closed vault companion's USE surface (`vault_use` + `create_secret_capture`) into its own tool surface, so a user connects ONE MCP server and gets memory + rooms + discovery + secrets.

Three commits: the fold seam plus two adversarial hardening waves. +532 lines, no deletions.

## Why

The facade direction is ONE memory-MCP for users, while the vault crypto stays in a separate closed package. This open MIT package must never carry the closed code or depend on it — so the fold is a best-effort, guarded runtime probe for an *optional* companion, not an import.

## Contents

- `src/vault-surface.ts` (+273) — the fold seam:
  - guarded dynamic import behind a `const` specifier (`@mnemoverse/mcp-vault/register`) that tsc never statically resolves; deliberately NO package.json dependency
  - env-gated on all three `MNEMOVERSE_VAULT_{SERVER_URL,TOKEN,PASSPHRASE}` (whitespace-only = absent)
  - statuses: `off` / `unavailable` / `timeout` / `live` / `scaffold` / `error`
  - fail-OPEN for the server (missing / broken / slow companion degrades to memory-only, never crashes or stalls startup), fail-CLOSED for the secret (no env, no USE surface)
  - timeout-bounded import AND registration; rollback proxy removes a partial registration; a LATE (post-timeout) registration self-removes via an aborted flag — the client never sees a half-folded surface
  - stderr-only diagnostics (stdout is the MCP stdio transport)
- `src/index.ts` (+5) — fold runs in `main()` before transport connect so any vault tools are present for the client's initial `tools/list`
- `test/vault-surface.test.mjs` (+253) — 14 `node:test` branches via an injected importer (off / partial-off / whitespace-off / unavailable / timeout / never-settling import and registration / async-reject / sync-throw rollback / late-registration self-removal / throwing getter / unexpected mode / live / scaffold); zero new dependencies
- `package.json` (+1) — new `test` script: `npm run build && node --test test/vault-surface.test.mjs`

## How verified

- 14-branch behavioral suite with the companion fully mocked — runs green with the closed package absent
- Re-verified end-to-end against the real local companion: a live fold registers both vault tools
- Branch sits exactly on current `main` (4d92129, #52 = Inc1 discovery tools); merge is a fast-forward, no conflicts
- Full-diff secret scan: only env var NAMES and test fixtures; the companion package name is intentionally public — this seam is the open half of the design

## Risks

- **Inert until the companion ships**: `@mnemoverse/mcp-vault` is not yet on npm; today every install takes the graceful `unavailable` path and the server stays memory-only. Merging early is safe but pointless.
- **Contract freeze**: `registerVaultSurface(server, env) -> "live" | "scaffold"` is co-owned by the vault-side counterpart PR, which is still under review — hence **draft**; merge after that contract freezes.
- **Trust boundary**: the companion loads into the same tool surface; the seam defends against a broken/slow companion, not a hostile one (documented in the module header — the companion is our own closed package).
- **CI gap**: no workflow currently runs `npm test` (PRs only run verify-configs / release-sync-check) — follow-up below.

## Follow-ups

- CI job running `npm test`
- Release/version decision (0.5.x vs 0.6.0) once the companion publishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)