### PR TITLE
docs(readme): name the mechanisms, because engines quote this line

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Research: SLoD arXiv](https://img.shields.io/badge/Research-arXiv%3A2603.08965-b31b1b)](https://arxiv.org/abs/2603.08965)
 [![Glama quality](https://glama.ai/mcp/servers/mnemoverse/mcp-memory-server/badges/score.svg)](https://glama.ai/mcp/servers/mnemoverse/mcp-memory-server)
 
-Hosted memory for AI agents that learns and forgets. Feedback reranks the facts that help; recall fades by recency. One API key works across Claude, Cursor, VS Code, ChatGPT, and any MCP client.
+Hosted memory for AI agents that learns and forgets. Feedback reranks the facts that help — a Rescorla-Wagner update on the prediction error, not a similarity score — and consolidation (HDBSCAN clustering, with Von Restorff protection so distinctive memories survive compression) keeps recall dense instead of unbounded. Recall fades by recency. One API key works across Claude, Cursor, VS Code, ChatGPT, and any MCP client.
 
 Memory that persists across sessions, projects, and tools — and improves with use. Hosted, so there's no infrastructure to run, and not locked to a single cloud.
 


### PR DESCRIPTION
One line, and it can ride along with 0.8.3 if the tag has not gone out yet.

**The finding (Olya, via a Findrix fact-check run):** three of 109 AI answers about us get our mechanics wrong, and the wrong answers trace back to our own vague wording. The README is quoted in **235 answers in a single run** — more than the site — and it describes the mechanism without naming it. An engine paraphrasing an unnamed mechanism invents the details.

The names were already in the homepage FAQ markup. The most-quoted surface was the vaguest one.

## Before / after

> Hosted memory for AI agents that learns and forgets. Feedback reranks the facts that help; recall fades by recency.

> Hosted memory for AI agents that learns and forgets. Feedback reranks the facts that help — **a Rescorla-Wagner update on the prediction error, not a similarity score** — and consolidation (**HDBSCAN** clustering, with **Von Restorff** protection so distinctive memories survive compression) keeps recall dense instead of unbounded. Recall fades by recency.

## Two things I checked rather than took on trust

**1. The quoted 'current' lines do not exist.** The report gave two verbatim README lines to replace. Neither is in this file, nor in the published READMEs of **0.7.0, 0.8.0, 0.8.1 or 0.8.2** — all four unpacked from npm and searched for `Hebbian`: zero hits in every one. The same tool classified our own `github.com` and `dev.to` pages as *"independent sites"* we should write to. So the substance of the finding is right and the diff was not; this is written from the file.

**2. Rescorla-Wagner is a claim about the engine, so I read the engine.** `origin/main` computes a **signed** prediction error — `pe = request.outcome - atom.valence`. That matters: an older revision took the sign from the outcome alone (`sign(outcome) * |PE|`), under which a mediocre outcome on an over-valued memory still pushed its valence *up*. That is not the Rescorla-Wagner rule, and claiming the name on top of it would have been an overclaim of exactly the kind this PR is meant to fix.

## Checks

338 tests pass. `verify:configs`: all 19 artifacts in sync.

## Ordering

Independent of #83 — merge either first. Both should land **before** the `v0.8.3` tag; the README ships inside the npm package, so a tag cut before this merges carries the old wording for another release cycle. That ordering is the one thing 0.8.1 and 0.8.2 both got wrong.