### PR TITLE
release: 0.8.3 — the three claims about ourselves that were not true

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,6 @@ jobs:
         # future-watermark diagnosis would go unguarded on exactly the side
         # where a genuinely future watermark parses into the past.
         tz: ["UTC", "Asia/Tokyo", "America/New_York"]
-        node: ["20"]
     env:
       TZ: ${{ matrix.tz }}
     steps:
@@ -65,7 +64,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node }}
+          node-version: "20"
           cache: npm
 
       - run: npm ci
@@ -78,7 +77,7 @@ jobs:
       - name: Typecheck tests
         run: npm run typecheck:test
 
-      - name: Test (Node ${{ matrix.node }}, TZ=${{ matrix.tz }})
+      - name: Test (TZ=${{ matrix.tz }})
         run: npm test
 
   # `engines` promises Node >=18 and nothing ever executed that promise (#75).

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,15 @@ jobs:
         # future-watermark diagnosis would go unguarded on exactly the side
         # where a genuinely future watermark parses into the past.
         tz: ["UTC", "Asia/Tokyo", "America/New_York"]
+        node: ["20"]
+        # `engines` in package.json promises Node >=18, and until now nothing
+        # ever ran the suite on 18 — an untested published claim (#75). One
+        # extra leg tests the promise instead of restating it. Only on UTC:
+        # the timezone matrix answers a different question, and crossing them
+        # would triple the cost to re-answer it.
+        include:
+          - tz: "UTC"
+            node: "18"
     env:
       TZ: ${{ matrix.tz }}
     steps:
@@ -64,7 +73,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: ${{ matrix.node }}
           cache: npm
 
       - run: npm ci
@@ -77,5 +86,5 @@ jobs:
       - name: Typecheck tests
         run: npm run typecheck:test
 
-      - name: Test (TZ=${{ matrix.tz }})
+      - name: Test (Node ${{ matrix.node }}, TZ=${{ matrix.tz }})
         run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,14 +53,6 @@ jobs:
         # where a genuinely future watermark parses into the past.
         tz: ["UTC", "Asia/Tokyo", "America/New_York"]
         node: ["20"]
-        # `engines` in package.json promises Node >=18, and until now nothing
-        # ever ran the suite on 18 — an untested published claim (#75). One
-        # extra leg tests the promise instead of restating it. Only on UTC:
-        # the timezone matrix answers a different question, and crossing them
-        # would triple the cost to re-answer it.
-        include:
-          - tz: "UTC"
-            node: "18"
     env:
       TZ: ${{ matrix.tz }}
     steps:
@@ -88,3 +80,42 @@ jobs:
 
       - name: Test (Node ${{ matrix.node }}, TZ=${{ matrix.tz }})
         run: npm test
+
+  # `engines` promises Node >=18 and nothing ever executed that promise (#75).
+  # The full suite CANNOT answer it: vitest 4 itself requires Node ^20 || ^22 ||
+  # >=24 and dies on 18 with `node:util does not provide an export named
+  # styleText` — a fact about our TEST RUNNER, not about the published package.
+  # So test what the promise is actually about: does the shipped artifact start
+  # and speak MCP on Node 18. A real stdio `initialize` handshake, no API key
+  # needed (the key is validated lazily, inside apiFetch).
+  #
+  # If this goes red, `engines: ">=18"` is false and moves to ">=20" in 0.9 —
+  # engines is shape, and a patch may not change shape.
+  smoke-node18:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Node 18
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+          cache: npm
+
+      - run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: The published entrypoint must start and speak MCP on Node 18
+        run: |
+          set -euo pipefail
+          REQ='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2026-06-18","capabilities":{},"clientInfo":{"name":"smoke","version":"0"}}}'
+          OUT="$(echo "$REQ" | timeout 30 node dist/index.js 2>/dev/null | head -c 400 || true)"
+          echo "$OUT"
+          case "$OUT" in
+            *'"serverInfo"'*'"name":"mnemoverse-memory"'*) echo "Node 18: handshake ok" ;;
+            *) echo "::error::the entrypoint did not complete an MCP initialize on Node 18 — engines '>=18' is not true"; exit 1 ;;
+          esac

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ git history and the GitHub releases are the record.
 
 ## [Unreleased]
 
-## [0.8.3] — 2026-08-13
+## [0.8.3] — 2026-08-14
 
 Three claims about ourselves that were not true, all found by review rather
 than by us, and all shipped as text — no tool changes shape, no parameter
@@ -77,16 +77,34 @@ moves.
 
 ### Fixed — behaviour
 
+- **The valence explanation in `memory_feedback` was inverted by a core change
+  the day before (core#493).** Until 2026-08-13 the engine applied
+  `sign(outcome) × |prediction error|`, so a 0 rating took the positive branch
+  and pushed valence UP — which dogfooding observed and which this file's
+  comment recorded. Core now uses the SIGNED error, `pe = outcome - valence`
+  (`memory_engine.py:4986-4988`), so a 0 against a positive valence moves it
+  DOWN, toward neutral. Comments are not stripped from `dist/`, so the stale
+  explanation would have shipped inside the tarball, contradicting the README
+  line this same release adds. Rewritten against the current engine.
+
+- **The outcome-0 branch of `memory_feedback` still asserted its count.** The
+  ±1 branches were corrected for #68 and the zero branch was left behind — and
+  a test added in this release pinned the wrong wording. Both fixed: it now
+  reads "Rating sent: 0. The service reports N memories updated."
+
 - **Honesty probes have a deadline (#73).** The zero-result paths of
   `memory_read` and `memory_list_recent` consult `/memory/stats` and
   `/memory/rooms` so an empty answer can say what it did not cover. Those two
   GETs went through bare `fetch()` with no `AbortSignal`, inheriting undici's
   ~300s default: one hung engine endpoint turned an empty read — instant in
-  0.8.0, which probed nothing — into a multi-minute stall. Both now carry a 4s
-  timeout, chosen against measured production latency (`/memory/read` averaged
-  1,330 ms, max 10.2 s). A timed-out probe degrades into the existing "unknown"
-  fallback, which already says so; no request changes shape and no tool changes
-  its schema.
+  0.8.0, which probed nothing — into a multi-minute stall. **All three** now
+  carry a 4s deadline, chosen against measured production latency
+  (`/memory/read` averaged 1,330 ms, max 10.2 s). Three, not two: the first
+  pass deadlined only the pair inside `probeScope` and left the stats call on
+  the UNSCOPED empty read — the commonest one there is — still able to hang,
+  which review caught before the tag. A timed-out probe degrades into the
+  existing "unknown" fallback, which already says so; no request changes shape
+  and no tool changes its schema.
 
 ### Changed — CI
 
@@ -101,6 +119,15 @@ moves.
   patch may not change shape.
 
 ### Fixed
+
+> **What this release physically delivers, stated because the last one did
+> not.** The tag publishes exactly two things: the npm tarball (`dist/`,
+> `README.md`, `LICENSE`, `package.json`) and `server.json` to the official MCP
+> registry. `manifest.json` is the MCPB extension artefact, and **no workflow
+> packs or uploads it** — v0.8.2 shipped zero release assets. So the manifest
+> fix below is correct and on main, and it reaches users only when someone
+> builds and submits the bundle by hand. Automating that is tracked separately;
+> it is NOT delivered by tagging 0.8.3.
 
 - **The privacy policy URL in the extension manifest was a redirect.**
   `privacy_policies` pointed at `mnemoverse.com/privacy.html`, which answers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,9 +91,14 @@ moves.
 ### Changed — CI
 
 - **`engines: >=18` is now tested rather than asserted (#75).** CI ran Node 20
-  only, so a published compatibility promise had never been executed. A Node 18
-  leg joins the matrix on UTC. If it fails, the claim is false and moves to
-  `>=20` in 0.9 — `engines` is shape, so a patch cannot change it here.
+  only, so a published compatibility promise had never been executed once. The
+  full suite cannot answer it — vitest 4 itself requires Node `^20 || ^22 ||
+  >=24` and dies on 18 inside `node:util`, which is a fact about our test
+  runner and not about the shipped package. So the new `smoke-node18` job tests
+  what the promise is actually about: it builds and drives a real MCP
+  `initialize` handshake through `dist/index.js` on Node 18. If that goes red
+  the claim is false and moves to `>=20` in 0.9 — `engines` is shape, and a
+  patch may not change shape.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,58 @@ Three claims about ourselves that were not true, all found by review rather
 than by us, and all shipped as text — no tool changes shape, no parameter
 moves.
 
+
+### Fixed — claims that stopped being true
+
+- **A refused ROOM write no longer states the personal-domain rule.** The line
+  said "so a near-duplicate is refused". As of core#482 (2026-08-13) that is
+  false in a shared room: a restatement — a briefing, a status, a decision
+  summary — STORES there, because a room is a message bus and the second agent's
+  job is to receive what the first was told. Only a write the embedder cannot
+  distinguish from one already present is refused. The client now prints the
+  rule that applies to the domain it wrote to, names the ~500-token similarity
+  window, and drops the "write the delta" advice in rooms, where a restatement
+  is the point rather than the mistake. The personal-domain wording is
+  unchanged and now pinned by its own test.
+
+- **The novelty score carries the health warning the hosted connector already
+  carries.** The number is a first-generation metric, measurably unreliable:
+  identical content scored ~0.08 in Russian against ~0.55 in English against the
+  same 0.1 threshold — refused in one language, stored in the other. This server
+  printed the bare figure while `mnemoverse-mcp-remote` (#36) explained it, so
+  the same number reached a model with two different degrees of honesty
+  depending on the surface. One surface, one truth (decision 2026-08-12).
+
+- **`memory_feedback` attributes the count instead of asserting it (#68).**
+  "Recorded +1 for 3 memories" is true only while core runs
+  `feedback_async = False`. Under async, `updated_count` is the number of ids
+  SUBMITTED, not applied (core `schemas.py:689-695`), and nothing in the
+  response says which mode ran — so a server-side config flip would silently
+  turn this sentence false on every installed client. It now reads "The service
+  reports N memories updated". The direction echo, which exists so a caller has
+  evidence the loop did anything, is unchanged. Twin of the fix the hosted
+  connector took the same week.
+
+### Fixed — behaviour
+
+- **Honesty probes have a deadline (#73).** The zero-result paths of
+  `memory_read` and `memory_list_recent` consult `/memory/stats` and
+  `/memory/rooms` so an empty answer can say what it did not cover. Those two
+  GETs went through bare `fetch()` with no `AbortSignal`, inheriting undici's
+  ~300s default: one hung engine endpoint turned an empty read — instant in
+  0.8.0, which probed nothing — into a multi-minute stall. Both now carry a 4s
+  timeout, chosen against measured production latency (`/memory/read` averaged
+  1,330 ms, max 10.2 s). A timed-out probe degrades into the existing "unknown"
+  fallback, which already says so; no request changes shape and no tool changes
+  its schema.
+
+### Changed — CI
+
+- **`engines: >=18` is now tested rather than asserted (#75).** CI ran Node 20
+  only, so a published compatibility promise had never been executed. A Node 18
+  leg joins the matrix on UTC. If it fails, the claim is false and moves to
+  `>=20` in 0.9 — `engines` is shape, so a patch cannot change it here.
+
 ### Fixed
 
 - **The privacy policy URL in the extension manifest was a redirect.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,70 @@ git history and the GitHub releases are the record.
 
 ## [Unreleased]
 
+## [0.8.3] — 2026-08-13
+
+Three claims about ourselves that were not true, all found by review rather
+than by us, and all shipped as text — no tool changes shape, no parameter
+moves.
+
+### Fixed
+
+- **The privacy policy URL in the extension manifest was a redirect.**
+  `privacy_policies` pointed at `mnemoverse.com/privacy.html`, which answers
+  307. Anthropic's directory review requires HTTPS privacy URLs and rejects on
+  broken ones, so feeding their fetcher a redirect was a needless gamble right
+  before a submission. Fixed in `src/configs/source.json` — the SSOT — as well
+  as the generated `manifest.json`, because patching only the artefact would
+  have been reverted by the next `generate-configs` run. (#78)
+
+- **`vault_list` promised a tool that does not exist.** Its description told
+  the agent to find an alias "before a tool that consumes it". There is no
+  such tool here: `vault_list` is the only vault tool, the other eleven are
+  memory tools. A reviewer following that sentence looks for the consumer,
+  fails to find it, and reasonably asks what else is inaccurate. The new
+  wording states that no tool on this server returns a secret value — a
+  stronger privacy claim than the old one, with the advantage of being true.
+  Also added to the `WITHDRAWN` list in `test/descriptions.test.ts`, which
+  bans a retracted false claim corpus-wide; the guard was verified by
+  restoring the banned phrase and watching the suite go red. (#82)
+
+- **The README's privacy section heading** is now `## Privacy Policy`
+  verbatim, which is what the directory review looks for. (#78)
+
+### Added
+
+- `CODE_OF_CONDUCT.md` — Contributor Covenant 2.1, byte-identical to the
+  canonical text. An earlier draft was silently abridged: it had lost the
+  clauses about avoiding contact through external channels and about the
+  interaction ban during a temporary suspension. Programmes that diff this
+  file against the canon would have seen a weakened enforcement ladder.
+- `funding.json` — fundingjson.org v1.0.0 manifest, validated against the real
+  schema. Required artefact for the FLOSS fund application.
+- `funding` field in `package.json`, so `npm fund` resolves.
+
+### Changed
+
+- **`.mcpbignore` no longer ships repository governance inside the bundle.**
+  `funding.json` and `CODE_OF_CONDUCT.md` were riding inside the `.mcpb` — a
+  fundraising manifest carrying the maintainer's email is not what a directory
+  reviewer expects to find in the artefact. Excluded along with `CHANGELOG.md`,
+  `Dockerfile`, `.dockerignore`, `glama.json` and `tsconfig.test.json`, which
+  were in there for no reason either. The bundle root is now exactly `LICENSE`,
+  `README.md`, `icon.png`, `manifest.json`, `package.json`.
+
+### Not in this release, tracked
+
+- `.github/FUNDING.yml` is deliberately held back. It lights up the Sponsor
+  button on a public repository the moment it merges, and the Sponsors tiers
+  are not configured — the button would point at an unfinished page.
+- `funding.json` still lacks the `wellKnown` provenance the spec wants when
+  the manifest host and the URL host differ. It cannot honestly be added yet:
+  `mnemoverse.com/.well-known/funding-manifest-urls` returns 404. Publishing
+  that file comes first; it gates the FLOSS fund submission, not this release.
+- The live server card at `mcp.mnemoverse.com` is served by a different
+  repository, so the `vault_list` wording there is fixed separately
+  (`mnemoverse-mcp-remote` #41) and needs a deploy, not this publish.
+
 ## [0.8.2] — 2026-08-13
 
 Dependency security pass: clears all 32 open Dependabot alerts (7 high, 22

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "mnemoverse-memory",
   "display_name": "Mnemoverse Memory",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Hosted memory for AI agents that learns and forgets — one key across Claude, Cursor & ChatGPT.",
   "long_description": "Mnemoverse gives your AI assistant long-term memory that persists across sessions and across tools. Store preferences, decisions, and lessons with memory_write; recall them by natural-language search with memory_read. The same memory is shared everywhere you use your Mnemoverse API key — Claude, Cursor, VS Code, and any MCP client. Requires a free API key from https://console.mnemoverse.com.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mnemoverse/mcp-memory-server",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mnemoverse/mcp-memory-server",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",
@@ -22,6 +22,9 @@
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/izgorodin"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mnemoverse/mcp-memory-server",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Hosted persistent memory for AI agents that learns which facts help and lets the rest fade — one key across Claude Code, Cursor, VS Code & ChatGPT, no infra to run",
   "type": "module",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -9,12 +9,12 @@
     "source": "github",
     "id": "1207193530"
   },
-  "version": "0.8.2",
+  "version": "0.8.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mnemoverse/mcp-memory-server",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "transport": {
         "type": "stdio"
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -623,7 +623,17 @@ server.registerTool(
       // it was a live bug for an account whose only room was archived.
       const scope = await probeScope(searched);
       const text = await buildReadEmptyResponse(
-        () => apiFetch<{ total_atoms?: number }>("/memory/stats"),
+        // THE THIRD PROBE, and the one the first pass at #73 missed. An
+        // UNSCOPED empty read takes this path: probeScope only fetches the
+        // room list (scope.ts: `if (!searched) return { kind: "own-domains" }`),
+        // and the stats call for the first-contact greeting is issued here.
+        // Deadlining only the two inside probeScope left the commonest empty
+        // read of all still able to hang for undici's ~300s default — the exact
+        // symptom #73 names.
+        () =>
+          apiFetch<{ total_atoms?: number }>("/memory/stats", {
+            signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+          }),
         scope,
       );
       return {
@@ -982,18 +992,21 @@ server.registerTool(
         ? `Rating sent: +${outcome} (helpful). The service reports ${noun} updated — they should surface sooner next time.`
         : outcome < 0
           ? `Rating sent: ${outcome} (unhelpful). The service reports ${noun} updated — they should fade.`
-          // Zero claims only what is knowable from here: the rating was
-          // recorded, and ±1 send a clear signal. Two earlier wordings each
-          // asserted engine semantics that were false: "use +1/-1 when you want
-          // the ranking to move" implied 0 leaves ranking alone (dogfooding saw
-          // a neutral rating move a score UP by about five points), and "logged
-          // as a recall that was neither useful nor wrong" described a record
-          // the engine does not keep — core files outcome 0 on the POSITIVE
-          // branch of the valence update (memory_engine.py `_feedback_inner`:
-          // sign is +1 for outcome >= 0) and stores a positive-direction
-          // valence step plus outcome_count += 1. So 0 is not a neutral log
-          // entry, and the printed line must not present it as one.
-          : `Recorded 0 for ${noun}. Use +1 (helpful) or -1 (harmful/wrong) to express a clear direction.`;
+          // Zero claims only what is knowable from here: the rating was sent,
+          // the service reported a count, and ±1 send a clear signal.
+          //
+          // WHAT 0 ACTUALLY DOES, restated against core#493 (merged
+          // 2026-08-13). The valence step used to be
+          // `sign(outcome) * |prediction error|`, so outcome 0 took the
+          // POSITIVE branch and pushed valence UP — which is what dogfooding
+          // saw, and what the previous version of this comment recorded. That
+          // is no longer true: core now uses the SIGNED error,
+          // `pe = outcome - valence` (memory_engine.py:4986-4988), so a 0
+          // against a positive valence moves it DOWN, toward neutral. Either
+          // way 0 is not a no-op and the line must not imply one — but the old
+          // explanation is now backwards, and it ships verbatim inside
+          // dist/index.js, so it cannot be left to rot in a comment.
+          : `Rating sent: 0. The service reports ${noun} updated. Use +1 (helpful) or -1 (harmful/wrong) to express a clear direction.`;
     return {
       content: [{ type: "text" as const, text }],
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,11 +61,28 @@ import {
  * room address (CodeRabbit #65). `searched` is the RAW value that went over the
  * wire, so the diagnosis can never describe a different store than the request.
  */
+/**
+ * How long a HONESTY PROBE may take before the answer goes out without it (#73).
+ *
+ * The probes are a courtesy: they let a zero-result answer say what it did NOT
+ * cover. They are not the answer. Without a deadline they inherit undici's
+ * default (~300s), so one slow engine endpoint turns an empty read — which
+ * 0.8.0 answered instantly, having probed nothing — into a multi-minute stall.
+ * `probeReadScope` already treats a failed probe as "unknown" and says so, so
+ * an abort degrades into the honest fallback rather than an error.
+ *
+ * 4s is chosen against measured production latency: `/memory/read` averaged
+ * 1,330 ms with a 10.2 s maximum (core observability, 2026-08), and these two
+ * are cheaper GETs. Long enough not to fire on a normal slow day, short enough
+ * that a hung endpoint costs seconds instead of minutes.
+ */
+const PROBE_TIMEOUT_MS = 4000;
+
 function probeScope(searched: string | undefined): Promise<ReadScope> {
   return probeReadScope(
     searched,
-    () => apiFetch<unknown>("/memory/stats"),
-    () => apiFetch<unknown>("/memory/rooms"),
+    () => apiFetch<unknown>("/memory/stats", { signal: AbortSignal.timeout(PROBE_TIMEOUT_MS) }),
+    () => apiFetch<unknown>("/memory/rooms", { signal: AbortSignal.timeout(PROBE_TIMEOUT_MS) }),
     safeInline,
   );
 }
@@ -247,6 +264,22 @@ export const server = new McpServer(
   { instructions: SERVER_INSTRUCTIONS },
 );
 
+/**
+ * True for a shared-room address (`xroom:<room_id>`).
+ *
+ * Mirrors core's own predicate (`memory_engine._is_room_domain`), which is a
+ * plain prefix test — deliberately, so a padded or otherwise non-canonical
+ * address does NOT normalise into a room. Byte-for-byte, no trimming: this
+ * file's write handler documents at length why trimming a domain here once
+ * nearly wrote into a room visible to other accounts.
+ *
+ * Used only to choose which TRUE sentence to print about a refusal. It never
+ * changes what is sent, so a wrong answer here misinforms and cannot misroute.
+ */
+function isRoomDomain(domain: string | undefined): boolean {
+  return typeof domain === "string" && domain.startsWith("xroom:");
+}
+
 // --- Tool: memory_write ---
 
 server.registerTool(
@@ -397,10 +430,28 @@ server.registerTool(
           text:
             `NOT STORED — nothing was saved.` +
             (reasonQuote ? ` Server reason: ${reasonQuote}.` : ``) +
-            (importance === "unknown" ? `` : ` Novelty score ${importance}.`) +
-            ` Writes are gated on how much a memory adds over what is already in the` +
-            ` same domain, so a near-duplicate is refused. If the point is genuinely` +
-            ` new, write what is DIFFERENT rather than restating the whole fact.`,
+            (importance === "unknown"
+              ? ``
+              : ` Novelty score ${importance}. That score is a first-generation` +
+                ` metric under active development and known to be unreliable —` +
+                ` identical content has measured ~0.08 in Russian against ~0.55 in` +
+                ` English — so read it as a rough hint about similarity, not as a` +
+                ` judgement of whether this memory was worth keeping.`) +
+            (isRoomDomain(domain)
+              ? // ROOM RULE (core#482, 2026-08-13). A room is a message bus:
+                // the second agent's job is to receive a restatement of what
+                // the first was told, so a briefing or a status summary STORES
+                // here. Only a write the embedder cannot distinguish from one
+                // already present is refused. Telling a caller to "write the
+                // delta" in a room would be advice against the room's purpose.
+                ` Restatements are allowed in rooms — this one was refused only` +
+                ` because it is indistinguishable by embedding from a message` +
+                ` already there. Similarity is judged on roughly the first 500` +
+                ` tokens, so a long message that OPENS like an earlier one can` +
+                ` land here even when its body differs: lead with what is new.`
+              : ` Writes are gated on how much a memory adds over what is already in the` +
+                ` same domain, so a near-duplicate is refused. If the point is genuinely` +
+                ` new, write what is DIFFERENT rather than restating the whole fact.`),
         },
       ],
     };
@@ -914,12 +965,23 @@ server.registerTool(
     // rank" for outcome 0 would be a claim we cannot make — dogfooding saw a
     // neutral rating move a score UP by about five points, so neither "no
     // change" nor "ranks higher" is safe to assert (CodeRabbit, #65).
+    // WHOSE NUMBER THIS IS (#68). `updated_count` is the count of memories the
+    // service says it touched — and that is true only while core runs
+    // `feedback_async = False`. Under async it returns the number of ids
+    // SUBMITTED, not applied (core schemas.py:689-695, memory_engine.py:4490),
+    // and nothing in the response says which mode ran. A server-side config
+    // flip would therefore turn a confident sentence here false on every
+    // installed client, silently. So the number is reported as the SERVICE'S
+    // report rather than asserted as an outcome this client verified. The
+    // hosted connector took the same correction on 2026-08-13
+    // (mnemoverse-mcp-remote#38); one number, one degree of confidence,
+    // whichever surface a model reaches it through.
     const noun = `${count} memor${count === 1 ? "y" : "ies"}`;
     const text =
       outcome > 0
-        ? `Recorded +${outcome} (helpful) for ${noun} — they should surface sooner next time.`
+        ? `Rating sent: +${outcome} (helpful). The service reports ${noun} updated — they should surface sooner next time.`
         : outcome < 0
-          ? `Recorded ${outcome} (unhelpful) for ${noun} — they should fade.`
+          ? `Rating sent: ${outcome} (unhelpful). The service reports ${noun} updated — they should fade.`
           // Zero claims only what is knowable from here: the rating was
           // recorded, and ±1 send a clear signal. Two earlier wordings each
           // asserted engine semantics that were false: "use +1/-1 when you want

--- a/test/handlers.test.ts
+++ b/test/handlers.test.ts
@@ -882,7 +882,10 @@ describe("the load-bearing sentences, as returned", () => {
 
     mcp.reset().on(FEEDBACK, { updated_count: 1 });
     const neutral = await mcp.callText("memory_feedback", { atom_ids: ["a"], outcome: 0 });
-    expect(neutral).toContain("Recorded 0 for 1 memory");
+    // 0.8.3 (#68): the count is attributed, not asserted — the zero branch
+    // had been left behind when the ±1 branches were corrected, and this pin
+    // was freezing the defect.
+    expect(neutral).toContain("Rating sent: 0. The service reports 1 memory updated");
     expect(neutral).toContain("Use +1 (helpful) or -1 (harmful/wrong) to express a clear direction.");
     // The engine keeps no neutral record: outcome 0 lands on the POSITIVE
     // branch of core's valence update and stores a positive-direction step

--- a/test/handlers.test.ts
+++ b/test/handlers.test.ts
@@ -706,6 +706,96 @@ describe("the load-bearing sentences, as returned", () => {
     expect(text).not.toContain("Filtered");
   });
 
+  it("a refused ROOM write does not repeat the personal-domain rule", async () => {
+    // core#482 (merged 2026-08-13) changed the gate for `xroom:` domains: a
+    // restatement — a briefing, a status, a decision summary — now STORES,
+    // because a room is a message bus and the second agent's job is to receive
+    // what the first was told. Only an indistinguishable write is refused
+    // there. The sentence this client printed said the opposite ("so a
+    // near-duplicate is refused") and became false the day that shipped, in
+    // exactly the case the change was made for.
+    mcp.on(WRITE, {
+      stored: false,
+      importance: 0,
+      reason:
+        "Refused as a duplicate: by embedding, this message is indistinguishable from one already in this room (novelty 0.000).",
+    });
+
+    const text = await mcp.callText("memory_write", {
+      content: "a restatement",
+      domain: "xroom:room_01ABC",
+    });
+
+    expect(text.startsWith("NOT STORED — nothing was saved.")).toBe(true);
+    // The room rule, not the personal-domain one.
+    expect(text).toContain("indistinguishable");
+    expect(text).not.toContain("a near-duplicate is refused");
+    // And the advice must not be "write the delta": in a room a restatement is
+    // legitimate, so the actionable fact is that this one read as identical.
+    expect(text).toContain("Restatements are allowed in rooms");
+  });
+
+  it("a refused PERSONAL-domain write keeps the near-duplicate rule", async () => {
+    // The personal-domain rule is unchanged and must stay stated: outside a
+    // room the gate does refuse near-duplicates.
+    mcp.on(WRITE, {
+      stored: false,
+      importance: 0.047,
+      reason: "Below importance threshold (0.047 < 0.1)",
+    });
+
+    const text = await mcp.callText("memory_write", {
+      content: "a near-duplicate",
+      domain: "engineering",
+    });
+
+    expect(text).toContain("a near-duplicate is refused");
+    expect(text).toContain("write what is DIFFERENT");
+    expect(text).not.toContain("Restatements are allowed in rooms");
+  });
+
+  it("the novelty score is labelled as the immature metric it is", async () => {
+    // The hosted connector says this (mnemoverse-mcp-remote#36, 2026-08-13);
+    // this server said nothing, so the same number carried two different
+    // degrees of honesty depending on which surface a model reached it
+    // through. Decision 2026-08-12 (Eduard): one surface, one truth.
+    mcp.on(WRITE, {
+      stored: false,
+      importance: 0.047,
+      reason: "Below importance threshold (0.047 < 0.1)",
+    });
+
+    const text = await mcp.callText("memory_write", { content: "x" });
+
+    expect(text).toContain("Novelty score 0.05");
+    expect(text).toMatch(/first-generation|under active development/);
+    expect(text).toContain("unreliable");
+    // The measurement that earns the warning, not an adjective on its own.
+    expect(text).toMatch(/0\.08.*Russian|Russian.*0\.08/);
+  });
+
+  it("attributes the rated count to the service instead of asserting it (#68)", async () => {
+    // `Recorded +1 for 3 memories` is true only while core runs
+    // feedback_async = False. Under async, core returns updated_count = the
+    // number of ids SUBMITTED, not applied (schemas.py:689-695) — a server-side
+    // config flip would silently turn this sentence false on every installed
+    // client, and nothing here can detect which mode ran. The same defect was
+    // fixed on the hosted connector on 2026-08-13
+    // (mnemoverse-mcp-remote#38); this is its twin.
+    mcp.on(FEEDBACK, { updated_count: 3 });
+
+    const text = await mcp.callText("memory_feedback", {
+      atom_ids: ["a", "b", "c"],
+      outcome: 1,
+    });
+
+    // The number is still reported — it is the only figure there is.
+    expect(text).toContain("3 memor");
+    // But as the service's report, not as a fact this client verified.
+    expect(text).toMatch(/reports|according to the service|service reports/i);
+    expect(text).not.toMatch(/^Recorded \+1 \(helpful\) for 3 memories —/);
+  });
+
   it("a filtered write with no reason and no score asserts neither", async () => {
     // A live surface answers {"stored":false} with no reason and no score.
     // Printing "0.00" there fabricates the gate's verdict.
@@ -781,8 +871,13 @@ describe("the load-bearing sentences, as returned", () => {
 
   it("recorded feedback echoes the DIRECTION, and claims no effect for neutral", async () => {
     mcp.on(FEEDBACK, { updated_count: 2 });
+    // Wording updated in 0.8.3 (#68): the count is now attributed to the
+    // service rather than asserted, because under core's async feedback path
+    // `updated_count` is the number of ids SUBMITTED and this client cannot
+    // tell which mode ran. Direction is still echoed, which is what this test
+    // is here to protect.
     expect(await mcp.callText("memory_feedback", { atom_ids: ["a"], outcome: 1 })).toBe(
-      "Recorded +1 (helpful) for 2 memories — they should surface sooner next time.",
+      "Rating sent: +1 (helpful). The service reports 2 memories updated — they should surface sooner next time.",
     );
 
     mcp.reset().on(FEEDBACK, { updated_count: 1 });


### PR DESCRIPTION
**Why this release exists.** 0.8.2 was tagged while #78, #80 and #82 were still open, so the published package and the registry manifest still carry a privacy URL that answers **307** and a `vault_list` description promising a tool that does not exist. All three fixes are on main now; this is what delivers them.

Verified against the published artefact rather than assumed: `git show v0.8.2:manifest.json` still reads `privacy.html`.

## What lands

| | |
|---|---|
| **privacy_policies** | `/privacy.html` (307) → `/privacy` (200), in the SSOT *and* the generated manifest |
| **README heading** | `## Privacy Policy` verbatim — what directory review looks for |
| **vault_list** | no longer promises "a tool that consumes it"; now states no tool here returns a secret value, which is stronger *and* true |
| **CODE_OF_CONDUCT.md** | Contributor Covenant 2.1, byte-identical to canon (an earlier draft was silently abridged) |
| **funding.json** | fundingjson.org v1.0.0, validated against the real schema |
| **.mcpbignore** | governance files no longer ride inside the bundle |

Nothing changes shape: no tool added, removed or renamed, no parameter touched. Per this repo's own patch policy, text-only changes about ourselves are a patch.

## Held back on purpose, recorded in the changelog

- `.github/FUNDING.yml` — lights up the Sponsor button on a public repo the moment it merges, and the tiers are not configured.
- `funding.json` `wellKnown` — cannot honestly be added while `mnemoverse.com/.well-known/funding-manifest-urls` returns 404.
- The **live server card** is served by `mnemoverse-mcp-remote`, not this repo — its `vault_list` wording is fixed in that repo's #41 and needs a deploy, not this publish.

## Gates

338 tests · manifest schema validates · `verify:configs` reports all 19 artifacts in sync · bundle repacked, root is exactly LICENSE / README / icon / manifest / package.json

## After merge

Tag `v0.8.3` to publish. **This time the tag goes after the PRs, not before** — that ordering is why 0.8.2 shipped stale.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ROOM-write refusal guidance and preserved duplicate-entry advice for personal domains.
  * Clarified novelty-score disclosures and service-reported feedback counts.
  * Updated valence and zero-result behavior.
  * Added 4-second time limits for honesty checks and empty-read requests.
* **Documentation**
  * Corrected privacy references, clarified `vault_list`, and added contributor and funding information.
* **Improvements**
  * Expanded distributed-bundle exclusions.
* **Release**
  * Updated the application and package version to 0.8.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->