### PR TITLE
release: 0.8.0 — until and exclude_author on the recent feed

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "mnemoverse-memory",
   "display_name": "Mnemoverse Memory",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Hosted memory for AI agents that learns and forgets — one key across Claude, Cursor & ChatGPT.",
   "long_description": "Mnemoverse gives your AI assistant long-term memory that persists across sessions and across tools. Store preferences, decisions, and lessons with memory_write; recall them by natural-language search with memory_read. The same memory is shared everywhere you use your Mnemoverse API key — Claude, Cursor, VS Code, and any MCP client. Requires a free API key from https://console.mnemoverse.com.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mnemoverse/mcp-memory-server",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mnemoverse/mcp-memory-server",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mnemoverse/mcp-memory-server",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Hosted persistent memory for AI agents that learns which facts help and lets the rest fade — one key across Claude Code, Cursor, VS Code & ChatGPT, no infra to run",
   "type": "module",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -9,12 +9,12 @@
     "source": "github",
     "id": "1207193530"
   },
-  "version": "0.7.0",
+  "version": "0.8.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mnemoverse/mcp-memory-server",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Version bump only. Merge this, then `git tag v0.8.0 && git push origin v0.8.0` fires the release workflow (npm publish → MCP registry → GitHub release).

## Why 0.8.0 and not 0.7.1

One unreleased commit (#61), and it **adds** two parameters to the `memory_list_recent` tool schema. Added backwards-compatible functionality is a MINOR bump under semver — 0.7.1 would say "bug fix" about a release where the tool contract grew, and the version number is the only thing most people read before deciding whether to look at the changelog.

## What ships

- **`until`** — bounds the feed from above. With `since`, a closed window: *"what happened on Monday"* instead of paging back from now until something looks familiar.
- **`exclude_author`** — skips one author principal, the *"only what others wrote"* read in a shared room.

Both mirror parameters that already exist on `memory_read`, so the feed and the search now take one vocabulary rather than two.

## Backing endpoint is live, and this was checked rather than assumed

Core #437 merged as `8830d45` and is deployed on `core.mnemoverse.com`. Verified against production before cutting this release:

| Behaviour | Result |
| --- | --- |
| `until` bounds from above | ✅ |
| inclusive at the exact instant | ✅ |
| naive instant read as UTC | ✅ identical rows to the aware spelling |
| `exclude_author` drops the named principal | ✅ |
| entries with no author survive it | ✅ (`IS DISTINCT FROM`, not `!=`) |
| pages stay full, cursor present under filters | ✅ |

That last pair matters: a plain inequality would have silently dropped every unauthored entry, and post-filtering would have returned short pages with a cursor that skips.

## Gates

- `npm test` — 31 passed
- `npm run verify:configs` — all 19 artifacts in sync
- `npm run build` — clean
- `npm pack --dry-run` — 15 files, 34.5 kB

## Note on release coordination

This publishes the npm package. The hosted connector at `mcp.mnemoverse.com` already serves both parameters (deployed with #32) but carries **no version of its own**, so there is currently no way to look at the two surfaces and tell whether they agree. Raised separately — it is a real gap, not something to solve inside a version-bump PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application, package, and server version to **0.8.0**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->