### PR TITLE
chore(readme): UTM labels on the two console links (npm page)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Memory that persists across sessions, projects, and tools — and improves with 
 
 ### 1. Get a free API key
 
-Sign up at [console.mnemoverse.com](https://console.mnemoverse.com) — takes 30 seconds, no credit card.
+Sign up at [console.mnemoverse.com](https://console.mnemoverse.com?utm_source=npm&utm_medium=readme&utm_campaign=mcp-memory-server) — takes 30 seconds, no credit card.
 
 ### 2. Connect to your AI tool
 
@@ -248,7 +248,7 @@ The same API key works across all tools. Write a memory in Claude Code — read 
 - [Cursor](https://mnemoverse.com/docs/api/cursor) · [VS Code](https://mnemoverse.com/docs/api/vs-code) · [Claude Code](https://mnemoverse.com/docs/api/claude) · [ChatGPT](https://mnemoverse.com/docs/api/chatgpt)
 - [Python SDK](https://mnemoverse.com/docs/api/python-sdk)
 - [API Reference](https://mnemoverse.com/docs/api/reference)
-- [Console (get API key)](https://console.mnemoverse.com)
+- [Console (get API key)](https://console.mnemoverse.com?utm_source=npm&utm_medium=readme&utm_campaign=mcp-memory-server)
 
 **Background reading**
 


### PR DESCRIPTION
The package README **is** the npm page, and its two `console.mnemoverse.com` links carried no marks — the most unlabeled surface of the whole campaign, per Olya's npm channel analysis (`mnemoverse-distribution` → `research/npm-channel-analysis-2026-08-15.md`, commit 0c852ff).

Labels: `?utm_source=npm&utm_medium=readme&utm_campaign=mcp-memory-server`

Note: npm refreshes the README only on publish, so the labels reach npmjs.com with the next release (releases are frequent — 22 versions in four months).

Two-line diff, README only; `src/` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated console links in the README with UTM tracking parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->