### PR TITLE
fix(deps): clear all 32 dependabot alerts — SDK floor to ^1.30.0, transitive deps float to patched lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,39 @@ This file starts at 0.8.1. Entries for earlier versions are reconstructed from
 the release commits and are deliberately terse — for anything before 0.8.1 the
 git history and the GitHub releases are the record.
 
+## [Unreleased]
+
+Dependency security pass: clears all 32 open Dependabot alerts (7 high, 22
+medium, 3 low) — 22 against `hono`, 5 `fast-uri`, 2 `ip-address`, and one each
+for `@hono/node-server`, `qs`, `body-parser`. Every one is a transitive
+dependency of `@modelcontextprotocol/sdk`; this package's two direct runtime
+dependencies are the SDK and zod, and neither was itself vulnerable.
+
+The one deliberate move is raising the SDK floor from `^1.12.1` to `^1.30.0`.
+1.30.0 is a minor release with no breaking changes, and it is specifically the
+release that widens the SDK's `@hono/node-server` range to admit 2.x — the
+patched line for the path-traversal alert, unreachable under 1.29.0's
+`^1.19.9` pin. Everything else floats up in the lockfile within ranges the SDK
+already declared: `hono` 4.12.12 → 4.13.1, `@hono/node-server` 1.19.13 →
+2.1.0, `fast-uri` 3.1.0 → 3.1.5, `ip-address` 10.1.0 → 10.4.0 (via
+`express-rate-limit` 8.3.2 → 8.6.2), `qs` 6.15.1 → 6.15.3, `body-parser` 2.2.2
+→ 2.3.0. No `overrides` were needed. The dev-only `nanoid` advisory
+(GHSA-2v37-7h3g-55p8, vitest → vite → postcss chain, not among the 32) floated
+to 3.3.18 in the same pass; `npm audit` now reports zero vulnerabilities.
+
+Stated honestly: most of these alerts never reached running code. This is a
+stdio server — the hono/express stack inside the SDK belongs to its HTTP
+transports and OAuth handlers, which `server/mcp.js` and `server/stdio.js`
+never import, so the vulnerable code was shipped but not loaded. The exception
+is `fast-uri`, which IS loaded at runtime through the SDK's ajv schema
+validator — though it only ever sees local stdio protocol messages, never
+network input. The bump closes all of it regardless: unreachable today is one
+transport change away from reachable.
+
+No tool changes shape and no request changes a byte — the wire format is
+pinned byte-for-byte by `test/requests.test.ts`, and all 338 tests pass
+unchanged against SDK 1.30.0. The published file set is untouched.
+
 ## [0.8.1] — 2026-08-09
 
 An honesty pass. Every result line looks different afterwards, and nine

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.12.1",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "zod": "^4.3.6"
       },
       "bin": {
@@ -59,12 +59,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.13",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
-      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -78,12 +78,12 @@
       "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -651,21 +651,34 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -891,9 +904,9 @@
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -1002,12 +1015,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
-      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -1026,9 +1040,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -1184,9 +1198,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -1196,9 +1210,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -1247,9 +1261,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -1642,9 +1656,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -1832,12 +1846,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -2008,14 +2023,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -2181,17 +2196,34 @@
       "optional": true
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "homepage": "https://mnemoverse.com/docs/api/mcp-server",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.12.1",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {


### PR DESCRIPTION
Clears **all 32 open Dependabot alerts** (7 high, 22 medium, 3 low). Every alerted package is a transitive dependency of `@modelcontextprotocol/sdk` — this package's only direct runtime deps are the SDK and zod, and neither was itself vulnerable.

## The move

One deliberate change in `package.json`: SDK floor `^1.12.1` → `^1.30.0`. SDK **1.30.0 is a minor release with no breaking changes** ([release notes](https://github.com/modelcontextprotocol/typescript-sdk/releases/tag/1.30.0)), and it is specifically the release that widens the SDK's `@hono/node-server` range from `^1.19.9` to `^1.19.9 || ^2.0.5` — without it, alert #22 is unfixable inside semver. Everything else floats up in the lockfile **within ranges the SDK already declared** — no `overrides` needed:

| package | before | after | needed |
|---|---|---|---|
| `@modelcontextprotocol/sdk` | 1.29.0 | 1.30.0 | ≥1.30.0 (admits @hono/node-server 2.x) |
| `hono` | 4.12.12 | 4.13.1 | ≥4.12.34 |
| `@hono/node-server` | 1.19.13 | 2.1.0 | ≥2.0.5 |
| `fast-uri` | 3.1.0 | 3.1.5 | ≥3.1.5 |
| `ip-address` | 10.1.0 | 10.4.0 (via `express-rate-limit` 8.3.2→8.6.2, which pinned it exactly) | ≥10.3.1 |
| `qs` | 6.15.1 | 6.15.3 | ≥6.15.2 |
| `body-parser` | 2.2.2 | 2.3.0 | ≥2.3.0 |

Bonus, outside the 32: the dev-only `nanoid` advisory (GHSA-2v37-7h3g-55p8, vitest→vite→postcss chain) floated 3.3.16 → 3.3.18. **`npm audit` now reports 0 vulnerabilities** (was: 1 low, 4 moderate, 4 high by package).

## Reachability, honestly

This is a **stdio server** — `src/` imports only `server/mcp.js` and `server/stdio.js` from the SDK. Verified by grepping the SDK dist import graph:

- **hono** — not imported by any shipped SDK module outside its bundled `examples/`; it enters `node_modules` as an SDK direct dep + dep of `@hono/node-server`. *Present but unreachable in this package's usage.*
- **@hono/node-server** — imported only by `server/streamableHttp.js` (Streamable HTTP transport). Never loaded here. *Present but unreachable.*
- **ip-address** (via `express-rate-limit`) — imported only by SDK `server/auth/handlers/*` (OAuth HTTP endpoints). *Present but unreachable.*
- **qs / body-parser** (via `express`) — express is imported only by the SDK's `server/express.js` HTTP adapter. *Present but unreachable.*
- **fast-uri** (via `ajv`) — **reachable**: `server/index.js` (which `server/mcp.js` imports) instantiates `AjvJsonSchemaValidator` → `ajv` → `fast-uri`. It only ever sees local stdio protocol messages, never network input, and no URI-parse result gates a trust decision here — so practical exploitability is low, but the code is loaded at runtime.

No alerts are dev-only; all 32 sit under the SDK's runtime tree. Unreachable today is one transport change away from reachable — the bump closes all of it regardless.

## Alert-by-alert

| # | sev | package | advisory | fixed by |
|---|---|---|---|---|
| 29 | high | ip-address | GHSA-mwp4-54f8-5fhr — leading-zero octet SSRF | 10.4.0 ✅ (unreachable: SDK auth handlers only) |
| 28 | high | fast-uri | GHSA-7p8r-x3mc-p8w7 — backslash authority host confusion | 3.1.5 ✅ (loaded via ajv; local input only) |
| 26 | high | fast-uri | GHSA-v2hh-gcrm-f6hx — literal backslash host confusion | 3.1.5 ✅ (loaded via ajv; local input only) |
| 25 | high | fast-uri | GHSA-4c8g-83qw-93j6 — failed IDN canonicalization | 3.1.5 ✅ (loaded via ajv; local input only) |
| 6 | high | fast-uri | GHSA-v39h-62p7-jpjc — percent-encoded authority delimiters | 3.1.5 ✅ (loaded via ajv; local input only) |
| 5 | high | fast-uri | GHSA-q3j6-qgpj-74h6 — percent-encoded dot path traversal | 3.1.5 ✅ (loaded via ajv; local input only) |
| 17 | high | hono | GHSA-88fw-hqm2-52qc — CORS reflects any origin with credentials | 4.13.1 ✅ (unreachable: no HTTP) |
| 32 | med | hono | GHSA-f23p-vx2j-j53r — memo() SSR cross-user leak | 4.13.1 ✅ (unreachable) |
| 30 | med | hono | GHSA-54fx-42gc-7vw4 — language middleware DoS | 4.13.1 ✅ (unreachable) |
| 27 | med | hono | GHSA-8j4g-w8fx-2239 — CORS ReDoS | 4.13.1 ✅ (unreachable) |
| 24 | med | hono | GHSA-w62v-xxxg-mg59 — JSX cx() XSS | 4.13.1 ✅ (unreachable) |
| 23 | med | hono | GHSA-xgm2-5f3f-mvvc — API GW header de-dup drop | 4.13.1 ✅ (unreachable) |
| 22 | med | @hono/node-server | GHSA-frvp-7c67-39w9 — serve-static Windows path traversal | 2.1.0 ✅ (needs SDK ≥1.30.0; unreachable) |
| 21 | med | hono | GHSA-hvrm-45r6-mjfj — jsx context cross-request leak | 4.13.1 ✅ (unreachable) |
| 19 | med | hono | GHSA-rv63-4mwf-qqc2 — body limit bypass on Lambda | 4.13.1 ✅ (unreachable) |
| 18 | med | hono | GHSA-wgpf-jwqj-8h8p — Lambda@Edge repeated header drop | 4.13.1 ✅ (unreachable) |
| 16 | med | hono | GHSA-wwfh-h76j-fc44 — serve-static Windows path traversal | 4.13.1 ✅ (unreachable) |
| 15 | med | hono | GHSA-j6c9-x7qj-28xf — Set-Cookie merge drops cookies | 4.13.1 ✅ (unreachable) |
| 14 | med | hono | GHSA-2gcr-mfcq-wcc3 — mount prefix undecoded path routing | 4.13.1 ✅ (unreachable) |
| 13 | med | hono | GHSA-xrhx-7g5j-rcj5 — IP restriction IPv6 bypass | 4.13.1 ✅ (unreachable) |
| 12 | med | hono | GHSA-3hrh-pfw6-9m5x — Set-Cookie injection via sameSite | 4.13.1 ✅ (unreachable) |
| 11 | med | hono | GHSA-f577-qrjj-4474 — JWT accepts any auth scheme | 4.13.1 ✅ (unreachable) |
| 10 | med | qs | GHSA-q8mj-m7cp-5q26 — stringify DoS on comma arrays | 6.15.3 ✅ (unreachable: express stack) |
| 9 | med | hono | GHSA-qp7p-654g-cw7p — CSS declaration injection in JSX SSR | 4.13.1 ✅ (unreachable) |
| 7 | med | hono | GHSA-p77w-8qqv-26rm — cache middleware ignores Vary | 4.13.1 ✅ (unreachable) |
| 4 | med | hono | GHSA-9vqf-7f2p-gf9v — bodyLimit bypass chunked | 4.13.1 ✅ (unreachable) |
| 3 | med | hono | GHSA-69xw-7hcm-h432 — JSX tag name HTML injection | 4.13.1 ✅ (unreachable) |
| 2 | med | ip-address | GHSA-v2v4-37r5-5v8g — Address6 HTML-emitting XSS | 10.4.0 ✅ (unreachable) |
| 1 | med | hono | GHSA-458j-xx4x-4375 — JSX attribute HTML injection | 4.13.1 ✅ (unreachable) |
| 31 | low | hono | GHSA-79qm-7rj5-m7r9 — proxy helper Connection headers | 4.13.1 ✅ (unreachable) |
| 20 | low | body-parser | GHSA-v422-hmwv-36x6 — invalid limit disables enforcement | 2.3.0 ✅ (unreachable: express stack) |
| 8 | low | hono | GHSA-hm8q-7f3q-5f36 — JWT NumericDate validation | 4.13.1 ✅ (unreachable) |

**Resolved: 32 of 32. Left open: none.** No fix required a breaking bump.

## Gate (all green, local)

- `npx tsc --noEmit` ✅
- `npm run typecheck:test` ✅
- `npx vitest run` — **338/338 passing**; `test/requests.test.ts` pins request bodies byte-for-byte and holds unchanged against SDK 1.30.0 ✅
- `npm run verify:configs` — 19 artifacts in sync ✅
- `npm pack --dry-run` — file set unchanged (21 files, dist untouched) ✅
- `npm run check:release-sync` ✅
- `npm audit` — 0 vulnerabilities ✅

Diff is three files: one line in `package.json`, the lockfile, and a `## [Unreleased]` CHANGELOG entry (no version bump — that happens at release cut, and per the CHANGELOG's own rules this is PATCH-shaped: no tool changes shape, no request changes a byte).
