### PR TITLE
fix(server.json): drop the phantom self-host claim from the registry env description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,16 @@ No tool changes shape and no request changes a byte — the wire format is
 pinned byte-for-byte by `test/requests.test.ts`, and all 338 tests pass
 unchanged against SDK 1.30.0. The published file set is untouched.
 
+### Fixed
+
+- `server.json` / `src/configs/source.json`: the `MNEMOVERSE_API_URL` env
+  description promised a self-host path ("unless you self-host the core
+  engine") that does not exist — it had shipped to the official MCP registry
+  in every version since 0.3.8, including 0.8.1, whose registry manifest
+  still carries it. The description now says what the override is for:
+  testing against a non-production environment. Registry text corrects
+  itself on the next `mcp-publisher` run — description prose only, no shape
+  change. (#72)
 ## [0.8.1] — 2026-08-09
 
 An honesty pass. Every result line looks different afterwards, and nine

--- a/server.json
+++ b/server.json
@@ -29,7 +29,7 @@
         },
         {
           "name": "MNEMOVERSE_API_URL",
-          "description": "Mnemoverse API base URL. Leave as the default unless you self-host the core engine.",
+          "description": "Mnemoverse API base URL. Leave as the default; override only for testing against a non-production environment.",
           "isRequired": false,
           "format": "string",
           "isSecret": false,

--- a/src/configs/source.json
+++ b/src/configs/source.json
@@ -22,7 +22,7 @@
     "MNEMOVERSE_API_URL": {
       "value": "https://core.mnemoverse.com/api/v1",
       "placeholder": "https://core.mnemoverse.com/api/v1",
-      "description": "Mnemoverse API base URL. Leave as the default unless you self-host the core engine.",
+      "description": "Mnemoverse API base URL. Leave as the default; override only for testing against a non-production environment.",
       "required": false,
       "secret": false
     }


### PR DESCRIPTION
One line, two copies (`src/configs/source.json` is the SSOT, `server.json` the generated artifact; `generate-configs.mjs` re-run confirms sync — 0 written, 19 unchanged).

## What was wrong

`MNEMOVERSE_API_URL`'s description read **"Leave as the default unless you self-host the core engine"** — and has shipped to the official MCP registry in every version since 0.3.8. There is no self-host path for the core engine. Our own docs say so plainly (the MCP comparison article states "cloud-only — there is no self-host path" as a disclosed weakness), so the registry manifest and the docs contradicted each other, and round-3 verification of docs #331 flagged that a competitor can quote our manifest against our article.

## What it says now

"Leave as the default; override only for testing against a non-production environment" — which is what the override is actually for.

## What this PR does NOT do

It does not publish to the registry. The fixed description reaches registry.modelcontextprotocol.io only on the next `mcp-publisher` run — a public-surface action that stays behind its own explicit gate. Until then, live registry versions ≤0.8.0 still carry the old wording.