### PR TITLE
release: 0.8.4 — the wrong-key silence, and the words that reach npm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,44 @@ git history and the GitHub releases are the record.
 
 ## [Unreleased]
 
+## [0.8.4] — 2026-08-16
+
+A patch under this file's own rules: one read-only probe (declared below, as
+the rules require), and text — the README the npm page renders.
+
+### Fixed
+
+- **A wrong API key now says so at startup, where the user looks.** Verified
+  live on 0.8.3: with a garbage key the server completed `initialize`, listed
+  all twelve tools, and wrote nothing to stderr — the 401 only surfaced
+  mid-conversation, on the first real tool call. A green connection followed
+  by silent failure reads as "the product does not work". Now, if a key is
+  configured, one read-only `GET /memory/stats` runs in the background AFTER
+  connect: 401/403 puts one human sentence on stderr naming
+  `MNEMOVERSE_API_KEY`; other HTTP failures get a soft note that says nothing
+  about the key; network errors stay silent (flaky wifi must not cry wolf);
+  a valid key keeps startup quiet. The probe never blocks and never exits —
+  keyless startup remains exactly as documented for registries. All three
+  paths verified by running the built server.
+- **README no longer claims a decay the ranking does not have.** "Recall
+  fades by recency" was first deleted as false, then restored in precise
+  form after an adversarial check proved the engine ships an always-on
+  exponential recency boost (weight 0.15, ~30-day half-life): "recall favors
+  recent memories". Consolidation is now described as shipping in the engine
+  rather than as what keeps hosted recall dense — on the hosted service it
+  is switched off.
+- **`claude mcp add` snippets now carry `-s user`.** The CLI's default scope
+  registers the server for the current project directory only, so memory
+  installed in one repo was silently absent in the next — the opposite of
+  cross-tool memory, in every install snippet we published. Fixed in the
+  generator, so README and all channel snippets changed together.
+
+### Changed
+
+- The two console links in the README carry UTM tags
+  (`utm_source=npm&utm_medium=readme&utm_campaign=mcp-memory-server`) — npm
+  strips referrers, so these links are the only attribution that channel has.
+
 ## [0.8.3] — 2026-08-14
 
 Three claims about ourselves that were not true, all found by review rather

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "mnemoverse-memory",
   "display_name": "Mnemoverse Memory",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Hosted memory for AI agents that learns and forgets — one key across Claude, Cursor & ChatGPT.",
   "long_description": "Mnemoverse gives your AI assistant long-term memory that persists across sessions and across tools. Store preferences, decisions, and lessons with memory_write; recall them by natural-language search with memory_read. The same memory is shared everywhere you use your Mnemoverse API key — Claude, Cursor, VS Code, and any MCP client. Requires a free API key from https://console.mnemoverse.com.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mnemoverse/mcp-memory-server",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mnemoverse/mcp-memory-server",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mnemoverse/mcp-memory-server",
-  "version": "0.8.3",
-  "description": "Hosted persistent memory for AI agents that learns which facts help and lets the rest fade — one key across Claude Code, Cursor, VS Code & ChatGPT, no infra to run",
+  "version": "0.8.4",
+  "description": "Hosted persistent memory for AI agents that learns which facts help and lets the rest fade \u2014 one key across Claude Code, Cursor, VS Code & ChatGPT, no infra to run",
   "type": "module",
   "bin": {
     "mcp-memory-server": "./dist/index.js"

--- a/server.json
+++ b/server.json
@@ -9,12 +9,12 @@
     "source": "github",
     "id": "1207193530"
   },
-  "version": "0.8.3",
+  "version": "0.8.4",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mnemoverse/mcp-memory-server",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
**A patch by this repo's own changelog rules** — they state a patch may add a read-only probe and must declare it; declared.

## What ships

| | |
|---|---|
| **Startup key probe** (#91) | a wrong key speaks at connect time on stderr; valid key stays quiet; keyless startup unchanged (registries). All three paths verified against the built server |
| **Honest README mechanisms** (#90) | recency restored in PRECISE form after the adversarial check proved the boost real (0.15, ~30d half-life); consolidation described as in-engine, not as hosted behaviour |
| **`-s user` in every install snippet** (#90) | default scope stranded memory in one project directory — fixed at the generator, README + all channel snippets together |
| **UTM on the two console links** (#88) | npm strips referrers; these links are that channel's only attribution — they reach the world with this publish |

## Why publish now

Everything above is already on main but **invisible until a version ships**: npm refreshes the README only on publish, and the probe only helps users who install a version containing it. Olya's five-client screenshot instructions and tomorrow's tutorial video both teach the `-s user` command — publishing first means the package matches what the materials show.

## After merge

Tag `v0.8.4` → release.yml publishes to npm + updates the MCP registry. Merge before tag — the ordering that kept 0.8.3 honest.

342 tests · verify:configs green (19 artifacts) · manifest schema validates.