### PR TITLE
chore(readme): tag the two console links so the npm channel stops being invisible

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Memory that persists across sessions, projects, and tools — and improves with 
 
 ### 1. Get a free API key
 
-Sign up at [console.mnemoverse.com](https://console.mnemoverse.com) — takes 30 seconds, no credit card.
+Sign up at [console.mnemoverse.com](https://console.mnemoverse.com?utm_source=npm&utm_medium=readme&utm_campaign=mcp-memory-server) — takes 30 seconds, no credit card.
 
 ### 2. Connect to your AI tool
 
@@ -248,7 +248,7 @@ The same API key works across all tools. Write a memory in Claude Code — read 
 - [Cursor](https://mnemoverse.com/docs/api/cursor) · [VS Code](https://mnemoverse.com/docs/api/vs-code) · [Claude Code](https://mnemoverse.com/docs/api/claude) · [ChatGPT](https://mnemoverse.com/docs/api/chatgpt)
 - [Python SDK](https://mnemoverse.com/docs/api/python-sdk)
 - [API Reference](https://mnemoverse.com/docs/api/reference)
-- [Console (get API key)](https://console.mnemoverse.com)
+- [Console (get API key)](https://console.mnemoverse.com?utm_source=npm&utm_medium=readme&utm_campaign=mcp-memory-server)
 
 **Background reading**
 


### PR DESCRIPTION
Two lines, requested by Olya's analyst in the shared room.

**She could not do it herself** and said so plainly: the `OlyaTi` account has `push: false` on this repository, and the fork route is blocked because her token lacks the `workflow` scope that `.github/workflows/release.yml` forces GitHub to check — it refuses even a fork sync. Worth a decision separately: either write access here, or a token with that scope, so this class of thirty-second fix stops needing a relay.

## Why these two links specifically

The README **is** the npm package page, and **npm returns no referrers at all**. These two links are the only part of that channel we can attribute today.

Everything else needs MCP `clientInfo` at first handshake — layer 4 of the attribution spec — because most of this traffic never touches a web page: an assistant prints the `npx` command and the user runs it.

That the channel is real is measured, not assumed: `npmjs.com` itself is cited in **149 AI answers across 25 prompts** in our niche, so the assistant hands someone an install command and they land on the package page.

## Scope

| | |
|---|---|
| Line 20 | sign-up link → tagged |
| Line 251 | "Console (get API key)" → tagged |
| Everything else | untouched |

Tag: `utm_source=npm&utm_medium=readme&utm_campaign=mcp-memory-server`.

**These reach the world only on the next publish** — npm refreshes a README when a version ships, not when main changes.

## Checks

342 tests. `verify:configs` green, 19 artifacts in sync.

One trap recorded for whoever edits this file next: the install-snippet block (lines 24–177) is generated, and rewriting the file with CRLF line endings fails `verify:configs` **even when the region's content is byte-identical**. My first attempt did exactly that and the failure message points at the region, not at the line endings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated console signup and API-key links with npm README tracking parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->