### PR TITLE
chore(community): code of conduct + funding.json — unblock GitHub SOSF

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: izgorodin

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-github: izgorodin

--- a/.mcpbignore
+++ b/.mcpbignore
@@ -18,4 +18,15 @@ server.json
 llms.txt
 CONTRIBUTING.md
 dist-mcpb/
+# Repository-governance and packaging files: meaningful on GitHub, noise inside
+# a user's extension bundle. funding.json in particular would ship a
+# fundraising manifest with the maintainer's email to every installed copy,
+# which is not what a directory reviewer expects to find in the artefact.
+CODE_OF_CONDUCT.md
+funding.json
+CHANGELOG.md
+Dockerfile
+.dockerignore
+glama.json
+tsconfig.test.json
 *.mcpb

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -32,11 +32,11 @@ Community leaders have the right and responsibility to remove, edit, or reject c
 
 ## Scope
 
-This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the maintainers at hello@mnemoverse.com. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at hello@mnemoverse.com. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 
@@ -54,13 +54,13 @@ Community leaders will follow these Community Impact Guidelines in determining t
 
 **Community Impact**: A violation through a single incident or series of actions.
 
-**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. Violating these terms may lead to a temporary or permanent ban.
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
 
 ### 3. Temporary Ban
 
 **Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
 
-**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. Violating these terms may lead to a permanent ban.
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
 
 ### 4. Permanent Ban
 
@@ -70,8 +70,14 @@ Community leaders will follow these Community Impact Guidelines in determining t
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
 
-Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
 
-For answers to common questions about this code of conduct, see the FAQ at https://www.contributor-covenant.org/faq.
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,77 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the maintainers at hello@mnemoverse.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see the FAQ at https://www.contributor-covenant.org/faq.

--- a/funding.json
+++ b/funding.json
@@ -1,0 +1,60 @@
+{
+  "version": "v1.0.0",
+  "entity": {
+    "type": "individual",
+    "role": "maintainer",
+    "name": "Eduard Izgorodin",
+    "email": "hello@mnemoverse.com",
+    "description": "Independent researcher and engineer working on open memory infrastructure for AI agents, and on honest evaluation of it. Author of the peer-reviewed SLoD paper (GRAAI workshop, IEEE WCCI 2026).",
+    "webpageUrl": {
+      "url": "https://mnemoverse.com"
+    }
+  },
+  "projects": [
+    {
+      "guid": "mcp-memory-server",
+      "name": "@mnemoverse/mcp-memory-server",
+      "description": "Persistent memory for AI agents over the Model Context Protocol. One key gives Claude Code, Cursor, VS Code and ChatGPT memory that survives across sessions and across tools. MIT licensed and listed in the official MCP Registry.",
+      "webpageUrl": {
+        "url": "https://mnemoverse.com/docs/api/mcp-server"
+      },
+      "repositoryUrl": {
+        "url": "https://github.com/mnemoverse/mcp-memory-server"
+      },
+      "licenses": ["spdx:MIT"],
+      "tags": ["ai", "agents", "memory", "mcp", "developer-tools"]
+    }
+  ],
+  "funding": {
+    "channels": [
+      {
+        "guid": "github-sponsors",
+        "type": "other",
+        "address": "https://github.com/sponsors/izgorodin",
+        "description": "GitHub Sponsors, the maintainer's settlement account."
+      }
+    ],
+    "plans": [
+      {
+        "guid": "maintenance",
+        "status": "active",
+        "name": "Maintenance and security review",
+        "description": "Funds ongoing maintenance of the server: dependency and security review on an execution boundary that turns agent tool calls into authenticated API calls, release engineering across npm and the MCP Registry, and test coverage over the tool schemas.",
+        "amount": 10000,
+        "currency": "USD",
+        "frequency": "yearly",
+        "channels": ["github-sponsors"]
+      },
+      {
+        "guid": "support",
+        "status": "active",
+        "name": "Any amount",
+        "description": "Support the project at whatever level makes sense for you.",
+        "amount": 0,
+        "currency": "USD",
+        "frequency": "one-time",
+        "channels": ["github-sponsors"]
+      }
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   ],
   "author": "Mnemoverse <hello@mnemoverse.com>",
   "license": "MIT",
+  "funding": "https://github.com/sponsors/izgorodin",
   "repository": {
     "type": "git",
     "url": "https://github.com/mnemoverse/mcp-memory-server"


### PR DESCRIPTION
Files staged on the funding side since 2026-08-10; Olya could not push them here (no write access), so the GitHub Secure Open Source Fund application has been standing still.

**Revised after an adversarial audit of the first version — three findings, all correct, all fixed.**

## What ships

| File | Why it exists |
|---|---|
| `CODE_OF_CONDUCT.md` | Contributor Covenant 2.1, **byte-identical to the canonical text** (asserted, not assumed). Heroku's OSS credit programme checks for one before considering a project. |
| `funding.json` | fundingjson.org v1.0.0 manifest at repo root — the FLOSS fund's application artefact. Validated against the real schema with ajv. |
| `funding` field in package.json | Makes `npm fund` resolve. Reaches nobody until a tagged publish. |
| `.mcpbignore` additions | See finding 3. |

## What the audit caught

**1. The Sponsor button is a public surface that lights up ON MERGE.** This repo is public, and by my own earlier PR text the Sponsors tiers are **not configured** — so the button would have shipped pointing at an unfinished page. `.github/FUNDING.yml` is **removed from this PR**; it lands separately once tiers exist. That is a decision for Eduard, not a side effect of a chore PR.

**2. The CoC was not the verbatim 2.1 the body claimed.** Two cuts weakened the enforcement ladder: §2 lost *"This includes avoiding interactions in community spaces as well as external channels like social media"*, §3 lost *"No public or private interaction with the people involved… is allowed during this period"*. Programmes that diff this file against the canon would have seen an abridged code of conduct. Replaced with the canonical text from EthicalSource, their `[INSERT CONTACT METHOD]` placeholder substituted — verified byte-identical.

**3. `funding.json` and `CODE_OF_CONDUCT.md` were riding inside the `.mcpb` bundle.** A fundraising manifest carrying the maintainer's email is not what a Connectors Directory reviewer expects to find in the artefact. Added to `.mcpbignore`, along with `CHANGELOG.md`, `Dockerfile`, `.dockerignore`, `glama.json` and `tsconfig.test.json`, which were in there for no reason either.

Bundle root is now exactly: `LICENSE`, `README.md`, `icon.png`, `manifest.json`, `package.json`.

## Open, tracked, not blocking this merge

CodeRabbit asked for `wellKnown` provenance in `funding.json`. **The finding is real** — the spec requires it when the manifest host and the URL host differ, which is our case. But it cannot honestly be added yet: `https://mnemoverse.com/.well-known/funding-manifest-urls` currently returns **404**. Publishing that file on mnemoverse.com comes first; it gates the FLOSS fund submission, not this merge.

## Checks

338 tests · manifest schema validates · `funding.json` valid against the real v1.0.0 schema · bundle repacked and its contents inspected.