### PR TITLE
refactor!: remove memory_delete and memory_delete_domain — deletion is administrative-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,48 @@ git history and the GitHub releases are the record.
 
 ## [Unreleased]
 
+## [0.9.0] — 2026-08-20
+
+A MINOR bump under this file's own rule: SHAPE changes — two tools removed —
+so this cannot be a patch, and the project is pre-1.0 so a MINOR bump is
+where a breaking change belongs.
+
+### Removed
+
+- **`memory_delete` and `memory_delete_domain`** — both tools removed
+  entirely: registration, handlers, input schemas, descriptions, and their
+  entries in `src/configs/source.json` (and the manifest.json/llms.txt/README
+  surfaces generated or written from it). Deletion is withdrawn from this
+  agent-facing surface to an administrative, REST-only operation.
+  Why: a core delete path destroyed learned Hebbian associations
+  tenant-wide (56,683 edges across 14 tenants in the logged incident
+  window); the remote MCP connector already excludes delete by design
+  (ADR-012); this npm package was the last agent-facing surface still
+  exposing it. Founder decision, 2026-08-20.
+
+### Changed
+
+- **Every remaining surface that referenced deletion now points at a
+  corrective write instead.** `memory_read`'s description no longer sends
+  callers to `memory_delete`; `memory_stats`'s description no longer says
+  "before a delete" (now "before writing to it"); the server instructions
+  (`SERVER_INSTRUCTIONS`) no longer mention either removed tool and instead
+  say: to correct a wrong or stale memory, write a fresh one — deletion is
+  an administrative operation, not a tool here.
+
+### Migration
+
+- The REST API's `DELETE /memory/atoms/{id}` and `DELETE /memory/domain/{domain}`
+  are unaffected and remain the way to delete, for administrative use.
+- To correct a wrong or stale memory from an MCP client, write a fresh one
+  with `memory_write` rather than deleting the old one. A non-destructive
+  write primitive that marks a memory as superseding an older one is
+  planned to replace the delete-for-update lifecycle; no date is promised
+  here, and no such tool exists yet.
+- If your integration calls `memory_delete` or `memory_delete_domain`
+  directly, those calls will fail against 0.9.0 — there is no compatibility
+  shim.
+
 ## [0.8.4] — 2026-08-16
 
 A patch under this file's own rules: one read-only probe (declared below, as

--- a/README.md
+++ b/README.md
@@ -203,8 +203,6 @@ If it doesn't remember: check that the client was fully restarted and the config
 | `memory_list_recent` | List newest memories first — no query; `since`/`until` bounds (inclusive) + cursor paging |
 | `memory_feedback` | Rate memories as helpful or not (improves future recall) |
 | `memory_stats` | Check how many memories stored, which domains exist |
-| `memory_delete` | Permanently delete a single memory by `atom_id` |
-| `memory_delete_domain` | Wipe an entire domain (requires `confirm: true` safety interlock) |
 | `memory_create_room` | Create a shared memory room; its address works as a `domain` on write/read |
 | `memory_invite_to_room` | Mint a one-time invite (code + link) for a room you own |
 | `memory_join_room` | Join a shared room with an invite code (`mnvr_...`) |
@@ -277,7 +275,6 @@ What each tool sends:
 | `memory_read` | the `query`, plus any filters: `domain`, `since`/`until`, `exclude_author`, `top_k`, `order_by` |
 | `memory_list_recent` | the feed filters: `domain`, `since`/`until`, `exclude_author`, `limit`, `cursor` |
 | `memory_feedback` | the `atom_ids` being rated and the `outcome` score |
-| `memory_delete` / `memory_delete_domain` | the `atom_id` / `domain` being deleted |
 | `memory_create_room` | the room `name` and `description` |
 | `memory_invite_to_room` | the `room_id`, invite `scope`, and expiry |
 | `memory_join_room` | the invite `code` |
@@ -288,7 +285,7 @@ One thing goes out that you did not explicitly request: since 0.8.1, when a sear
 | | |
 |---|---|
 | **Privacy Policy** | <https://mnemoverse.com/privacy> |
-| **Retention & deletion** | delete one memory with `memory_delete`, or an entire namespace with `memory_delete_domain` |
+| **Retention & deletion** | correct a wrong or stale memory by writing a fresh one; deletion is an administrative operation on the REST API, not exposed through this MCP server |
 | **Contact** | hello@mnemoverse.com |
 
 ## License

--- a/llms.txt
+++ b/llms.txt
@@ -25,7 +25,7 @@ Parameters:
 - since / until (ISO-8601 strings, optional): inclusive created_at bounds; naive = UTC.
 - exclude_author (string, optional): drop memories written by this author principal. Results never show a principal, so only pass one known from elsewhere (e.g. the REST API); a guess like "me" silently filters nothing.
 
-Returns: List of memories ranked best-match-first (no numeric score is shown) with content, concepts, domain, author tag, created_at, and id (pass ids to memory_feedback / memory_delete).
+Returns: List of memories ranked best-match-first (no numeric score is shown) with content, concepts, domain, author tag, created_at, and id (pass ids to memory_feedback). To correct a wrong or stale memory, write a fresh one with memory_write — deletion is an administrative operation, not available through this server.
 
 ### memory_list_recent
 
@@ -56,23 +56,6 @@ Get memory statistics — total count, episodes vs prototypes, Hebbian concept-c
 Parameters: none
 
 Returns: {total_atoms, episodes, prototypes, hebbian_edges, domains, avg_valence, avg_importance}
-
-### memory_delete
-Permanently delete ONE memory by its atom_id — irreversible. Reaches your own domains only: memories in shared rooms cannot be deleted through this tool.
-
-Parameters:
-- atom_id (string, required): The atom_id of the memory to delete (from memory_read results — each item has an id).
-
-Returns: Confirmation of the delete, or a note that nothing was deleted.
-
-### memory_delete_domain
-Permanently delete EVERY memory in one domain — an irreversible bulk wipe. Names match byte-for-byte, including case; shared rooms cannot be wiped through this tool.
-
-Parameters:
-- domain (string, required): The domain namespace to wipe. Must match exactly.
-- confirm (boolean, required): Must be exactly true — a deliberate safety interlock.
-
-Returns: The deleted count, or a note that nothing matched.
 
 ### memory_create_room
 Create a SHARED memory room — a space other people's assistants can read, and write too when their invite granted read_write (the default scope). Pass the returned address as the domain on memory_write/memory_read to use it.

--- a/manifest.json
+++ b/manifest.json
@@ -63,14 +63,6 @@
       "description": "Show how many memories are stored, which domains exist, and the average valence and importance scores."
     },
     {
-      "name": "memory_delete",
-      "description": "Permanently delete a single memory by its atom_id."
-    },
-    {
-      "name": "memory_delete_domain",
-      "description": "Permanently delete every memory in a domain (requires an explicit confirm)."
-    },
-    {
       "name": "memory_create_room",
       "description": "Create a shared memory room — a space other people's assistants can read, and write too when invited with read_write scope, across Claude/ChatGPT/editors."
     },

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "mnemoverse-memory",
   "display_name": "Mnemoverse Memory",
-  "version": "0.8.4",
+  "version": "0.9.0",
   "description": "Hosted memory for AI agents that learns and forgets — one key across Claude, Cursor & ChatGPT.",
   "long_description": "Mnemoverse gives your AI assistant long-term memory that persists across sessions and across tools. Store preferences, decisions, and lessons with memory_write; recall them by natural-language search with memory_read. The same memory is shared everywhere you use your Mnemoverse API key — Claude, Cursor, VS Code, and any MCP client. Requires a free API key from https://console.mnemoverse.com.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mnemoverse/mcp-memory-server",
-  "version": "0.8.4",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mnemoverse/mcp-memory-server",
-      "version": "0.8.4",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mnemoverse/mcp-memory-server",
-  "version": "0.8.4",
+  "version": "0.9.0",
   "description": "Hosted persistent memory for AI agents that learns which facts help and lets the rest fade \u2014 one key across Claude Code, Cursor, VS Code & ChatGPT, no infra to run",
   "type": "module",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -9,12 +9,12 @@
     "source": "github",
     "id": "1207193530"
   },
-  "version": "0.8.4",
+  "version": "0.9.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mnemoverse/mcp-memory-server",
-      "version": "0.8.4",
+      "version": "0.9.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/configs/source.json
+++ b/src/configs/source.json
@@ -104,14 +104,6 @@
         "description": "Show how many memories are stored, which domains exist, and the average valence and importance scores."
       },
       {
-        "name": "memory_delete",
-        "description": "Permanently delete a single memory by its atom_id."
-      },
-      {
-        "name": "memory_delete_domain",
-        "description": "Permanently delete every memory in a domain (requires an explicit confirm)."
-      },
-      {
         "name": "memory_create_room",
         "description": "Create a shared memory room — a space other people's assistants can read, and write too when invited with read_write scope, across Claude/ChatGPT/editors."
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -330,15 +330,18 @@ server.registerTool(
     //      left the caller in 0.8.0 would leave the account in 0.8.1. The
     //      address in that shape is one our own output hands the model.
     //   2. For a caller who has been padding a domain for months, trimming
-    //      silently relocates new writes and orphans the old corpus — and
-    //      memory_delete_domain does NOT trim, so the same client can no
-    //      longer even name the shard it created.
+    //      silently relocates new writes and orphans the old corpus, and (at
+    //      the time this was written) memory_delete_domain did NOT trim, so
+    //      the same client could no longer even name the shard it created —
+    //      that tool was withdrawn to an administrative REST-only operation
+    //      on 2026-08-20, so this specific consequence no longer applies, but
+    //      the orphaned-corpus risk from silently relocating writes does.
     //
     // Both are behaviour changes, so they do not belong in a patch whose
-    // whole claim is that it only changes wording. Normalisation returns in
-    // 0.9.0 with delete_domain included, room addresses deliberately EXEMPT,
-    // and zero-width characters handled (JS trim() does not strip them —
-    // verified, contrary to what an earlier comment here asserted).
+    // whole claim is that it only changes wording. Normalisation, if it ever
+    // returns, needs room addresses deliberately EXEMPT and zero-width
+    // characters handled (JS trim() does not strip them — verified, contrary
+    // to what an earlier comment here asserted).
     const r = await apiFetch<{
       stored?: boolean;
       atom_id?: string | null;
@@ -423,10 +426,11 @@ server.registerTool(
           // score the same or lower" was asserted as fact and is probably
           // BACKWARDS — novelty decreases with similarity to the blocking
           // memory, so a reworded sentence is usually LESS similar and scores
-          // HIGHER. And the delete-then-write advice an earlier draft carried is
-          // impossible for a room write: the blocker is a room atom, which
-          // memory_delete cannot touch, as this file's own delete message says
-          // (reviews, 2026-08-08).
+          // HIGHER. And delete-then-write advice an earlier draft carried was
+          // impossible for a room write even when memory_delete still existed:
+          // the blocker is a room atom, which that tool could not touch either
+          // (reviews, 2026-08-08). Deletion is administrative-only now
+          // (2026-08-20), so this message never suggests it at all.
           text:
             `NOT STORED — nothing was saved.` +
             (reasonQuote ? ` Server reason: ${reasonQuote}.` : ``) +
@@ -464,7 +468,7 @@ server.registerTool(
   "memory_read",
   {
     description:
-      "Search your long-term memory before answering anything that may have come up before — user preferences, past decisions, project setup, people, or earlier context. This memory is shared: it persists across sessions and across every AI tool the user has connected (Claude, ChatGPT, Cursor, VS Code). ALWAYS check here first when you're unsure whether you already know something; no need to call it for general world knowledge you already hold. Returns matches ranked by relevance (or newest-first with order_by: 'recency'); each result carries an id you can pass to memory_feedback or memory_delete.",
+      "Search your long-term memory before answering anything that may have come up before — user preferences, past decisions, project setup, people, or earlier context. This memory is shared: it persists across sessions and across every AI tool the user has connected (Claude, ChatGPT, Cursor, VS Code). ALWAYS check here first when you're unsure whether you already know something; no need to call it for general world knowledge you already hold. Returns matches ranked by relevance (or newest-first with order_by: 'recency'); each result carries an id you can pass to memory_feedback. A wrong or stale memory is corrected by writing a fresh one with memory_write, not by deleting it.",
     inputSchema: {
       query: z
         .string()
@@ -1019,7 +1023,7 @@ server.registerTool(
   "memory_stats",
   {
     description:
-      "Get an overview of the stored memory: total count, episodes vs consolidated prototypes, number of learned associations, the list of domains, and average quality scores. This memory is shared across all AI tools the user has connected to Mnemoverse. Use it to orient yourself, to confirm the exact domain name before a delete, or when the user asks what you remember. Read-only — changes nothing.",
+      "Get an overview of the stored memory: total count, episodes vs consolidated prototypes, number of learned associations, the list of domains, and average quality scores. This memory is shared across all AI tools the user has connected to Mnemoverse. Use it to orient yourself, to confirm the exact domain name before writing to it, or when the user asks what you remember. Read-only — changes nothing.",
     inputSchema: {},
     annotations: {
       title: "Memory Statistics",
@@ -1047,9 +1051,11 @@ server.registerTool(
     const num = (v: unknown) => (typeof v === "number" ? String(v) : "unknown");
     const dec = (v: unknown) => (typeof v === "number" ? v.toFixed(2) : "unknown");
 
-    // THE surface two other tool descriptions send the reader to "to confirm
-    // the exact domain name before a delete" — so it has to be able to answer
-    // that, and until now it could not.
+    // THE surface this tool's own description sends the reader to, to
+    // confirm the exact domain name before writing to it — so it has to be
+    // able to answer that. (Until 2026-08-20 memory_delete_domain also sent
+    // readers here for the same reason, before deletion was withdrawn to an
+    // administrative REST-only operation; see CHANGELOG.)
     //
     // Quoting was tried, then withdrawn as a fix that wasn't one: safeInline
     // collapses and trims whitespace BEFORE the quotes go on, so " engineering"
@@ -1091,184 +1097,6 @@ server.registerTool(
           text: withDomainEscapeLegend(
             text,
             ...(Array.isArray(r?.domains) ? r.domains : []),
-          ),
-        },
-      ],
-    };
-  },
-);
-
-// --- Tool: memory_delete ---
-
-server.registerTool(
-  "memory_delete",
-  {
-    description:
-      "Permanently delete ONE memory by its atom_id — irreversible, the memory is gone for good. Use it to keep the memory trustworthy: prune a memory that is obsolete, superseded by a newer decision, or that you stored wrongly — and whenever the user asks to forget something. Get the atom_id from a memory_read result. Reaches your own domains only: memories in shared rooms CANNOT be deleted through this tool. To clear an entire topic at once, use memory_delete_domain instead.",
-    inputSchema: {
-      atom_id: z
-        .string()
-        .min(1)
-        .describe(
-          "The atom_id of the memory to delete (from memory_read results — each item has an id)",
-        ),
-    },
-    annotations: {
-      title: "Delete a Memory",
-      readOnlyHint: false,
-      destructiveHint: true,
-      idempotentHint: true,
-      openWorldHint: true,
-    },
-  },
-  async ({ atom_id }) => {
-    // Core API returns { deleted: <count>, atom_id }, so today a falsy
-    // `deleted` means the count came back 0 — nothing in the caller's own store
-    // carried that id.
-    //
-    // The check below is `!r?.deleted`, which is falsy-not-zero: a MISSING
-    // field lands in the same branch as a real 0. `apiFetch` turns a 204 or an
-    // empty body into `{}` (see its own note that FastAPI DELETE handlers may
-    // switch to 204), so under that response a successful delete would report
-    // "nothing was deleted". Unknown rendered as zero, then zero rendered as an
-    // absence claim — the same family as `updated_count ?? 0` in
-    // memory_feedback and `deleted ?? 0` in memory_delete_domain. Left as it
-    // stands and listed in CHANGELOG's "Known and NOT fixed here"; it is a
-    // behaviour fix, not a wording one.
-    const r = await apiFetch<{ deleted?: number; atom_id?: string }>(
-      `/memory/atoms/${encodeURIComponent(atom_id)}`,
-      { method: "DELETE" },
-    );
-
-    if (!r?.deleted) {
-      // NOT "no such memory". Deletion is scoped to the caller's OWN store —
-      // core has no room-scoped delete at all — so a room atom's id lands here
-      // even when the memory lives on in its room. This release made room ids
-      // MORE visible in read results, so an agent is now MORE likely to bring
-      // one here, ask to forget it, and be told it never existed while it stays
-      // (review, 2026-08-08). Every other empty branch in this file learned to
-      // state its boundary; the destructive one has to as well.
-      //
-      // The boundary claim is the ONLY claim: "this delete never reached it"
-      // is knowable from here (room stores are out of this tool's reach by
-      // construction). "it still exists" — a previous wording — is not: the
-      // room owner may have deleted it since, and this handler has no way to
-      // check (review, 2026-08-08).
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text:
-              `Nothing was deleted: no memory with id ${atom_id} in your own domains. ` +
-              `Note that memories in shared rooms CANNOT be deleted through this tool — ` +
-              `if that id came from a room, this delete never reached it.`,
-          },
-        ],
-      };
-    }
-
-    return {
-      content: [
-        {
-          type: "text" as const,
-          text: `Deleted memory ${atom_id}.`,
-        },
-      ],
-    };
-  },
-);
-
-// --- Tool: memory_delete_domain ---
-
-server.registerTool(
-  "memory_delete_domain",
-  {
-    description:
-      "Permanently delete EVERY memory in one domain — irreversible, and far more sweeping than memory_delete. This is a bulk wipe: run it only when the user asks for it (e.g. 'forget everything about project X') or has explicitly confirmed a wipe you proposed — never on your own judgment alone. First run memory_stats to confirm the exact domain name, then pass it together with confirm=true (a deliberate safety interlock). Names match byte-for-byte, including case, and shared rooms cannot be wiped through this tool. For a single wrong or stale memory, memory_delete is the right tool.",
-    inputSchema: {
-      domain: z
-        .string()
-        .min(1)
-        .max(200)
-        .describe(
-          "The domain namespace to wipe (e.g., 'project:old', 'experiments-2025'). Must match exactly.",
-        ),
-      confirm: z
-        .literal(true)
-        .describe(
-          "Must be exactly true to proceed. Acts as a safety interlock against accidental invocation.",
-        ),
-    },
-    annotations: {
-      title: "Delete an Entire Memory Domain",
-      readOnlyHint: false,
-      destructiveHint: true,
-      idempotentHint: true,
-      openWorldHint: true,
-    },
-  },
-  // The `confirm: z.literal(true)` in the input schema is the safety
-  // interlock — Zod rejects any call without confirm === true before it
-  // reaches this handler, so no runtime re-check is needed here.
-  async ({ domain }) => {
-    const r = await apiFetch<{ deleted?: number; domain?: string }>(
-      `/memory/domain/${encodeURIComponent(domain)}`,
-      { method: "DELETE" },
-    );
-
-    // `?? 0` again: a missing `deleted` field becomes 0 and then becomes the
-    // "NOTHING was deleted" claim below. Core sends the count, so this is not
-    // reachable through core today — recorded with the other two in CHANGELOG's
-    // "Known and NOT fixed here".
-    const count = r?.deleted ?? 0;
-    // The name of a store on a DESTRUCTIVE confirmation, so it is printed
-    // exactly or not at all. safeInline named a different store than the one
-    // acted on: wiping `" project x"` confirmed `"project x"`, and the very next
-    // clause tells the reader that names match byte-for-byte. When the name
-    // cannot be reproduced the sentences fall back to naming nothing, which
-    // still leaves them true.
-    //
-    // NOT called `wiped`, which is what it was: on the zero branch nothing was
-    // wiped, and the value is whatever the server echoed — core echoes the path
-    // parameter back, so it equals what we sent, but a server that echoed
-    // something else would have this handler name a store the caller never
-    // passed, one clause before telling them names match byte-for-byte. The
-    // fallback to `domain` is the value that actually went over the wire.
-    const reportedDomain = r?.domain ?? domain;
-    const reportedName = domainPhrase(reportedDomain, "the domain you passed");
-
-    // Zero is NOT a successful wipe, and this line used to read like one.
-    // Core echoes back the caller's own string, so "Deleted 0 memories from
-    // domain 'Project X'" implies a domain that existed and is now empty. The
-    // casing trap runs in this direction too: the user says "forget everything
-    // about project X", the agent passes "Project X", gets a success-shaped
-    // line, reports done — and the atoms live on under "project x" (review,
-    // 2026-08-08). This release built the diagnosis for exactly that and had
-    // applied it only to reads.
-    if (count === 0) {
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: withDomainEscapeLegend(
-              `NOTHING was deleted — no memories matched domain ${reportedName} in your own ` +
-                `store. Names match byte-for-byte, so check the spelling and case against ` +
-                `memory_stats before reporting this as done. Shared rooms cannot be wiped ` +
-                `through this tool at all.`,
-              reportedDomain,
-            ),
-          },
-        ],
-      };
-    }
-
-    return {
-      content: [
-        {
-          type: "text" as const,
-          text: withDomainEscapeLegend(
-            `Deleted ${count} ${count === 1 ? "memory" : "memories"} from domain ${reportedName}.`,
-            reportedDomain,
           ),
         },
       ],

--- a/src/names.ts
+++ b/src/names.ts
@@ -176,9 +176,12 @@ export function roomNamePhrase(name: unknown): string {
 }
 
 /**
- * The `Domains:` line of memory_stats — the surface two tool descriptions send
- * the reader to "to confirm the exact domain name before a delete", which it
- * could not do while the names went through `safeInline`.
+ * The `Domains:` line of memory_stats — the surface this tool's own
+ * description sends the reader to "to confirm the exact domain name before
+ * writing to it", which it could not do while the names went through
+ * `safeInline`. (Until 2026-08-20, `memory_delete_domain`'s description sent
+ * readers here for the same reason, before deletion was withdrawn to an
+ * administrative REST-only operation.)
  *
  * A name that cannot be printed exactly is COUNTED, never silently dropped:
  * dropping it would make this list assert that a store does not exist, on the

--- a/src/render.ts
+++ b/src/render.ts
@@ -4,9 +4,9 @@
  * Kept out of index.ts (same move as teaching.ts) so tests can pin the
  * rendered contract: since the #404 temporal work, every item line
  * carries its id and created_at date WHENEVER the server provides them
- * (memory_feedback / memory_delete are uncallable without ids — the tool
- * description always promised them, the old render never delivered any;
- * a reader cannot reason about recency it cannot see). Legacy response
+ * (memory_feedback is uncallable without ids — the tool description always
+ * promised them, the old render never delivered any; a reader cannot reason
+ * about recency it cannot see). Legacy response
  * shapes without atom_id/created_at degrade gracefully: those parts of
  * the line are simply omitted.
  */
@@ -131,9 +131,9 @@ export function formatDateTag(createdAt?: string): string {
  * One memory_read result line:
  * `N. content (concepts) @"domain" [by X] · 2026-08-01 21:04Z\n   id: <uuid>`
  *
- * The id sits on its own indented line: full-width (feedback/delete need
- * the EXACT id, truncation would break them) without crowding the content
- * line a model actually reads.
+ * The id sits on its own indented line: full-width (feedback needs the
+ * EXACT id, truncation would break it) without crowding the content line a
+ * model actually reads.
  *
  * NO SCORE, as of 0.8.1 (Eduard's call). The line used to lead with the
  * server's `relevance` rendered as a percentage, and that was wrong twice

--- a/src/requests.ts
+++ b/src/requests.ts
@@ -24,9 +24,11 @@
  *
  * Deliberately NOT normalising: core matches domains byte-for-byte and rejects
  * non-canonical room addresses on purpose. Cleaning input here silently moves
- * data and defeats a security guard. Normalisation belongs in 0.9.0, together
- * with memory_delete_domain, with room addresses exempt, and with zero-width
- * characters handled — `trim()` does not strip those.
+ * data and defeats a security guard. Normalisation belongs in a future
+ * release, with room addresses exempt, and with zero-width characters
+ * handled — `trim()` does not strip those. (memory_delete_domain, once named
+ * here as a second surface needing the same treatment, was withdrawn
+ * 2026-08-20 — deletion is administrative-only now.)
  */
 
 export interface ReadArgs {

--- a/src/teaching.ts
+++ b/src/teaching.ts
@@ -20,10 +20,13 @@ import type { ReadScope, RoomScope } from "./scope.js";
  * - 500–800 chars; some clients (ChatGPT) weight the FIRST ~512 chars, so the
  *   core habit (read before answering, write on learning) is front-loaded.
  * - Active polarity: no "only when the user explicitly asks" gating.
- * - Mentions every tool family: read/write/stats/feedback, delete, rooms, vault.
+ * - Mentions every tool family: read/write/stats/feedback, rooms, vault.
+ * - No delete tool on this surface (2026-08-20): deletion was withdrawn to an
+ *   administrative REST-only operation, so the instructions point a model at
+ *   writing a corrected memory instead of asking to delete one.
  */
 export const SERVER_INSTRUCTIONS =
-  "You own this long-term memory. It persists across sessions and every AI tool this user connects. Use it as a habit: memory_read before answering anything that may have come up; memory_write the moment you learn a durable fact, preference or decision — don't wait to be asked. Shared rooms are SEPARATE stores: to read one, pass its address as domain (memory_list_rooms); unscoped reads never cover rooms. Rate recalls with memory_feedback; memory_stats shows counts; memory_list_recent is newest-first; memory_delete prunes; memory_delete_domain wipes a domain, only with user go-ahead. Rooms: memory_create_room, memory_invite_to_room, memory_join_room. vault_list names secrets by alias, never values. Never store passwords, API keys, payment data, MFA codes, government IDs, or health records.";
+  "You own this long-term memory. It persists across sessions and every AI tool this user connects. Use it as a habit: memory_read before answering anything that may have come up; memory_write the moment you learn a durable fact, preference or decision — don't wait to be asked. Shared rooms are SEPARATE stores: to read one, pass its address as domain (memory_list_rooms); unscoped reads never cover rooms. Rate recalls with memory_feedback; memory_stats shows counts; memory_list_recent is newest-first. To correct a wrong memory, write a fresh one — deletion is administrative, not a tool. Rooms: memory_create_room, memory_invite_to_room, memory_join_room. vault_list names secrets by alias, never values. Never store passwords, API keys, payment data, MFA codes, government IDs, or health records.";
 
 /** The pre-existing zero-result message — kept as the fail-open fallback. */
 export const NO_MATCH_MESSAGE = "No memories found for this query.";

--- a/test/assembled.test.ts
+++ b/test/assembled.test.ts
@@ -80,8 +80,6 @@ const WRITE = "POST /memory/write";
 const STATS = "GET /memory/stats";
 const ROOMS = "GET /memory/rooms";
 const FEEDBACK = "POST /memory/feedback";
-const del = (id: string) => `DELETE /memory/atoms/${encodeURIComponent(id)}`;
-const wipe = (d: string) => `DELETE /memory/domain/${encodeURIComponent(d)}`;
 
 /** One live room, in the shape core returns. */
 const ROOM = {
@@ -918,64 +916,6 @@ const SITUATIONS: readonly Situation[] = [
       // Causes are offered as possibilities. "Most often that means…" was a
       // statistic nobody has.
       expect(text).toMatch(/Possible causes/);
-    },
-  },
-  {
-    id: "n",
-    what: "memory_delete on an id that is not in the caller's store",
-    tool: "memory_delete",
-    args: { atom_id: "atom_room_9" },
-    routes: { [del("atom_room_9")]: { deleted: 0 } },
-    bounds: { surface: "other", boundedBy: /in your own domains/ },
-    meaning(text) {
-      // NOT "no such memory". Deletion is scoped to the caller's own store and
-      // core has no room-scoped delete at all, so a room atom's id lands here
-      // while the memory may live on in its room — and this release made room
-      // ids MORE visible in read results. The line claims only the boundary:
-      // "this delete never reached it" is knowable; "it still exists" (the
-      // previous wording) was not — the room owner may have deleted it since
-      // (truth review F12).
-      expect(text).toContain("atom_room_9");
-      expect(text).toMatch(/CANNOT be deleted through this tool/);
-      expect(text).toMatch(/this delete never reached it/);
-      expect(text).not.toMatch(/still exists/);
-      expect(text).not.toMatch(/never existed|no such memory/i);
-    },
-  },
-  {
-    id: "o",
-    what: "memory_delete_domain matching zero rows",
-    tool: "memory_delete_domain",
-    args: { domain: "Project X", confirm: true },
-    routes: { [wipe("Project X")]: { deleted: 0, domain: "Project X" } },
-    bounds: { surface: "other", searched: "Project X", boundedBy: /in your own store/ },
-    meaning(text) {
-      // Zero is not a successful wipe. "Deleted 0 memories from domain 'Project
-      // X'" implied a domain that existed and is now empty — so the user says
-      // "forget everything about project X", the agent passes "Project X", reads
-      // a success-shaped line, reports done, and the atoms live on under
-      // "project x".
-      expect(text.startsWith("NOTHING was deleted")).toBe(true);
-      expect(text).not.toMatch(/^Deleted 0/);
-      expect(text).toContain('domain "Project X"');
-      expect(text).toMatch(/before reporting this as done/);
-    },
-  },
-  {
-    id: "o2",
-    what:
-      "memory_delete_domain matching zero rows for a name whose last character is " +
-      "invisible — a destructive confirmation is where an unreproducible name is worst",
-    tool: "memory_delete_domain",
-    args: { domain: ZWSP_NAME, confirm: true },
-    routes: { [wipe(ZWSP_NAME)]: { deleted: 0, domain: ZWSP_NAME } },
-    bounds: { surface: "other", searched: ZWSP_NAME, boundedBy: /in your own store/ },
-    meaning(text) {
-      expect(text).toContain(`no memories matched domain ${ZWSP_LITERAL}`);
-      // The name carries an escape, so the answer must explain the escape —
-      // once. Asserted universally above; named here because this is the surface
-      // where a misread name deletes the wrong store.
-      expect(count(text, LEGEND)).toBe(1);
     },
   },
   {

--- a/test/descriptions.test.ts
+++ b/test/descriptions.test.ts
@@ -6,8 +6,10 @@
  * connected model's system prompt, so every sentence in them is shipped
  * behaviour — and nine of this release's own fixes ARE description sentences:
  * the top_k not-a-hard-cap warning, the exclude_author not-usable-yet warning,
- * the room boundaries on feedback/delete/delete_domain, the importance-gate
- * sentence on memory_write, the unscoped-reads-never-cover-rooms rule. Until
+ * the room boundary on feedback, the importance-gate sentence on memory_write,
+ * the unscoped-reads-never-cover-rooms rule. (The room boundaries this file
+ * once also pinned on memory_delete/memory_delete_domain went with those
+ * tools on 2026-08-20 — deletion is administrative-only now.) Until
  * this file, none of that was asserted anywhere: a fire-drill made 11
  * description sabotages — inversions, deletions, restorations of withdrawn
  * claims — and the suite stayed green through all of them (tests-lens F1,
@@ -125,20 +127,6 @@ describe("the advertised descriptions carry this release's truth claims", () => 
     expect(d).toContain(
       "rating a memory that lives in a shared room silently does nothing",
     );
-  });
-
-  it("memory_delete names its boundary: room memories cannot be deleted here", () => {
-    const d = description("memory_delete");
-    expect(d).toContain("Reaches your own domains only");
-    expect(d).toContain(
-      "memories in shared rooms CANNOT be deleted through this tool",
-    );
-  });
-
-  it("memory_delete_domain names byte-for-byte matching and the room boundary", () => {
-    const d = description("memory_delete_domain");
-    expect(d).toContain("Names match byte-for-byte, including case");
-    expect(d).toContain("shared rooms cannot be wiped through this tool");
   });
 
   it("vault_list promises aliases only — the value is never returned", () => {

--- a/test/handlers.test.ts
+++ b/test/handlers.test.ts
@@ -71,8 +71,6 @@ const FEEDBACK = "POST /memory/feedback";
 const JOIN = "POST /memory/rooms/join";
 const VAULT = "GET /vault/secrets";
 const CREATE_ROOM = "POST /memory/rooms";
-const del = (id: string) => `DELETE /memory/atoms/${encodeURIComponent(id)}`;
-const wipe = (d: string) => `DELETE /memory/domain/${encodeURIComponent(d)}`;
 const invites = (id: string) => `POST /memory/rooms/${encodeURIComponent(id)}/invites`;
 
 /** Which endpoints the handler consulted — the evidence behind its claim. */
@@ -104,12 +102,13 @@ describe("what a connecting client is actually told", () => {
     expect(mcp.client.getInstructions()).toBe(SERVER_INSTRUCTIONS);
   });
 
-  it("advertises twelve tools by their public names", async () => {
+  it("advertises ten tools by their public names — no delete tool on this surface", async () => {
+    // memory_delete / memory_delete_domain removed 2026-08-20: deletion was
+    // withdrawn from the agent-facing surface to an administrative REST-only
+    // operation (see CHANGELOG). This surface never exposes a delete tool.
     const { tools } = await mcp.client.listTools();
     expect(tools.map((t) => t.name).sort()).toEqual([
       "memory_create_room",
-      "memory_delete",
-      "memory_delete_domain",
       "memory_feedback",
       "memory_invite_to_room",
       "memory_join_room",
@@ -817,44 +816,6 @@ describe("the load-bearing sentences, as returned", () => {
     );
   });
 
-  it("a delete that hit nothing does not claim the memory never existed", async () => {
-    mcp.on(del("atom_room_9"), { deleted: 0 });
-
-    const text = await mcp.callText("memory_delete", { atom_id: "atom_room_9" });
-
-    expect(text).toContain(
-      "Nothing was deleted: no memory with id atom_room_9 in your own domains.",
-    );
-    expect(text).toContain(
-      "memories in shared rooms CANNOT be deleted through this tool",
-    );
-    // The boundary claim only — this delete never reached the room. "it still
-    // exists" was a claim this handler cannot check: the room owner may have
-    // deleted it since (truth review F12, 2026-08-08).
-    expect(text).toContain("this delete never reached it");
-    expect(text).not.toContain("still exists");
-    expect(text).not.toContain("No memory found with id");
-  });
-
-  it("a zero-row domain wipe does not read like a successful wipe", async () => {
-    mcp.on(wipe("Project X"), { deleted: 0, domain: "Project X" });
-
-    const text = await mcp.callText("memory_delete_domain", {
-      domain: "Project X",
-      confirm: true,
-    });
-
-    expect(text.startsWith("NOTHING was deleted")).toBe(true);
-    // The casing trap runs in this direction too: the user says "forget
-    // everything about project X", the agent passes "Project X", and a
-    // success-shaped line lets it report done while the atoms live on under
-    // "project x". So the zero branch names the store it did NOT wipe.
-    expect(text).toContain('no memories matched domain "Project X" in your own store');
-    expect(text).toContain("Names match byte-for-byte");
-    expect(text).toContain("before reporting this as done");
-    expect(text).not.toMatch(/^Deleted 0/);
-  });
-
   it("zero feedback names the invisible cause first, and does not blame deletion", async () => {
     mcp.on(FEEDBACK, { updated_count: 0 });
 
@@ -968,8 +929,8 @@ describe("the load-bearing sentences, as returned", () => {
 describe("naming a store the reader has to reproduce", () => {
   it("memory_stats prints two names that differ only by a space as two names", async () => {
     // safeInline trimmed and collapsed before the quotes went on, so these
-    // printed identically and the list read like a tool bug — on the surface two
-    // other tool descriptions send the reader to for a byte-exact check.
+    // printed identically and the list read like a tool bug — on the surface
+    // this tool's own description sends the reader to for a byte-exact check.
     mcp.on(STATS, {
       total_atoms: 9,
       domains: [" engineering", "engineering", "проект:acme", "план:acme"],
@@ -1008,7 +969,9 @@ describe("naming a store the reader has to reproduce", () => {
     // Replaces a source count of `withDomainEscapeLegend(` occurrences, which
     // could not tell a wired call from a decorative one. Together with the two
     // tests above and the results pages ("the escape legend survives the size
-    // cap" below), this covers all six surfaces that can name a store.
+    // cap" below), this covers the surfaces that can name a store. (Until
+    // 2026-08-20 memory_delete_domain's wipe confirmation was a third anchor
+    // here; that surface is gone now that deletion is administrative-only.)
     mcp.on(READ, { items: [] }).on(STATS, { domains: [] });
     const filtered = await mcp.callText("memory_read", {
       query: "x",
@@ -1022,32 +985,6 @@ describe("naming a store the reader has to reproduce", () => {
     const feed = await mcp.callText("memory_list_recent", { domain: ZWSP_NAME });
     expect(feed).toContain(`No memories in ${ZWSP_LITERAL} yet.`);
     expect(legends(feed)).toBe(1);
-
-    mcp.reset().on(wipe(ZWSP_NAME), { deleted: 0, domain: ZWSP_NAME });
-    const wiped = await mcp.callText("memory_delete_domain", {
-      domain: ZWSP_NAME,
-      confirm: true,
-    });
-    expect(wiped).toContain(`no memories matched domain ${ZWSP_LITERAL}`);
-    expect(legends(wiped)).toBe(1);
-  });
-
-  it("a successful wipe carries the legend that decodes the store it names", async () => {
-    // The most destructive confirmation this client prints. The zero branch's
-    // legend is pinned by "carries the legend on every OTHER message" above;
-    // the SUCCESS branch's had no test at all,
-    // so deleting that one call left the whole suite green (tests-lens F4,
-    // 2026-08-08). A wipe confirmation whose store name carries an invisible
-    // character MUST explain that the printed \u200b is one character, not six.
-    mcp.on(wipe(ZWSP_NAME), { deleted: 3, domain: ZWSP_NAME });
-
-    const text = await mcp.callText("memory_delete_domain", {
-      domain: ZWSP_NAME,
-      confirm: true,
-    });
-
-    expect(text).toContain(`Deleted 3 memories from domain ${ZWSP_LITERAL}.`);
-    expect(legends(text)).toBe(1);
   });
 
   it("the plain-empty read is legended by its notes, not by a wrapper", async () => {
@@ -1080,21 +1017,6 @@ describe("naming a store the reader has to reproduce", () => {
     });
     expect(twin).toContain(ZWSP_LITERAL);
     expect(legends(twin)).toBe(1);
-  });
-
-  it("a destructive confirmation names the store it acted on, byte for byte", async () => {
-    // safeInline named a DIFFERENT store here: wiping `" project x"` confirmed
-    // `"project x"`, one clause before telling the reader names match
-    // byte-for-byte.
-    mcp.on(wipe(" project x"), { deleted: 3, domain: " project x" });
-
-    const text = await mcp.callText("memory_delete_domain", {
-      domain: " project x",
-      confirm: true,
-    });
-
-    expect(text).toBe('Deleted 3 memories from domain " project x".');
-    expect(text).not.toContain('domain "project x"');
   });
 
   it("prints an owner-chosen room name to a joiner exactly, and still injection-safe", async () => {

--- a/test/names.test.ts
+++ b/test/names.test.ts
@@ -205,7 +205,7 @@ describe("formatDomainList — the memory_stats line", () => {
     expect(line).toBe('" engineering", "engineering"');
   });
 
-  it("supports the byte-exact check memory_delete_domain sends the reader here for", () => {
+  it("supports the byte-exact check memory_stats' own description sends the reader here for", () => {
     for (const name of [" project x", "Проект", "eng\u200b"]) {
       // A single-name list IS the literal, so the check that description
       // promises can be run mechanically: decode what was printed, then compare

--- a/test/render.test.ts
+++ b/test/render.test.ts
@@ -3,10 +3,10 @@
  * 0.8.1 added to or removed from a result line.
  *
  * What this file guarantees, in the order the cases appear:
- * 1. Every item with an atom_id renders the FULL id — memory_feedback and
- *    memory_delete are uncallable without exact ids, and the tool
- *    description has promised them all along (the pre-#404 render never
- *    delivered any: the standing dead-id bug).
+ * 1. Every item with an atom_id renders the FULL id — memory_feedback is
+ *    uncallable without exact ids, and the tool description has promised
+ *    them all along (the pre-#404 render never delivered any: the standing
+ *    dead-id bug).
  * 2. created_at renders as a compact UTC date tag — a reader cannot
  *    reason about recency it cannot see.
  * 3. NO relevance score reaches a reader, on either surface, at any value
@@ -54,7 +54,7 @@ describe("formatReadItem", () => {
     expect(line).toContain("1. Retry with backoff fixed it (retry, backoff)");
     expect(line).toContain("[by codex · external]");
     expect(line).toContain("· 2026-08-01 21:04Z");
-    expect(line).toContain(`id: ${ID}`); // full, untruncated — feedback/delete need it
+    expect(line).toContain(`id: ${ID}`); // full, untruncated — feedback needs it
     // NO score, as of 0.8.1. There IS a relevance floor — core's
     // `min_relevance` defaults to 0.3 — and this comment used to say there was
     // none, which is the claim src/render.ts and the CHANGELOG both withdrew

--- a/test/teaching-surface.test.ts
+++ b/test/teaching-surface.test.ts
@@ -74,18 +74,26 @@ describe("server instructions", () => {
     }
   });
 
-  it("mention every tool family: read/write/stats/feedback + delete + rooms + vault", () => {
+  it("mention every tool family: read/write/stats/feedback + rooms + vault", () => {
     for (const tool of [
       "memory_read",
       "memory_write",
       "memory_stats",
       "memory_feedback",
-      "memory_delete",
       "room",
       "vault",
     ]) {
       expect(SERVER_INSTRUCTIONS.toLowerCase()).toContain(tool);
     }
+  });
+
+  it("has no delete tool on this surface, and points a correction at a fresh write instead", () => {
+    // memory_delete / memory_delete_domain removed 2026-08-20: deletion was
+    // withdrawn from the agent-facing surface to an administrative REST-only
+    // operation. The instructions must not name either retired tool, and must
+    // not carry the old delete-to-correct advice.
+    expect(SERVER_INSTRUCTIONS.toLowerCase()).not.toContain("memory_delete");
+    expect(SERVER_INSTRUCTIONS).toMatch(/write a fresh one/i);
   });
 
   it("front-load the core habit in the first 512 chars (ChatGPT weighting) and stay 500-800 chars", () => {


### PR DESCRIPTION
## Summary

- **BREAKING**: removes `memory_delete` and `memory_delete_domain` from this MCP server entirely — registration, handlers, schemas, descriptions, generated `manifest.json`. Deletion is withdrawn from the agent-facing surface to an administrative REST-only operation (decision 2026-08-20).
- Why: the core delete path destroyed learned Hebbian associations tenant-wide (56,683 edges / 14 tenants in the logged incident window — fix: mnemoverse/mnemoverse-core#509); the remote MCP connector already excludes delete by design (ADR-012); this npm package was the **last agent-facing surface** still exposing it. Worse, `memory_delete`'s own description recommended deleting a memory "superseded by a newer decision" — recommending exactly the delete-for-update lifecycle that triggered the incident — and `memory_delete_domain`'s documented flow (run `memory_stats` to confirm the domain name, then wipe with `confirm:true`) walks an agent straight past the `secrets` domain in the stats list.
- Every remaining tool description and the server instructions swept for stale delete advice; corrections now point at writing a corrected memory (a non-destructive supersede-style primitive is planned; no dates promised, no unshipped tool names referenced).
- Regenerated artifacts via the repo's own generator (`src/configs/source.json` → `npm run generate:configs`, 19/19 in sync — no hand-edited generated files). `llms.txt` and `README.md` (tools table, privacy-data table, retention row) updated at source.
- Version 0.8.4 → **0.9.0**. Note: the task brief said "major", but CHANGELOG.md's own house rules state the project is pre-1.0 and behaviour changes belong in MINOR — following the repo's documented convention. Override to 1.0.0 is a one-line change if preferred.

## Migration for users

- REST `DELETE /memory/atoms/{id}` and `DELETE /memory/domain/{domain}` are unaffected — administrative deletion still works there (documented as destructive).
- To correct a wrong or stale memory from an MCP client: write a fresh memory with `memory_write`. A supersede primitive replaces the delete-for-update lifecycle in an upcoming release.
- Any integration calling the removed tools will fail against 0.9.0 — no compatibility shim, by design.

## ⚠️ npm publish is a SEPARATE, explicitly-gated step

This PR does not publish. Merging is not authorization to publish. The same-day coupling on publish day: `mnemoverse-docs` privacy policy §11.1 (tool table) and §11.5 (the "per-atom deletion — call `memory_delete`" bullet) must change in the same window, or the legal page lies.

## Test plan

- `npm run verify:configs` — 19/19 artifacts in sync with source.json
- `npm run build`, `npx tsc --noEmit`, `npm run typecheck:test` — clean
- `npm test` — 334/334
- Live stdio smoke test (`initialize` + `tools/list` piped into built `dist/index.js`): exactly 10 tools advertised, none are delete tools, version 0.9.0, new `SERVER_INSTRUCTIONS` text confirmed.

---
*Provenance: built during a supervised night shift. Shift lead independently verified zero `memory_delete` references in README/llms.txt/manifest.json (remaining `src/` mentions are historical past-tense comments explaining code shape).*
