### PR TITLE
release: 0.8.2 — dependency security pass + honest registry description

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,9 +73,14 @@ jobs:
       # from package.json, but it is committed, so a missed
       # `npm run generate:configs` desyncs the registry manifest the same way.
       - name: Verify tag matches package.json, package-lock.json and server.json
+        # TAG arrives through env, never through `${{ }}` inside `run:`.
+        # `workflow_dispatch.inputs.tag` is human-supplied, so interpolating it
+        # into shell SOURCE lets a dispatcher inject commands; via env it is
+        # only ever data. (CodeRabbit, #81.)
+        env:
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
         run: |
           set -euo pipefail
-          TAG="${{ github.event.inputs.tag || github.ref_name }}"
           TAG_VERSION="${TAG#v}"
           PKG_VERSION="$(node -p "require('./package.json').version")"
           LOCK_VERSION="$(node -p "require('./package-lock.json').version")"
@@ -127,9 +132,10 @@ jobs:
         run: ./mcp-publisher publish
 
       - name: Verify the registry entry shows the new version
+        env:
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
         run: |
           set -euo pipefail
-          TAG="${{ github.event.inputs.tag || github.ref_name }}"
           VERSION="${TAG#v}"
           echo "Waiting a few seconds for the registry to propagate..."
           sleep 3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,19 +64,39 @@ jobs:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Verify tag matches package.json#version
+      # The version lives in THREE places, so the guard checks all three.
+      # It used to check package.json alone, and 0.8.2 shipped its PR with the
+      # lockfile still reading 0.8.1 — caught in review, not by this step
+      # (mcp-memory-server#81). `npm ci` does not compare the lockfile's own
+      # `version` field, so a stale one sails through the build and lands in
+      # the published tree as a quiet contradiction. server.json is generated
+      # from package.json, but it is committed, so a missed
+      # `npm run generate:configs` desyncs the registry manifest the same way.
+      - name: Verify tag matches package.json, package-lock.json and server.json
         run: |
           set -euo pipefail
           TAG="${{ github.event.inputs.tag || github.ref_name }}"
           TAG_VERSION="${TAG#v}"
           PKG_VERSION="$(node -p "require('./package.json').version")"
-          echo "tag:         $TAG"
-          echo "tag version: $TAG_VERSION"
-          echo "pkg version: $PKG_VERSION"
-          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
-            echo "::error::Tag $TAG (version $TAG_VERSION) does not match package.json version $PKG_VERSION"
-            exit 1
-          fi
+          LOCK_VERSION="$(node -p "require('./package-lock.json').version")"
+          LOCK_ROOT_VERSION="$(node -p "require('./package-lock.json').packages[''].version")"
+          SERVER_VERSION="$(node -p "require('./server.json').version")"
+          echo "tag:             $TAG"
+          echo "tag version:     $TAG_VERSION"
+          echo "package.json:    $PKG_VERSION"
+          echo "lock .version:   $LOCK_VERSION"
+          echo "lock packages[]: $LOCK_ROOT_VERSION"
+          echo "server.json:     $SERVER_VERSION"
+          FAIL=0
+          for pair in "package.json:$PKG_VERSION" "package-lock.json:$LOCK_VERSION" \
+                      "package-lock.json packages[\"\"]:$LOCK_ROOT_VERSION" "server.json:$SERVER_VERSION"; do
+            WHERE="${pair%:*}"; GOT="${pair##*:}"
+            if [ "$TAG_VERSION" != "$GOT" ]; then
+              echo "::error::$WHERE reads $GOT, tag $TAG expects $TAG_VERSION"
+              FAIL=1
+            fi
+          done
+          [ "$FAIL" -eq 0 ] || exit 1
 
       - name: Install dependencies
         run: npm ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ git history and the GitHub releases are the record.
 
 ## [Unreleased]
 
+## [0.8.2] — 2026-08-13
+
 Dependency security pass: clears all 32 open Dependabot alerts (7 high, 22
 medium, 3 low) — 22 against `hono`, 5 `fast-uri`, 2 `ip-address`, and one each
 for `@hono/node-server`, `qs`, `body-parser`. Every one is a transitive

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "mnemoverse-memory",
   "display_name": "Mnemoverse Memory",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Hosted memory for AI agents that learns and forgets — one key across Claude, Cursor & ChatGPT.",
   "long_description": "Mnemoverse gives your AI assistant long-term memory that persists across sessions and across tools. Store preferences, decisions, and lessons with memory_write; recall them by natural-language search with memory_read. The same memory is shared everywhere you use your Mnemoverse API key — Claude, Cursor, VS Code, and any MCP client. Requires a free API key from https://console.mnemoverse.com.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mnemoverse/mcp-memory-server",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mnemoverse/mcp-memory-server",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mnemoverse/mcp-memory-server",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Hosted persistent memory for AI agents that learns which facts help and lets the rest fade — one key across Claude Code, Cursor, VS Code & ChatGPT, no infra to run",
   "type": "module",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -9,12 +9,12 @@
     "source": "github",
     "id": "1207193530"
   },
-  "version": "0.8.1",
+  "version": "0.8.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mnemoverse/mcp-memory-server",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Ships the three commits that have sat on main since 0.8.1: the Dependabot pass (32 alerts → 0), the server.json description fix (#72), and the CI permissions block (#77).

Patch, per this repo's own stated policy — the CHANGELOG entry argues it explicitly: no tool changes shape, no request changes a byte, and the user-visible changes are prose only.

338/338 green, `verify:configs` clean, all 19 generated artifacts in sync.

**After merge**: `git tag v0.8.2 && git push origin v0.8.2` fires release.yml → npm publish + MCP registry + GitHub release. Publishing is irreversible — тег ставлю по твоему слову.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release**
  * Released version 0.8.2.

* **Security**
  * Updated dependencies, including security-related upgrades.
  * No reported vulnerabilities were identified.

* **Compatibility**
  * Existing tools and request formats remain unchanged.

* **Quality**
  * Confirmed that all tests pass.
  * Release checks now validate version consistency across published package metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->