### PR TITLE
fix(manifest): privacy URL that answers 200, not a 307

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ The same API key works across all tools. Write a memory in Claude Code — read 
 - [MCP Registry entry](https://registry.modelcontextprotocol.io/v0/servers?search=mnemoverse)
 - [Contributing](CONTRIBUTING.md)
 
-## Privacy
+## Privacy Policy
 
 This server sends to the Mnemoverse API (`core.mnemoverse.com`), authenticated with your API key, what a tool call carries — and nothing else it can see. It does **not** read your AI client's conversation history, your local files, or anything you don't pass to a `memory_*` / `vault_*` tool. Stored memories live under your account; Mnemoverse never sells them and never shares them on its own. The one sharing path is the one you create yourself: inviting someone to a shared room grants their assistant access to that room's memories, bounded by the invite's scope.
 

--- a/manifest.json
+++ b/manifest.json
@@ -26,7 +26,7 @@
     "oauth"
   ],
   "privacy_policies": [
-    "https://mnemoverse.com/privacy.html"
+    "https://mnemoverse.com/privacy"
   ],
   "server": {
     "type": "node",

--- a/src/configs/source.json
+++ b/src/configs/source.json
@@ -61,7 +61,7 @@
     },
     "longDescription": "Mnemoverse gives your AI assistant long-term memory that persists across sessions and across tools. Store preferences, decisions, and lessons with memory_write; recall them by natural-language search with memory_read. The same memory is shared everywhere you use your Mnemoverse API key — Claude, Cursor, VS Code, and any MCP client. Requires a free API key from https://console.mnemoverse.com.",
     "privacyPolicies": [
-      "https://mnemoverse.com/privacy.html"
+      "https://mnemoverse.com/privacy"
     ],
     "icon": "icon.png",
     "compatibility": {


### PR DESCRIPTION
One line in the SSOT (`src/configs/source.json`), regenerated into `manifest.json`.

`privacy_policies` pointed at `https://mnemoverse.com/privacy.html` — a **307 redirect** to `/privacy`. Anthropic's Connectors Directory review requires HTTPS privacy-policy URLs and rejects on missing/broken ones; feeding their fetcher a redirect is a needless gamble on the eve of a submission. Same bug class as the llms.txt 301s and the README `/privacy.html` fixed in #63 — this was the last copy left (verified by grep across the repo).

Pre-submission context: the freshly built 0.8.1 `.mcpb` validates clean, and all 10 remote tools already carry `title` + `readOnlyHint`/`destructiveHint` — after this lands, every checklist item of the directory review that is ours to control is green. The `.mcpb` gets rebuilt from main after merge so the submitted artifact carries the 200 URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Renamed the README section to “Privacy Policy” for clarity.

* **Updates**
  * Updated privacy policy links to use the new `/privacy` URL across the application and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->