### PR TITLE
release: 0.9.1 — instructive tool errors + honest re-ranking claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ git history and the GitHub releases are the record.
 
 ## [Unreleased]
 
+## [0.9.1] — 2026-08-24
+
 Text under this file's own rules: what a tool returns when it fails. No tool,
 parameter, annotation or route changes; no new request is made — the one new
 thing read off the wire is the `Retry-After` header of a response that had

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "mnemoverse-memory",
   "display_name": "Mnemoverse Memory",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Hosted memory for AI agents that learns from outcomes — one key across Claude, Cursor & ChatGPT.",
   "long_description": "Mnemoverse gives your AI assistant long-term memory that persists across sessions and across tools. Store preferences, decisions, and lessons with memory_write; recall them by natural-language search with memory_read. The same memory is shared everywhere you use your Mnemoverse API key — Claude, Cursor, VS Code, and any MCP client. Requires a free API key from https://console.mnemoverse.com.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mnemoverse/mcp-memory-server",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mnemoverse/mcp-memory-server",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mnemoverse/mcp-memory-server",
-  "version": "0.9.0",
-  "description": "Hosted persistent memory for AI agents that learns which facts help \u2014 feedback re-ranks recall \u2014 one key across Claude Code, Cursor, VS Code & ChatGPT, no infra to run",
+  "version": "0.9.1",
+  "description": "Hosted persistent memory for AI agents that learns which facts help — feedback re-ranks recall — one key across Claude Code, Cursor, VS Code & ChatGPT, no infra to run",
   "type": "module",
   "bin": {
     "mcp-memory-server": "./dist/index.js"

--- a/server.json
+++ b/server.json
@@ -9,12 +9,12 @@
     "source": "github",
     "id": "1207193530"
   },
-  "version": "0.9.0",
+  "version": "0.9.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mnemoverse/mcp-memory-server",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Cuts a release for the changes already merged to main (#93, #95). 0.9.0 is already published to npm, so this is a **PATCH** — text + a bugfix, no tool/param/route shape change, per this file's own versioning rule.

## What this PR is

Purely the release ritual — no new behaviour:
- `package.json`, `package-lock.json` (both `.version` and `packages[""].version`), `server.json`, `manifest.json` → **0.9.1**
- All 19 generated artifacts regenerated from `source.json`; `verify:configs` green
- `CHANGELOG.md`: `[Unreleased]` folded into `## [0.9.1] — 2026-08-24` (fresh empty `[Unreleased]` left on top)

## What ships in 0.9.1

- **#93** — a failed tool call now returns status-specific guidance to the agent instead of the raw wire body; one disclosed feed-degrade behaviour correction.
- **#95** — the description surfaces say the strong true thing again ("learns from outcomes — feedback re-ranks recall"); the false decay/forget wording and the half-life magnitude stay out.

## Verification

- `package.json` / lockfile (×2) / `server.json` / `manifest.json` all read `0.9.1` — the release-time version-match gate checks exactly these.
- `verify:configs` — all 19 artifacts in sync.
- `npm test` — 415/415.
- The new release pipeline's CHANGELOG gate (`## [0.9.1] — YYYY-MM-DD`) is satisfied, and its awk extraction returns the full section.

## Release order

1. ✅ **#100 merged** (998d1c1) — the new pipeline is on main, so the tag will run under the new gates.
2. Merge **this PR** (0.9.1 on main).
3. Tag `v0.9.1` and push → the pipeline publishes to npm + registry + GitHub release + docs dispatch.

Merge and tag are Eduard's clicks, per the publicity gate; the tag/publish is the irreversible one. F1 hardening (protected `release` environment + tag ruleset + env-scoped NPM_TOKEN) is deferred to the 0.10 prep — this release is gated by Eduard triggering the tag by hand.

Done-by: Σ (Sigma)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the application, server, and package versions to **0.9.1**.
  - Added a **0.9.1** entry to the changelog.
  - Improved package description punctuation for clearer presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->