### PR TITLE
fix(vault): the description promised a consumer that does not exist

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -88,7 +88,7 @@
     },
     {
       "name": "vault_list",
-      "description": "List the secrets in your Mnemoverse Vault by alias and purpose only — the secret value is never returned or shown."
+      "description": "List the secrets in your Mnemoverse Vault by alias and purpose only — the value is never returned, by this tool or any other on this server."
     }
   ],
   "user_config": {

--- a/src/configs/source.json
+++ b/src/configs/source.json
@@ -129,7 +129,7 @@
       },
       {
         "name": "vault_list",
-        "description": "List the secrets in your Mnemoverse Vault by alias and purpose only — the secret value is never returned or shown."
+        "description": "List the secrets in your Mnemoverse Vault by alias and purpose only — the value is never returned, by this tool or any other on this server."
       }
     ]
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1491,7 +1491,7 @@ server.registerTool(
   "vault_list",
   {
     description:
-      "List the secrets stored in your Mnemoverse Vault — by ALIAS and purpose only; the secret VALUE is never returned or shown to you. Use this to DISCOVER which secret to use (e.g. the user says 'use my GitHub token' — find its alias here) before a tool that consumes it. Only YOUR account's secrets are listed.",
+      "List the secrets stored in your Mnemoverse Vault — by ALIAS and purpose only; the secret VALUE is never returned or shown to you, and no tool on this server returns it. Use this to check WHICH secrets the user has stored and under what alias (e.g. the user says 'do I have a GitHub token saved?'). Only YOUR account's secrets are listed.",
     inputSchema: {},
     annotations: {
       title: "List vault secrets",

--- a/test/descriptions.test.ts
+++ b/test/descriptions.test.ts
@@ -144,6 +144,10 @@ describe("the advertised descriptions carry this release's truth claims", () => 
   it("vault_list promises aliases only — the value is never returned", () => {
     const d = description("vault_list");
     expect(d).toContain("the secret VALUE is never returned");
+    // The stronger half of the promise, added when the phantom-consumer
+    // sentence was withdrawn. Pinned separately because the clause above
+    // survives in any rewrite, so on its own it asserts nothing about this one.
+    expect(d).toContain("no tool on this server returns it");
   });
 });
 
@@ -181,6 +185,12 @@ describe("withdrawn claims stay withdrawn on every advertised surface", () => {
     // 'Pass "me" for the everyone-but-me read' — the author principal is not
     // visible from this tool, so 'me' matches nothing and filters nothing.
     [/everyone-but-me/i, "the exclude_author 'me' pitch"],
+    // "before a tool that consumes it" — vault_list is the only vault tool on
+    // this server; the other eleven are memory tools, and none of them takes a
+    // secret. The sentence sent a reviewer looking for a consumer that does not
+    // exist, which is the kind of mismatch Anthropic's directory policy fails
+    // a submission for.
+    [/a tool that consumes it/i, "the phantom secret-consumer claim"],
   ];
 
   it("no tool or parameter description carries one", () => {


### PR DESCRIPTION
Olya caught this reading the live server card against Anthropic's directory policy, which requires a tool's description to match what the software actually does.

`vault_list` told the agent to find an alias **"before a tool that consumes it"**. There is no such tool. `vault_list` is the only vault tool on this server; the other eleven are memory tools. A reviewer who follows that sentence looks for the consumer, does not find it, and then reasonably asks what else in our surface is inaccurate — right before deciding whether to list us.

## What it says now

> List the secrets stored in your Mnemoverse Vault — by ALIAS and purpose only; the secret VALUE is never returned or shown to you, **and no tool on this server returns it**. Use this to check WHICH secrets the user has stored and under what alias.

That is a *stronger* privacy claim than the old wording, and it has the advantage of being true.

## Where

Fixed in `src/index.ts` (what the running server advertises) **and** in `src/configs/source.json` (the MCPB manifest SSOT) in the same commit — patching only the generated `manifest.json` would have been reverted by the next `generate-configs` run.

338 tests pass; manifest schema validates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that vault listing displays available aliases and purposes without exposing secret values.
  * Confirmed that secret values are never returned by the vault listing feature or any other server tool.
  * Updated descriptions consistently across the application and configuration documentation.
  * Removed wording suggesting the listing is used to discover secrets for later retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->