### PR TITLE
ci(verify-configs): least-privilege permissions block, matching the other workflows

### DIFF
--- a/.github/workflows/verify-configs.yml
+++ b/.github/workflows/verify-configs.yml
@@ -38,6 +38,10 @@ on:
       - "server.json"
       - ".github/workflows/verify-configs.yml"
 
+# Least privilege, as in test.yml / release-sync-check.yml: a drift check reads and compares, never writes.
+permissions:
+  contents: read
+
 jobs:
   verify:
     runs-on: ubuntu-latest


### PR DESCRIPTION
`verify-configs.yml` was the one workflow in `.github/` still running on the default writable `GITHUB_TOKEN`. The other three already scope theirs: `test.yml` and `release-sync-check.yml` declare `contents: read` at the top (test.yml's comment spells out why it is not a formality in a repo that publishes to npm), and `release.yml` declares per-job permissions for OIDC publishing.

This adds the same top-level block, with a one-line comment in the same register:

```yaml
# Least privilege, as in test.yml / release-sync-check.yml: a drift check reads and compares, never writes.
permissions:
  contents: read
```

The job itself is untouched. It runs `node scripts/generate-configs.mjs --check` with no `npm ci` — no dependency lifecycle scripts even run here — but checkout still persists the job token into `.git/config` by default, and a token that only ever reads should only be able to read.

Four lines, no behaviour change: the check needs exactly `contents: read` to check out and compare.

Noticed while in the file, not touched here (drift-check comment has itself drifted): the header comment and step name say "all 14 generated artifacts", while `npm run verify:configs` today reports **19**. Left for a separate sweep since this PR is permissions-only.
