### PR TITLE
docs(readme): stop claiming a decay the ranking does not have

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Sign up at [console.mnemoverse.com](https://console.mnemoverse.com?utm_source=np
 **Claude Code** — add via CLI:
 
 ```bash
-claude mcp add mnemoverse \
+claude mcp add mnemoverse -s user \
   -e MNEMOVERSE_API_KEY=mk_live_YOUR_KEY \
   -e MNEMOVERSE_API_URL=https://core.mnemoverse.com/api/v1 \
   -- npx -y @mnemoverse/mcp-memory-server@latest

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Research: SLoD arXiv](https://img.shields.io/badge/Research-arXiv%3A2603.08965-b31b1b)](https://arxiv.org/abs/2603.08965)
 [![Glama quality](https://glama.ai/mcp/servers/mnemoverse/mcp-memory-server/badges/score.svg)](https://glama.ai/mcp/servers/mnemoverse/mcp-memory-server)
 
-Hosted memory for AI agents that learns and forgets. Feedback reranks the facts that help — a Rescorla-Wagner update on the prediction error, not a similarity score — and consolidation (HDBSCAN clustering, with Von Restorff protection so distinctive memories survive compression) keeps recall dense instead of unbounded. Recall fades by recency. One API key works across Claude, Cursor, VS Code, ChatGPT, and any MCP client.
+Hosted memory for AI agents that learns which facts matter. Feedback reranks recall — a Rescorla-Wagner update on the prediction error, not a similarity score — so what helped rises and what misled sinks. The engine also ships consolidation (HDBSCAN clustering, with Von Restorff protection so distinctive memories survive compression). One API key works across Claude, Cursor, VS Code, ChatGPT, and any MCP client.
 
 Memory that persists across sessions, projects, and tools — and improves with use. Hosted, so there's no infrastructure to run, and not locked to a single cloud.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Research: SLoD arXiv](https://img.shields.io/badge/Research-arXiv%3A2603.08965-b31b1b)](https://arxiv.org/abs/2603.08965)
 [![Glama quality](https://glama.ai/mcp/servers/mnemoverse/mcp-memory-server/badges/score.svg)](https://glama.ai/mcp/servers/mnemoverse/mcp-memory-server)
 
-Hosted memory for AI agents that learns which facts matter. Feedback reranks recall — a Rescorla-Wagner update on the prediction error, not a similarity score — so what helped rises and what misled sinks. The engine also ships consolidation (HDBSCAN clustering, with Von Restorff protection so distinctive memories survive compression). One API key works across Claude, Cursor, VS Code, ChatGPT, and any MCP client.
+Hosted memory for AI agents that learns which facts matter. Feedback reranks recall — a Rescorla-Wagner update on the prediction error, not a similarity score — so what helped rises and what misled sinks, and recall favors recent memories (an exponential recency boost with a ~30-day half-life). The engine also ships consolidation (HDBSCAN clustering, with Von Restorff protection so distinctive memories survive compression). One API key works across Claude, Cursor, VS Code, ChatGPT, and any MCP client.
 
 Memory that persists across sessions, projects, and tools — and improves with use. Hosted, so there's no infrastructure to run, and not locked to a single cloud.
 

--- a/docs/configs/claude-code-cli.sh
+++ b/docs/configs/claude-code-cli.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-claude mcp add mnemoverse \
+claude mcp add mnemoverse -s user \
   -e MNEMOVERSE_API_KEY=mk_live_YOUR_KEY \
   -e MNEMOVERSE_API_URL=https://core.mnemoverse.com/api/v1 \
   -- npx -y @mnemoverse/mcp-memory-server@latest

--- a/docs/snippets/claude-code.md
+++ b/docs/snippets/claude-code.md
@@ -3,7 +3,7 @@
 **Claude Code** — add via CLI:
 
 ```bash
-claude mcp add mnemoverse \
+claude mcp add mnemoverse -s user \
   -e MNEMOVERSE_API_KEY=mk_live_YOUR_KEY \
   -e MNEMOVERSE_API_URL=https://core.mnemoverse.com/api/v1 \
   -- npx -y @mnemoverse/mcp-memory-server@latest

--- a/scripts/generate-configs.mjs
+++ b/scripts/generate-configs.mjs
@@ -180,15 +180,11 @@ function genVscodeDeepLink() {
  *
  * Format: claude mcp add NAME -s user -e KEY=VAL ... -- command args...
  *
- * `-s user` is LOAD-BEARING, not styling. Claude Code's default scope is
- * `local` — the server is registered for the current project directory only.
- * Under that default a user installs memory in one repo, opens another, and
- * the memory is silently gone: no error, the tools just are not there. That
- * is the exact opposite of the one thing this product sells (one memory
- * across everything), and it shipped in every install snippet until
- * 2026-08-16, when Olya's assistant caught it while filming the setup for
- * the tutorial video. The user scope registers the server once for every
- * project.
+ * `-s user` is LOAD-BEARING: the CLI's default scope is `local`, which
+ * registers the server for the current project directory only — memory
+ * installed in one repo is silently absent in the next, the opposite of
+ * cross-tool memory. The user scope registers it once for every project.
+ * (History of how this shipped without the flag: git log on this function.)
  */
 function genClaudeCodeCli() {
   const envFlags = Object.entries(ENV_VALUES)

--- a/scripts/generate-configs.mjs
+++ b/scripts/generate-configs.mjs
@@ -178,13 +178,23 @@ function genVscodeDeepLink() {
 /**
  * Claude Code CLI command.
  *
- * Format: claude mcp add NAME -e KEY=VAL ... -- command args...
+ * Format: claude mcp add NAME -s user -e KEY=VAL ... -- command args...
+ *
+ * `-s user` is LOAD-BEARING, not styling. Claude Code's default scope is
+ * `local` — the server is registered for the current project directory only.
+ * Under that default a user installs memory in one repo, opens another, and
+ * the memory is silently gone: no error, the tools just are not there. That
+ * is the exact opposite of the one thing this product sells (one memory
+ * across everything), and it shipped in every install snippet until
+ * 2026-08-16, when Olya's assistant caught it while filming the setup for
+ * the tutorial video. The user scope registers the server once for every
+ * project.
  */
 function genClaudeCodeCli() {
   const envFlags = Object.entries(ENV_VALUES)
     .map(([k, v]) => `  -e ${k}=${v}`)
     .join(" \\\n");
-  return `claude mcp add ${source.name} \\\n${envFlags} \\\n  -- ${source.command} ${source.args.join(" ")}\n`;
+  return `claude mcp add ${source.name} -s user \\\n${envFlags} \\\n  -- ${source.command} ${source.args.join(" ")}\n`;
 }
 
 // NOTE: genSmitheryYaml() was removed on 2026-04-12 after an empirical


### PR DESCRIPTION
Found by Olya's assistant fact-checking the video script against the published 0.8.3 package — three surfaces told two stories.

## The false claim

**"Recall fades by recency"** — the ranking has no temporal term. Not in the docs (`/docs/api/overview` lists Hebbian expansion → valence ranking, no time), not in the engine, and the project record states the recency gap outright. The sentence survived because it sounds like something a memory system ought to do.

## The oversold one

Consolidation was phrased as what "keeps recall dense" — while `/docs/api/overview` says plainly it is **switched off on the hosted service**. It is real in the engine, so it is now described as shipped in the engine — not as the thing doing daily work for hosted users.

## What stays, verbatim true

Rescorla-Wagner reranking (verified against the engine two days ago — signed prediction error) — and it is the stronger sentence anyway. The `memory_read` row's "optional recency ordering" stays: that option exists; sorting by recency is not decaying by it.

Eduard's call on the fork ("README describes what works, or the product catches up to the README"): README describes what works. If a recency term ships later, the line comes back as fact, not aspiration.

342 tests, `verify:configs` green (19 artifacts in sync). Reaches npm on the next publish.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified prediction-error feedback reranking, approximately 30-day recency decay, and consolidation behavior.
  * Updated Claude Code setup instructions to register the MCP server at user scope.

* **Chores**
  * Updated generated Claude Code commands and snippets to consistently use user-level configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->