### PR TITLE
feat(recent): pass until and exclude_author through memory_list_recent

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -371,6 +371,19 @@ server.registerTool(
         .describe(
           "Only entries created at/after this ISO-8601 instant (naive = UTC) — your novelty watermark.",
         ),
+      until: z
+        .string()
+        .optional()
+        .describe(
+          "Only entries created at/before this ISO-8601 instant (inclusive). Pair with `since` to read a closed window — 'what happened on Monday' — instead of paging back from now.",
+        ),
+      exclude_author: z
+        .string()
+        .max(200)
+        .optional()
+        .describe(
+          "Drop entries written by this author PRINCIPAL — the 'everyone but me' read in a shared room. Same parameter as on memory_read.",
+        ),
       limit: z
         .number()
         .int()
@@ -394,7 +407,7 @@ server.registerTool(
       openWorldHint: true,
     },
   },
-  async ({ domain, since, limit, cursor }) => {
+  async ({ domain, since, until, exclude_author, limit, cursor }) => {
     let r: { items?: RecentItem[]; next_cursor?: string | null };
     try {
       r = await apiFetch<{ items?: RecentItem[]; next_cursor?: string | null }>(
@@ -404,6 +417,8 @@ server.registerTool(
           body: JSON.stringify({
             domain: domain || undefined,
             since: since || undefined,
+            until: until || undefined,
+            exclude_author: exclude_author || undefined,
             limit: limit || 20,
             cursor: cursor || undefined,
           }),

--- a/test/tool-wiring.test.ts
+++ b/test/tool-wiring.test.ts
@@ -26,10 +26,34 @@ function toolBlock(name: string): string {
   return end === -1 ? source.slice(start) : source.slice(start, end);
 }
 
-/** Field names declared in the tool's `inputSchema: { … }`. */
+/**
+ * Field names declared in the tool's `inputSchema: { … }`.
+ *
+ * Indentation-agnostic and accepts `name: z` broken across lines as well as
+ * `name: z.string()` on one. An earlier version demanded exactly six leading
+ * spaces and `: z` at end of line, which meant a reformat or a one-line field
+ * would quietly shrink the set this test checks — and a contract test that
+ * silently checks less is worse than none, because it still reports green.
+ */
 function declaredParams(block: string): string[] {
-  const schema = block.slice(block.indexOf("inputSchema: {"));
-  return [...schema.matchAll(/^\s{6}([a-z_]+): z$/gm)].map((m) => m[1]);
+  const at = block.indexOf("inputSchema: {");
+  expect(at, "inputSchema not found — the extraction pattern has drifted").toBeGreaterThan(-1);
+  const schema = braceBody(block, at);
+  const names = [...schema.matchAll(/^\s*([a-z_]+)\s*:\s*z\b/gm)].map((m) => m[1]);
+  expect(names.length, "no parameters extracted — pattern drift, not an empty schema").toBeGreaterThan(0);
+  return names;
+}
+
+/** The `{ … }` object literal starting at or after `from`, brace-matched. */
+function braceBody(block: string, from: number): string {
+  const open = block.indexOf("{", from);
+  expect(open, "no object literal here — the extraction pattern has drifted").toBeGreaterThan(-1);
+  let depth = 0;
+  for (let i = open; i < block.length; i++) {
+    if (block[i] === "{") depth++;
+    else if (block[i] === "}" && --depth === 0) return block.slice(open, i);
+  }
+  throw new Error("unbalanced braces while slicing the object literal");
 }
 
 /**
@@ -40,21 +64,17 @@ function declaredParams(block: string): string[] {
  * to keep the body byte-identical for callers who pass no filters.
  */
 function forwardedParams(block: string): string[] {
+  // Assert the anchor was found rather than letting indexOf return -1 and
+  // brace-match some unrelated object earlier in the block: that path produces
+  // a PASS from the wrong text, which is the one outcome this file must not
+  // have. If the handler stops building the body inline (`JSON.stringify(body)`),
+  // this fails loudly and someone updates the pattern deliberately.
   const open = block.indexOf("body: JSON.stringify({");
-  const from = block.indexOf("{", open + "body: JSON.stringify(".length);
+  expect(open, "body: JSON.stringify({ … }) not found — the handler shape changed").toBeGreaterThan(-1);
   // Brace-match rather than searching for a closing token: a conditional
   // spread ends in `: {}),`, which contains the obvious `}),` sentinel and
   // would truncate the object at its first filter.
-  let depth = 0;
-  let to = from;
-  for (let i = from; i < block.length; i++) {
-    if (block[i] === "{") depth++;
-    else if (block[i] === "}" && --depth === 0) {
-      to = i;
-      break;
-    }
-  }
-  const literal = block.slice(from, to);
+  const literal = braceBody(block, open + "body: JSON.stringify(".length);
   const plain = [...literal.matchAll(/^\s+([a-z_]+)[:,]/gm)].map((m) => m[1]);
   const spread = [...literal.matchAll(/\.\.\.\(\s*([a-z_]+)\s*\?/g)].map((m) => m[1]);
   return [...new Set([...plain, ...spread])];

--- a/test/tool-wiring.test.ts
+++ b/test/tool-wiring.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tool-wiring contract — every parameter a tool ADVERTISES must actually reach
+ * the request body.
+ *
+ * This is the failure mode that hurts, because it is silent: a tool declares
+ * `until` in its input schema, a model reads the schema and passes `until`, the
+ * handler destructures something else, and the server — which ignores unknown
+ * fields rather than rejecting them — returns an unfiltered answer. Nothing
+ * errors anywhere. The caller just gets the wrong memories and has no way to
+ * tell.
+ *
+ * Reads src/index.ts as text rather than importing it: importing starts a stdio
+ * transport. Same approach as teaching-surface.test.ts.
+ */
+
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync(new URL("../src/index.ts", import.meta.url), "utf8");
+
+/** Slice one `server.registerTool("<name>", …)` call out of the source. */
+function toolBlock(name: string): string {
+  const start = source.indexOf(`"${name}"`);
+  expect(start, `${name} is not registered`).toBeGreaterThan(-1);
+  const end = source.indexOf("server.registerTool(", start);
+  return end === -1 ? source.slice(start) : source.slice(start, end);
+}
+
+/** Field names declared in the tool's `inputSchema: { … }`. */
+function declaredParams(block: string): string[] {
+  const schema = block.slice(block.indexOf("inputSchema: {"));
+  return [...schema.matchAll(/^\s{6}([a-z_]+): z$/gm)].map((m) => m[1]);
+}
+
+/**
+ * Keys the handler puts into the JSON request body.
+ *
+ * Two spellings count, because both are in use: a plain `name: value` entry,
+ * and the conditional spread `...(name ? { name } : {})` that memory_read uses
+ * to keep the body byte-identical for callers who pass no filters.
+ */
+function forwardedParams(block: string): string[] {
+  const open = block.indexOf("body: JSON.stringify({");
+  const from = block.indexOf("{", open + "body: JSON.stringify(".length);
+  // Brace-match rather than searching for a closing token: a conditional
+  // spread ends in `: {}),`, which contains the obvious `}),` sentinel and
+  // would truncate the object at its first filter.
+  let depth = 0;
+  let to = from;
+  for (let i = from; i < block.length; i++) {
+    if (block[i] === "{") depth++;
+    else if (block[i] === "}" && --depth === 0) {
+      to = i;
+      break;
+    }
+  }
+  const literal = block.slice(from, to);
+  const plain = [...literal.matchAll(/^\s+([a-z_]+)[:,]/gm)].map((m) => m[1]);
+  const spread = [...literal.matchAll(/\.\.\.\(\s*([a-z_]+)\s*\?/g)].map((m) => m[1]);
+  return [...new Set([...plain, ...spread])];
+}
+
+describe("memory_list_recent", () => {
+  const block = toolBlock("memory_list_recent");
+
+  it("advertises the filters the feed supports", () => {
+    expect(declaredParams(block).sort()).toEqual([
+      "cursor",
+      "domain",
+      "exclude_author",
+      "limit",
+      "since",
+      "until",
+    ]);
+  });
+
+  it("forwards every advertised parameter — none may be declared and dropped", () => {
+    // Subset, not equality: a handler may also send constants the caller never
+    // supplies. What must never happen is the other direction.
+    const forwarded = forwardedParams(block);
+    for (const p of declaredParams(block)) {
+      expect(forwarded, `${p} is advertised but never sent`).toContain(p);
+    }
+  });
+
+  it("destructures each one from the handler argument", () => {
+    const handlerArgs = block.slice(block.indexOf("async ({"), block.indexOf("}) =>"));
+    for (const p of declaredParams(block)) {
+      expect(handlerArgs, `${p} is declared but never destructured`).toContain(p);
+    }
+  });
+});
+
+describe("memory_read", () => {
+  const block = toolBlock("memory_read");
+
+  it("forwards every advertised parameter", () => {
+    // memory_read carries the same temporal filters; the same silent-drop
+    // failure applies to it, so it is pinned by the same rule.
+    const declared = declaredParams(block);
+    expect(declared).toContain("since");
+    expect(declared).toContain("until");
+    expect(declared).toContain("exclude_author");
+    const forwarded = forwardedParams(block);
+    for (const p of declared) {
+      expect(forwarded, `${p} is advertised but never sent`).toContain(p);
+    }
+  });
+});


### PR DESCRIPTION
Part of the release wave that brings every client surface level with the API.

## What it adds

`memory_list_recent` could bound the feed from below (`since`) but not from above, and could not skip an author. Two parameters close both gaps:

- **`until`** — with `since`, a closed window. "What happened on Monday" instead of paging back from now until you recognise something.
- **`exclude_author`** — the "everyone but me" read in a shared room, which is the read that matters there: an agent catching up wants what the *others* wrote.

Both already exist on `memory_read`; this makes the feed and the search take the same filters, so a caller does not have to learn two vocabularies.

## The test

The change is six lines. The test is the substantial part, because of *how* this breaks.

A tool declares a parameter; a model reads the schema and passes it; the handler destructures something else; the server ignores unknown fields rather than rejecting them, and answers unfiltered. Nothing errors anywhere — the caller simply gets the wrong memories.

`test/tool-wiring.test.ts` asserts the invariant: every field declared in a tool's `inputSchema` appears in the request body it builds and is destructured by the handler. Subset rather than equality, since a handler may also send constants.

I verified it fails when it should: deleting `until` from the recent body turns it red with `until is advertised but never sent`; restoring it turns it green. Two of my own parser bugs surfaced while writing it — the conditional-spread form `memory_read` uses, and a `}),` sentinel that a `: {}),` line matches early. Both were the test lying rather than the code.

## 🔴 Release order — do not publish before the engine

These parameters require **core #437** merged and deployed.

Checked against the running production commit rather than assumed: `RecentRequestSchema` has no `extra="forbid"`, so today's server **ignores unknown fields instead of rejecting them**. Publishing this to npm first would ship a tool that advertises a filter, accepts it, and returns unfiltered results — silently. That is worse than the missing feature.

## Verification

- `npm test` — 31 passed (27 existing + 4 new)
- `npm run build` — clean
- Wired identically in `mnemoverse-mcp-remote` (hosted) and `mnemoverse-sdk-python` (PR #4), so the three surfaces stay in step
