### PR TITLE
fix(rooms): surface core creation guidance

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   ],
   "scripts": {
     "build": "tsc",
+    "test": "npm run build --silent && node --test test/*.test.mjs",
     "dev": "tsc --watch",
     "start": "node dist/index.js",
     "generate:configs": "node scripts/generate-configs.mjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { createRequire } from "node:module";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
+import { roomCreatedNextSteps } from "./room-guidance.js";
 
 // Version is read at runtime from package.json so there is exactly one place
 // to bump on each release. Works both from `dist/` during local dev and from
@@ -548,6 +549,7 @@ server.registerTool(
       room_id?: string;
       address?: string;
       name?: string;
+      next_steps?: string;
     }>("/memory/rooms", {
       method: "POST",
       body: JSON.stringify({ name, description }),
@@ -555,14 +557,12 @@ server.registerTool(
     const roomName = safeInline(r?.name ?? name);
     const address = safeInline(r?.address);
     const roomId = safeInline(r?.room_id);
+    const nextSteps = roomCreatedNextSteps(r?.next_steps, address, roomId);
     // If core returned no usable id (empty body / sanitized away), don't print
     // broken `domain=""` guidance — say so instead (Copilot).
     const text = address
       ? `Created shared room "${roomName}". Address: ${address}\n` +
-        `Use it now: pass domain="${address}" on memory_write / memory_read.\n` +
-        (roomId
-          ? `To add someone: call memory_invite_to_room with room_id="${roomId}".`
-          : "")
+        nextSteps
       : `Room "${roomName}" was created but the server did not return a usable address — ` +
         `retry, or check that your API key is set.`;
     return {

--- a/src/room-guidance.ts
+++ b/src/room-guidance.ts
@@ -1,0 +1,43 @@
+/**
+ * Preserve executable punctuation in server-authored guidance while removing
+ * control/bidi/zero-width characters that could reshape an MCP tool result.
+ */
+export function sanitizeRoomGuidance(
+  value: string | undefined | null,
+  cap = 2000,
+): string {
+  let out = "";
+  for (const ch of value ?? "") {
+    const code = ch.codePointAt(0) ?? 0;
+    const isControl = code <= 0x1f || (code >= 0x7f && code <= 0x9f);
+    const isBidi =
+      code === 0x061c ||
+      (code >= 0x200e && code <= 0x200f) ||
+      (code >= 0x202a && code <= 0x202e) ||
+      (code >= 0x2066 && code <= 0x2069);
+    const isZeroWidth =
+      code === 0x200b ||
+      code === 0x200c ||
+      code === 0x200d ||
+      code === 0x2060 ||
+      code === 0xfeff;
+    out += isControl || isBidi || isZeroWidth ? " " : ch;
+  }
+  return out.replace(/\s+/g, " ").trim().slice(0, cap);
+}
+
+/**
+ * Prefer Core's current API-aware contract, with a compatibility fallback for
+ * connector-before-Core rolling deploys.
+ */
+export function roomCreatedNextSteps(
+  coreNextSteps: string | undefined | null,
+  address: string,
+  roomId: string,
+): string {
+  return (
+    sanitizeRoomGuidance(coreNextSteps) ||
+    `Use it now: pass domain="${address}" on memory_write / memory_read. ` +
+      `To add someone: call memory_invite_to_room with room_id="${roomId}".`
+  );
+}

--- a/test/room-guidance.test.mjs
+++ b/test/room-guidance.test.mjs
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { roomCreatedNextSteps } from "../dist/room-guidance.js";
+
+test("surfaces core next_steps without losing executable JSON punctuation", () => {
+  const guidance = roomCreatedNextSteps(
+    'POST /api/v1/memory/rooms/join with JSON {"code":"<code>"}.\nUse your own key.',
+    "xroom:room_abc",
+    "room_abc",
+  );
+
+  assert.match(guidance, /JSON \{"code":"<code>"\}/);
+  assert.match(guidance, /Use your own key/);
+});
+
+test("neutralizes control characters in core next_steps", () => {
+  const guidance = roomCreatedNextSteps(
+    "Use the room.\u001b[2J\nInvite someone next.",
+    "xroom:room_abc",
+    "room_abc",
+  );
+
+  assert.equal(/[\u0000-\u001f\u007f-\u009f]/u.test(guidance), false);
+  assert.match(guidance, /Invite someone next/);
+});
+
+test("keeps a useful fallback during connector-before-core rolling deploys", () => {
+  const guidance = roomCreatedNextSteps(undefined, "xroom:room_abc", "room_abc");
+
+  assert.match(guidance, /domain="xroom:room_abc"/);
+  assert.match(guidance, /room_id="room_abc"/);
+});


### PR DESCRIPTION
## What

Room creation (`memory_create_room`) now surfaces Core's own `next_steps` guidance from the
`POST /memory/rooms` response instead of always printing connector-hard-coded text. Core is
gaining an authoritative `next_steps` field on the creation response
(mnemoverse/mnemoverse-core#373); this makes the connector ready to relay it.

## Why

- The existing `safeInline` sanitizer strips everything outside `[\w .@:+/-]` — fine for
  ids/addresses, but it would mangle server-authored guidance containing JSON snippets
  (quotes, braces). Server-authored prose needs its own sanitizer.
- Guidance text should have one source of truth. Core already ships `next_steps` on the
  *join* response on core main; this extends the same pattern to create, connector-side first.

## Contents

- **`src/room-guidance.ts`** (new):
  - `sanitizeRoomGuidance(value, cap=2000)` — removes control (C0/C1), bidi (U+061C,
    U+200E/F, U+202A–E, U+2066–69) and zero-width (U+200B–D, U+2060, U+FEFF) characters
    that could reshape an MCP tool result, collapses whitespace, caps at 2000 chars —
    while PRESERVING executable punctuation so JSON snippets survive intact.
  - `roomCreatedNextSteps(coreNextSteps, address, roomId)` — prefers Core's sanitized
    `next_steps`; falls back to the previous hard-coded guidance when Core doesn't send one.
- **`src/index.ts`** — the typed create-room response gains `next_steps?: string`; the
  result text is built via `roomCreatedNextSteps(...)`. `address`/`roomId` fed to the
  fallback are already `safeInline`d.
- **`test/room-guidance.test.mjs`** (new) + `npm test` script — 3 `node:test` cases:
  JSON punctuation preserved / control chars neutralized / fallback on missing field.

## Compatibility

Safe to merge and release BEFORE core#373: Core's create response carries no `next_steps`
today, so the fallback reproduces current behavior exactly. When core#373 lands, Core's
text takes over with no connector change.

Note for core#373 (currently open and in a CONFLICTING state, so it needs a rebase anyway):
its draft text still says programmatic invites "are coming" — this connector already ships
`memory_invite_to_room` / `memory_join_room` (v0.5.0, #50) and core main has
`POST /memory/rooms/join`. That text should be refreshed before #373 merges, or the
authoritative text will be staler than the fallback it replaces.

## How verified

- `npm test` (tsc build + `node --test`): 3/3 pass locally before push.
- Branch is exactly ahead-1 / behind-0 of `origin/main` (`4d92129`) — merges clean.
- CI: `verify-configs` triggers (package.json is in its path filter) and passes —
  package.json is an *input* to the config generator, not one of its outputs, and no
  generated artifact is touched.

## Risks / review notes

- Edge note: the old fallback printed the invite line only when `roomId` was non-empty; the
  new fallback always interpolates `room_id="..."`. If Core ever returned an address with an
  empty `room_id` (and no `next_steps`), the text would read `room_id=""`. Unreachable with
  core main's current create schema (always carries `room_id`), and the outer
  `address ? ... : error` guard still covers the fully-degenerate case. Happy to restore the
  inner guard in-review if preferred.
- `sanitizeRoomGuidance` collapses newlines to spaces — fine for single-line guidance;
  multi-line Core text would flatten (content preserved, layout not).
- `npm test` glob `test/*.test.mjs` expands natively in `node --test` on Node >=21; on
  Windows cmd with Node 18/20 the literal pattern won't match (engines allow >=18). Cosmetic.

## Cross-link

Twin change for the remote connector: `mnemoverse/mnemoverse-mcp-remote`, branch
`fix/surface-room-next-steps` (PR opening in the same rescue batch — URL will follow in a
comment). Both connectors prefer Core's guidance with a connector-before-Core fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)