### PR TITLE
release: v0.6.0 — rooms discovery + vault_list + teaching surface; manifest tells the truth (11 tools)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "mnemoverse-memory",
   "display_name": "Mnemoverse Memory",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Hosted memory for AI agents that learns and forgets — one key across Claude, Cursor & ChatGPT.",
   "long_description": "Mnemoverse gives your AI assistant long-term memory that persists across sessions and across tools. Store preferences, decisions, and lessons with memory_write; recall them by natural-language search with memory_read. The same memory is shared everywhere you use your Mnemoverse API key — Claude, Cursor, VS Code, and any MCP client. Requires a free API key from https://console.mnemoverse.com.",
   "author": {
@@ -65,6 +65,26 @@
     {
       "name": "memory_delete_domain",
       "description": "Permanently delete every memory in a domain (requires an explicit confirm)."
+    },
+    {
+      "name": "memory_create_room",
+      "description": "Create a shared memory room — a space your and other people's assistants can both read and write, across Claude/ChatGPT/editors."
+    },
+    {
+      "name": "memory_invite_to_room",
+      "description": "Mint a one-time invite for a room you own and get a ready-to-forward message for the person you want to add."
+    },
+    {
+      "name": "memory_join_room",
+      "description": "Join a shared memory room with an invite code; then pass the returned address as the domain on memory_write/memory_read."
+    },
+    {
+      "name": "memory_list_rooms",
+      "description": "List the shared rooms you own or have joined, with the address to use as the domain — re-find a room in a new session."
+    },
+    {
+      "name": "vault_list",
+      "description": "List the secrets in your Mnemoverse Vault by alias and purpose only — the secret value is never returned or shown."
     }
   ],
   "user_config": {

--- a/manifest.json
+++ b/manifest.json
@@ -68,7 +68,7 @@
     },
     {
       "name": "memory_create_room",
-      "description": "Create a shared memory room — a space your and other people's assistants can both read and write, across Claude/ChatGPT/editors."
+      "description": "Create a shared memory room — a space that your and other people's assistants can both read and write, across Claude/ChatGPT/editors."
     },
     {
       "name": "memory_invite_to_room",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mnemoverse/mcp-memory-server",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mnemoverse/mcp-memory-server",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mnemoverse/mcp-memory-server",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Hosted persistent memory for AI agents that learns which facts help and lets the rest fade — one key across Claude Code, Cursor, VS Code & ChatGPT, no infra to run",
   "type": "module",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -9,12 +9,12 @@
     "source": "github",
     "id": "1207193530"
   },
-  "version": "0.5.0",
+  "version": "0.6.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mnemoverse/mcp-memory-server",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/configs/source.json
+++ b/src/configs/source.json
@@ -7,10 +7,7 @@
   "websiteUrl": "https://mnemoverse.com",
   "type": "stdio",
   "command": "npx",
-  "args": [
-    "-y",
-    "@mnemoverse/mcp-memory-server@latest"
-  ],
+  "args": ["-y", "@mnemoverse/mcp-memory-server@latest"],
   "env": {
     "MNEMOVERSE_API_KEY": {
       "value": "mk_live_YOUR_KEY",
@@ -33,10 +30,7 @@
   },
   "$comment_remotes": "The HOSTED remote endpoint — one-click OAuth, no API key to paste. OAuth-protected, so NO headers block here: clients negotiate auth via the MCP OAuth flow (RFC 9728 discovery at /.well-known/oauth-protected-resource/mcp) at connect time. This is the registry counterpart of the npx/mk_live `package` path above; consumers pick whichever they prefer.",
   "remotes": [
-    {
-      "type": "streamable-http",
-      "url": "https://mcp.mnemoverse.com/mcp"
-    }
+    { "type": "streamable-http", "url": "https://mcp.mnemoverse.com/mcp" }
   ],
   "metadata": {
     "homepage": "https://mnemoverse.com/docs/api/mcp-server",
@@ -44,33 +38,18 @@
     "repositoryId": 1207193530,
     "license": "MIT",
     "author": "Mnemoverse",
-    "tags": [
-      "memory",
-      "persistent",
-      "ai-agents",
-      "cross-tool",
-      "oauth"
-    ]
+    "tags": ["memory", "persistent", "ai-agents", "cross-tool", "oauth"]
   },
   "mcpb": {
     "$comment": "Fields specific to the Claude Desktop Extension (MCPB) manifest.json. version + identity fields are derived from package.json + the source above; only MCPB-specific extras live here.",
     "name": "mnemoverse-memory",
-    "author": {
-      "name": "Mnemoverse",
-      "url": "https://github.com/mnemoverse"
-    },
+    "author": { "name": "Mnemoverse", "url": "https://github.com/mnemoverse" },
     "longDescription": "Mnemoverse gives your AI assistant long-term memory that persists across sessions and across tools. Store preferences, decisions, and lessons with memory_write; recall them by natural-language search with memory_read. The same memory is shared everywhere you use your Mnemoverse API key — Claude, Cursor, VS Code, and any MCP client. Requires a free API key from https://console.mnemoverse.com.",
-    "privacyPolicies": [
-      "https://mnemoverse.com/privacy.html"
-    ],
+    "privacyPolicies": ["https://mnemoverse.com/privacy.html"],
     "icon": "icon.png",
     "compatibility": {
       "claudeDesktop": ">=1.0.0",
-      "platforms": [
-        "darwin",
-        "win32",
-        "linux"
-      ],
+      "platforms": ["darwin", "win32", "linux"],
       "node": ">=18.0.0"
     },
     "userConfig": {
@@ -83,50 +62,17 @@
       }
     },
     "tools": [
-      {
-        "name": "memory_write",
-        "description": "Store a memory that should persist across sessions and tools — preferences, decisions, lessons, project facts."
-      },
-      {
-        "name": "memory_read",
-        "description": "Search your long-term memory by natural-language query before answering or starting a task."
-      },
-      {
-        "name": "memory_feedback",
-        "description": "Report whether a recalled memory was helpful so good memories surface faster next time."
-      },
-      {
-        "name": "memory_stats",
-        "description": "Show how many memories are stored, which domains exist, and average quality scores."
-      },
-      {
-        "name": "memory_delete",
-        "description": "Permanently delete a single memory by its atom_id."
-      },
-      {
-        "name": "memory_delete_domain",
-        "description": "Permanently delete every memory in a domain (requires an explicit confirm)."
-      },
-      {
-        "name": "memory_create_room",
-        "description": "Create a shared memory room — a space your and other people's assistants can both read and write, across Claude/ChatGPT/editors."
-      },
-      {
-        "name": "memory_invite_to_room",
-        "description": "Mint a one-time invite for a room you own and get a ready-to-forward message for the person you want to add."
-      },
-      {
-        "name": "memory_join_room",
-        "description": "Join a shared memory room with an invite code; then pass the returned address as the domain on memory_write/memory_read."
-      },
-      {
-        "name": "memory_list_rooms",
-        "description": "List the shared rooms you own or have joined, with the address to use as the domain — re-find a room in a new session."
-      },
-      {
-        "name": "vault_list",
-        "description": "List the secrets in your Mnemoverse Vault by alias and purpose only — the secret value is never returned or shown."
-      }
+      { "name": "memory_write", "description": "Store a memory that should persist across sessions and tools — preferences, decisions, lessons, project facts." },
+      { "name": "memory_read", "description": "Search your long-term memory by natural-language query before answering or starting a task." },
+      { "name": "memory_feedback", "description": "Report whether a recalled memory was helpful so good memories surface faster next time." },
+      { "name": "memory_stats", "description": "Show how many memories are stored, which domains exist, and average quality scores." },
+      { "name": "memory_delete", "description": "Permanently delete a single memory by its atom_id." },
+      { "name": "memory_delete_domain", "description": "Permanently delete every memory in a domain (requires an explicit confirm)." },
+      { "name": "memory_create_room", "description": "Create a shared memory room — a space your and other people's assistants can both read and write, across Claude/ChatGPT/editors." },
+      { "name": "memory_invite_to_room", "description": "Mint a one-time invite for a room you own and get a ready-to-forward message for the person you want to add." },
+      { "name": "memory_join_room", "description": "Join a shared memory room with an invite code; then pass the returned address as the domain on memory_write/memory_read." },
+      { "name": "memory_list_rooms", "description": "List the shared rooms you own or have joined, with the address to use as the domain — re-find a room in a new session." },
+      { "name": "vault_list", "description": "List the secrets in your Mnemoverse Vault by alias and purpose only — the secret value is never returned or shown." }
     ]
   }
 }

--- a/src/configs/source.json
+++ b/src/configs/source.json
@@ -7,7 +7,10 @@
   "websiteUrl": "https://mnemoverse.com",
   "type": "stdio",
   "command": "npx",
-  "args": ["-y", "@mnemoverse/mcp-memory-server@latest"],
+  "args": [
+    "-y",
+    "@mnemoverse/mcp-memory-server@latest"
+  ],
   "env": {
     "MNEMOVERSE_API_KEY": {
       "value": "mk_live_YOUR_KEY",
@@ -30,7 +33,10 @@
   },
   "$comment_remotes": "The HOSTED remote endpoint — one-click OAuth, no API key to paste. OAuth-protected, so NO headers block here: clients negotiate auth via the MCP OAuth flow (RFC 9728 discovery at /.well-known/oauth-protected-resource/mcp) at connect time. This is the registry counterpart of the npx/mk_live `package` path above; consumers pick whichever they prefer.",
   "remotes": [
-    { "type": "streamable-http", "url": "https://mcp.mnemoverse.com/mcp" }
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.mnemoverse.com/mcp"
+    }
   ],
   "metadata": {
     "homepage": "https://mnemoverse.com/docs/api/mcp-server",
@@ -38,18 +44,33 @@
     "repositoryId": 1207193530,
     "license": "MIT",
     "author": "Mnemoverse",
-    "tags": ["memory", "persistent", "ai-agents", "cross-tool", "oauth"]
+    "tags": [
+      "memory",
+      "persistent",
+      "ai-agents",
+      "cross-tool",
+      "oauth"
+    ]
   },
   "mcpb": {
     "$comment": "Fields specific to the Claude Desktop Extension (MCPB) manifest.json. version + identity fields are derived from package.json + the source above; only MCPB-specific extras live here.",
     "name": "mnemoverse-memory",
-    "author": { "name": "Mnemoverse", "url": "https://github.com/mnemoverse" },
+    "author": {
+      "name": "Mnemoverse",
+      "url": "https://github.com/mnemoverse"
+    },
     "longDescription": "Mnemoverse gives your AI assistant long-term memory that persists across sessions and across tools. Store preferences, decisions, and lessons with memory_write; recall them by natural-language search with memory_read. The same memory is shared everywhere you use your Mnemoverse API key — Claude, Cursor, VS Code, and any MCP client. Requires a free API key from https://console.mnemoverse.com.",
-    "privacyPolicies": ["https://mnemoverse.com/privacy.html"],
+    "privacyPolicies": [
+      "https://mnemoverse.com/privacy.html"
+    ],
     "icon": "icon.png",
     "compatibility": {
       "claudeDesktop": ">=1.0.0",
-      "platforms": ["darwin", "win32", "linux"],
+      "platforms": [
+        "darwin",
+        "win32",
+        "linux"
+      ],
       "node": ">=18.0.0"
     },
     "userConfig": {
@@ -62,12 +83,50 @@
       }
     },
     "tools": [
-      { "name": "memory_write", "description": "Store a memory that should persist across sessions and tools — preferences, decisions, lessons, project facts." },
-      { "name": "memory_read", "description": "Search your long-term memory by natural-language query before answering or starting a task." },
-      { "name": "memory_feedback", "description": "Report whether a recalled memory was helpful so good memories surface faster next time." },
-      { "name": "memory_stats", "description": "Show how many memories are stored, which domains exist, and average quality scores." },
-      { "name": "memory_delete", "description": "Permanently delete a single memory by its atom_id." },
-      { "name": "memory_delete_domain", "description": "Permanently delete every memory in a domain (requires an explicit confirm)." }
+      {
+        "name": "memory_write",
+        "description": "Store a memory that should persist across sessions and tools — preferences, decisions, lessons, project facts."
+      },
+      {
+        "name": "memory_read",
+        "description": "Search your long-term memory by natural-language query before answering or starting a task."
+      },
+      {
+        "name": "memory_feedback",
+        "description": "Report whether a recalled memory was helpful so good memories surface faster next time."
+      },
+      {
+        "name": "memory_stats",
+        "description": "Show how many memories are stored, which domains exist, and average quality scores."
+      },
+      {
+        "name": "memory_delete",
+        "description": "Permanently delete a single memory by its atom_id."
+      },
+      {
+        "name": "memory_delete_domain",
+        "description": "Permanently delete every memory in a domain (requires an explicit confirm)."
+      },
+      {
+        "name": "memory_create_room",
+        "description": "Create a shared memory room — a space your and other people's assistants can both read and write, across Claude/ChatGPT/editors."
+      },
+      {
+        "name": "memory_invite_to_room",
+        "description": "Mint a one-time invite for a room you own and get a ready-to-forward message for the person you want to add."
+      },
+      {
+        "name": "memory_join_room",
+        "description": "Join a shared memory room with an invite code; then pass the returned address as the domain on memory_write/memory_read."
+      },
+      {
+        "name": "memory_list_rooms",
+        "description": "List the shared rooms you own or have joined, with the address to use as the domain — re-find a room in a new session."
+      },
+      {
+        "name": "vault_list",
+        "description": "List the secrets in your Mnemoverse Vault by alias and purpose only — the secret value is never returned or shown."
+      }
     ]
   }
 }

--- a/src/configs/source.json
+++ b/src/configs/source.json
@@ -68,7 +68,7 @@
       { "name": "memory_stats", "description": "Show how many memories are stored, which domains exist, and average quality scores." },
       { "name": "memory_delete", "description": "Permanently delete a single memory by its atom_id." },
       { "name": "memory_delete_domain", "description": "Permanently delete every memory in a domain (requires an explicit confirm)." },
-      { "name": "memory_create_room", "description": "Create a shared memory room — a space your and other people's assistants can both read and write, across Claude/ChatGPT/editors." },
+      { "name": "memory_create_room", "description": "Create a shared memory room — a space that your and other people's assistants can both read and write, across Claude/ChatGPT/editors." },
       { "name": "memory_invite_to_room", "description": "Mint a one-time invite for a room you own and get a ready-to-forward message for the person you want to add." },
       { "name": "memory_join_room", "description": "Join a shared memory room with an invite code; then pass the returned address as the domain on memory_write/memory_read." },
       { "name": "memory_list_rooms", "description": "List the shared rooms you own or have joined, with the address to use as the domain — re-find a room in a new session." },


### PR DESCRIPTION
## What

Version bump **0.5.0 → 0.6.0** covering the two features sitting unreleased on main:
- **#52** — `memory_list_rooms` + `vault_list` (self-find rooms & secrets)
- **#57** — the teaching surface: server instructions (there were **none**), active agent-memory polarity, first-contact greeting, and the repo's first test harness

Minor, not patch: both are new features (new tools in `tools/list`, new server behavior), and this repo's own history uses patch numbers for fixes only (v0.4.0→0.4.1→0.4.2).

**Plus an honesty fix in the package card:** `mcpb.tools` declared **6** tools while the server registers **11** — the 4 rooms tools and `vault_list` were invisible to every registry that reads the manifest. Now complete, with one-line summaries faithful to the real descriptions in `src/index.ts`.

## What merge does / does not do

Merge only lands the bump on main. **Publish fires on the `v0.6.0` tag push** (release.yml: version-match check → build → verify:configs → npm publish → MCP-registry publish). I will tag after this merges, per the agreed release go.

## Gate
`generate:configs` — 19 artifacts in sync · `verify:configs` clean · 17 tests green · `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)