### PR TITLE
docs(readme): point the directory multiplier at the library, fix a 404 mirrored in 11 listings

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,10 +237,24 @@ The same API key works across all tools. Write a memory in Claude Code — read 
 
 ## Links
 
+**Setup and reference**
+
 - [Documentation](https://mnemoverse.com/docs/api/mcp-server)
+- [Cursor](https://mnemoverse.com/docs/api/cursor) · [VS Code](https://mnemoverse.com/docs/api/vs-code) · [Claude Code](https://mnemoverse.com/docs/api/claude) · [ChatGPT](https://mnemoverse.com/docs/api/chatgpt)
 - [Python SDK](https://mnemoverse.com/docs/api/python-sdk)
 - [API Reference](https://mnemoverse.com/docs/api/reference)
 - [Console (get API key)](https://console.mnemoverse.com)
+
+**Background reading**
+
+- [Memory MCP servers compared](https://mnemoverse.com/docs/library/memory-mcp-servers-compared) — thirteen shipping options, with pricing and registry presence
+- [How to choose a memory MCP server](https://mnemoverse.com/docs/library/memory-mcp) — the five questions that narrow the field
+- [What AI agent memory is](https://mnemoverse.com/docs/library/ai-agent-memory) — the category explained
+- [Is this a vector database?](https://mnemoverse.com/docs/library/not-a-vector-database) — what makes a memory layer different
+- [Shared memory for multi-agent systems](https://mnemoverse.com/docs/library/shared-memory-for-multi-agent-systems) — how Rooms work and when to use them
+
+**Project**
+
 - [GitHub](https://github.com/mnemoverse/mcp-memory-server)
 - [Releases](https://github.com/mnemoverse/mcp-memory-server/releases)
 - [MCP Registry entry](https://registry.modelcontextprotocol.io/v0/servers?search=mnemoverse)
@@ -252,7 +266,7 @@ This server sends only what you explicitly choose to store or search to the Mnem
 
 | | |
 |---|---|
-| **Privacy Policy** | <https://mnemoverse.com/privacy.html> |
+| **Privacy Policy** | <https://mnemoverse.com/privacy> |
 | **Data sent** | the `content` / `concepts` / `domain` you pass to `memory_write`; the `query` you pass to `memory_read` |
 | **Retention & deletion** | delete one memory with `memory_delete`, or an entire namespace with `memory_delete_domain` |
 | **Contact** | hello@mnemoverse.com |


### PR DESCRIPTION
Аудит внешних ссылок вскрыл, что этот README — единственный множитель, который у нас есть: его перерисовывают около восьми каталогов (Glama, PulseMCP, mcpmarket, claudemarketplaces, mcpservers.org, VS Code Marketplace, Open VSX, npm, PyPI). И он вёл ровно на три страницы, все из `/docs/api/`.

Следствие: на `/docs/library/` **не было ни одной внешней ссылки во всём интернете**. Это часть причины, по которой статьи библиотеки висят непрокрауленными — у них нет ни внутренних контекстных голосов, ни внешних.

## Что изменено

- **Блок Links перегруппирован**: setup and reference / background reading / project. Добавлены пять статей библиотеки и per-editor страницы (Cursor, VS Code, Claude Code, ChatGPT), которых не существовало, когда список писался.
- **Починена битая ссылка**: Privacy Policy вела на `/privacy.html`, которая отдаёт 307. Этот битый адрес уже размножен примерно в одиннадцати внешних листингах — правка в источнике исправит их все при следующем перерендере.

Все целевые URL проверены на 200 перед коммитом.

Ссылки в каталогах в основном nofollow, и это нормально: цель здесь не вес, а краулинг-сигнал и то, что видят LLM-скраперы, которые эти каталоги читают.