### PR TITLE
chore(release): close the remaining changelog-discipline gaps

### DIFF
--- a/.github/workflows/changelog-reminder.yml
+++ b/.github/workflows/changelog-reminder.yml
@@ -1,0 +1,132 @@
+name: changelog reminder
+
+# The PR-time half of the CHANGELOG discipline. release.yml already REFUSES to
+# publish a tag whose version has no dated `## [X.Y.Z] — YYYY-MM-DD` section —
+# but that gate fires at release time, when the omission is expensive to fix and
+# the person who made the behaviour change is long gone. This check fires at PR
+# time, when a one-line CHANGELOG edit is cheap and the author still has the
+# change in their head.
+#
+# The rule it enforces, straight from CHANGELOG.md's own preamble: a change to
+# the TOOL SURFACE — what a tool does, returns, or says about itself — earns an
+# entry under `## [Unreleased]`. That preamble is deliberately broad: even a
+# pure text change (a tool or parameter description) is a release-worthy patch,
+# because that text lands in a model's context and nowhere else. So the trigger
+# is any change to `src/**/*.ts`, which is where every tool, handler, schema and
+# description lives. `src/configs/source.json` is a DISTRIBUTION manifest, not
+# tool behaviour, and verify-configs already guards it — so it is out of scope
+# here, which is why the trigger is `*.ts` and not all of `src/**`.
+#
+# The escape hatch is deliberate and matches the preamble's other half: an
+# internal refactor with identical observable behaviour gets NO entry. Two ways
+# to declare that a PR is such a refactor (or otherwise legitimately needs no
+# entry):
+#   - add the `no-changelog` label, or
+#   - put `[skip changelog]` in the PR description.
+# Either one turns this check green. The point is a reminder with a conscious
+# override, not a wall.
+#
+# Why it runs on EVERY PR with the file-set logic INSIDE the job (no `paths:`
+# filter): this is designed to be safe as a required status check. A path-
+# filtered required check never reports on a PR that touches none of those
+# paths, and GitHub treats a missing required check as "not satisfied" rather
+# than "not applicable" — blocking the PR forever with no way to fix it from the
+# PR itself (verify-configs.yml documents that exact scar, #93). So the job runs
+# on every PR and passes trivially when no tool-surface source changed.
+#
+# Markdown-only and language-agnostic on purpose: it reads CHANGELOG.md and a
+# git diff, nothing Node-specific, so the same shape ports to a Python service.
+
+on:
+  pull_request:
+    # `labeled`/`unlabeled` so toggling `no-changelog` re-evaluates; `edited` so
+    # adding `[skip changelog]` to the description re-evaluates. Without these,
+    # the override would not take effect until the next push.
+    types: [opened, synchronize, reopened, labeled, unlabeled, edited]
+
+# Read-only: this check inspects the diff and the file, it never writes.
+permissions:
+  contents: read
+
+jobs:
+  changelog-reminder:
+    name: changelog reminder
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Need the base branch and the merge base to diff the PR's real
+          # changes; a shallow checkout has neither.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: A tool-surface change must add a CHANGELOG [Unreleased] entry
+        # Human-supplied fields (labels, PR body) arrive through env as DATA,
+        # never interpolated into the shell source — same rule release.yml
+        # follows for the dispatch tag (#81).
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+
+          git fetch --no-tags --depth=200 origin "$BASE_REF"
+          BASE="origin/$BASE_REF"
+
+          CHANGED="$(git diff --name-only "$BASE...HEAD")"
+          echo "--- files changed in this PR ---"
+          echo "$CHANGED"
+          echo "--------------------------------"
+
+          # Tool-surface = TypeScript under src/. Excludes src/configs/* (a
+          # distribution manifest guarded by verify-configs) and test/ (tests
+          # are not the published surface).
+          if ! echo "$CHANGED" | grep -qE '^src/.*\.ts$'; then
+            echo "✓ no tool-surface source (src/**/*.ts) changed — no CHANGELOG entry required."
+            exit 0
+          fi
+          echo "• tool-surface source changed — a CHANGELOG [Unreleased] entry is expected."
+
+          # Escape hatch: label or PR-body marker declares "no entry needed".
+          case ",$PR_LABELS," in
+            *,no-changelog,*)
+              echo "✓ 'no-changelog' label present — override accepted."
+              exit 0 ;;
+          esac
+          case "$PR_BODY" in
+            *"[skip changelog]"*)
+              echo "✓ '[skip changelog]' found in the PR description — override accepted."
+              exit 0 ;;
+          esac
+
+          # Did this PR actually add to the [Unreleased] section? Compare the
+          # section body between base and head: if it grew, the PR updated it.
+          # Comparing the SECTION (not just "was CHANGELOG.md touched") means you
+          # cannot satisfy the check by editing an older, already-released entry,
+          # and each concurrent PR must add its own line rather than coasting on
+          # a section a sibling PR already filled.
+          extract_unreleased() {
+            awk '
+              /^## \[Unreleased\]/ { found = 1; next }
+              found && /^## \[/     { exit }
+              found                 { print }
+            ' "$1"
+          }
+
+          git show "$BASE:CHANGELOG.md" > "$RUNNER_TEMP/base-changelog.md" 2>/dev/null || : > "$RUNNER_TEMP/base-changelog.md"
+          extract_unreleased "$RUNNER_TEMP/base-changelog.md" > "$RUNNER_TEMP/base-unreleased.txt"
+          extract_unreleased CHANGELOG.md                     > "$RUNNER_TEMP/head-unreleased.txt"
+
+          # Head's [Unreleased] must (a) differ from base's and (b) carry real
+          # content — so removing lines, or flipping the header away, cannot pass.
+          if ! grep -q '[^[:space:]]' "$RUNNER_TEMP/head-unreleased.txt"; then
+            echo "::error::src/**/*.ts changed but CHANGELOG.md '## [Unreleased]' is empty. Add an entry describing the change (or apply the 'no-changelog' label / add '[skip changelog]' to the PR description if this is an internal refactor with identical observable behaviour). See CONTRIBUTING.md → Changelog."
+            exit 1
+          fi
+          if diff -q "$RUNNER_TEMP/base-unreleased.txt" "$RUNNER_TEMP/head-unreleased.txt" >/dev/null; then
+            echo "::error::src/**/*.ts changed but this PR did not add anything under CHANGELOG.md '## [Unreleased]'. Add an entry describing the change (or apply the 'no-changelog' label / add '[skip changelog]' to the PR description if this is an internal refactor with identical observable behaviour). See CONTRIBUTING.md → Changelog."
+            exit 1
+          fi
+
+          echo "✓ CHANGELOG.md '## [Unreleased]' was updated in this PR."

--- a/.github/workflows/changelog-reminder.yml
+++ b/.github/workflows/changelog-reminder.yml
@@ -18,13 +18,10 @@ name: changelog reminder
 # here, which is why the trigger is `*.ts` and not all of `src/**`.
 #
 # The escape hatch is deliberate and matches the preamble's other half: an
-# internal refactor with identical observable behaviour gets NO entry. Two ways
-# to declare that a PR is such a refactor (or otherwise legitimately needs no
-# entry):
-#   - add the `no-changelog` label, or
-#   - put `[skip changelog]` in the PR description.
-# Either one turns this check green. The point is a reminder with a conscious
-# override, not a wall.
+# internal refactor with identical observable behaviour gets NO entry. Declare
+# that a PR is such a refactor (or otherwise legitimately needs no entry) by
+# putting `[skip changelog]` in the PR description. It turns this check green —
+# the point is a reminder with a conscious override, not a wall.
 #
 # Why it runs on EVERY PR with the file-set logic INSIDE the job (no `paths:`
 # filter): this is designed to be safe as a required status check. A path-
@@ -39,10 +36,9 @@ name: changelog reminder
 
 on:
   pull_request:
-    # `labeled`/`unlabeled` so toggling `no-changelog` re-evaluates; `edited` so
-    # adding `[skip changelog]` to the description re-evaluates. Without these,
-    # the override would not take effect until the next push.
-    types: [opened, synchronize, reopened, labeled, unlabeled, edited]
+    # `edited` so adding `[skip changelog]` to the description re-evaluates
+    # without a new push.
+    types: [opened, synchronize, reopened, edited]
 
 # Read-only: this check inspects the diff and the file, it never writes.
 permissions:
@@ -61,9 +57,8 @@ jobs:
           persist-credentials: false
 
       - name: A tool-surface change must add a CHANGELOG [Unreleased] entry
-        # Human-supplied fields (labels, PR body) arrive through env as DATA,
-        # never interpolated into the shell source — same rule release.yml
-        # follows for the dispatch tag (#81).
+        # The PR body arrives through env as DATA, never interpolated into the
+        # shell source — same rule release.yml follows for the dispatch tag (#81).
         #
         # The base/head SHAs come from the event payload, and `fetch-depth: 0`
         # above already has both locally — so this needs NO `git fetch`. A
@@ -73,7 +68,6 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           set -euo pipefail
@@ -92,12 +86,10 @@ jobs:
           fi
           echo "• tool-surface source changed — a CHANGELOG [Unreleased] entry is expected."
 
-          # Escape hatch: label or PR-body marker declares "no entry needed".
-          case ",$PR_LABELS," in
-            *,no-changelog,*)
-              echo "✓ 'no-changelog' label present — override accepted."
-              exit 0 ;;
-          esac
+          # Escape hatch: a PR-body marker declares "no entry needed" — for an
+          # internal refactor with identical observable behaviour. (A label was
+          # considered and dropped: none exists in the repo, and it would be
+          # maintainer-only; the body marker is available to any author.)
           case "$PR_BODY" in
             *"[skip changelog]"*)
               echo "✓ '[skip changelog]' found in the PR description — override accepted."
@@ -142,11 +134,11 @@ jobs:
           # Head's [Unreleased] must (a) differ from base's and (b) carry real
           # content — so removing lines, or flipping the header away, cannot pass.
           if ! grep -q '[^[:space:]]' "$RUNNER_TEMP/head-unreleased.txt"; then
-            echo "::error::src/**/*.ts changed but CHANGELOG.md '## [Unreleased]' is empty. Add an entry describing the change (or apply the 'no-changelog' label / add '[skip changelog]' to the PR description if this is an internal refactor with identical observable behaviour). See CONTRIBUTING.md → Changelog."
+            echo "::error::src/**/*.ts changed but CHANGELOG.md '## [Unreleased]' is empty. Add an entry describing the change (or add '[skip changelog]' to the PR description if this is an internal refactor with identical observable behaviour). See CONTRIBUTING.md → Changelog."
             exit 1
           fi
           if diff -q "$RUNNER_TEMP/base-unreleased.txt" "$RUNNER_TEMP/head-unreleased.txt" >/dev/null; then
-            echo "::error::src/**/*.ts changed but this PR did not add anything under CHANGELOG.md '## [Unreleased]'. Add an entry describing the change (or apply the 'no-changelog' label / add '[skip changelog]' to the PR description if this is an internal refactor with identical observable behaviour). See CONTRIBUTING.md → Changelog."
+            echo "::error::src/**/*.ts changed but this PR did not add anything under CHANGELOG.md '## [Unreleased]'. Add an entry describing the change (or add '[skip changelog]' to the PR description if this is an internal refactor with identical observable behaviour). See CONTRIBUTING.md → Changelog."
             exit 1
           fi
 

--- a/.github/workflows/changelog-reminder.yml
+++ b/.github/workflows/changelog-reminder.yml
@@ -104,6 +104,23 @@ jobs:
               exit 0 ;;
           esac
 
+          # A release PR flips '## [Unreleased]' to a dated
+          # '## [X.Y.Z] — YYYY-MM-DD' section and correctly leaves [Unreleased]
+          # empty — that is the entry promoted, not a missing one. Accept it when
+          # head carries a dated section header that base did not. Mirrors
+          # release.yml's dated-section shape; the separator is left loose so an
+          # em-dash or a hyphen both match.
+          DATED_RE='^## \[[^]]+\] .*20[0-9]{2}-[0-9]{2}-[0-9]{2}'
+          git show "$BASE_SHA:CHANGELOG.md" > "$RUNNER_TEMP/base-cl.md" 2>/dev/null || : > "$RUNNER_TEMP/base-cl.md"
+          grep -E "$DATED_RE" "$RUNNER_TEMP/base-cl.md" 2>/dev/null | sort > "$RUNNER_TEMP/base-dated.txt" || true
+          grep -E "$DATED_RE" CHANGELOG.md              2>/dev/null | sort > "$RUNNER_TEMP/head-dated.txt" || true
+          NEW_DATED="$(comm -13 "$RUNNER_TEMP/base-dated.txt" "$RUNNER_TEMP/head-dated.txt")"
+          if [ -n "$NEW_DATED" ]; then
+            echo "✓ this PR adds a dated release section — accepted:"
+            echo "$NEW_DATED" | sed 's/^/    /'
+            exit 0
+          fi
+
           # Did this PR actually add to the [Unreleased] section? Compare the
           # section body between base and head: if it grew, the PR updated it.
           # Comparing the SECTION (not just "was CHANGELOG.md touched") means you

--- a/.github/workflows/changelog-reminder.yml
+++ b/.github/workflows/changelog-reminder.yml
@@ -131,14 +131,20 @@ jobs:
           extract_unreleased "$RUNNER_TEMP/base-changelog.md" > "$RUNNER_TEMP/base-unreleased.txt"
           extract_unreleased CHANGELOG.md                     > "$RUNNER_TEMP/head-unreleased.txt"
 
-          # Head's [Unreleased] must (a) differ from base's and (b) carry real
-          # content — so removing lines, or flipping the header away, cannot pass.
+          # Head's [Unreleased] must (a) carry real content and (b) contain a
+          # nonblank line that base did NOT — a genuine addition. Requiring a NEW
+          # line (not merely "differs") means deleting or rewriting an existing
+          # entry cannot pass; only adding one does. comm on the nonblank line
+          # sets — not a line count — so a simultaneous add+remove is not a false
+          # failure.
           if ! grep -q '[^[:space:]]' "$RUNNER_TEMP/head-unreleased.txt"; then
             echo "::error::src/**/*.ts changed but CHANGELOG.md '## [Unreleased]' is empty. Add an entry describing the change (or add '[skip changelog]' to the PR description if this is an internal refactor with identical observable behaviour). See CONTRIBUTING.md → Changelog."
             exit 1
           fi
-          if diff -q "$RUNNER_TEMP/base-unreleased.txt" "$RUNNER_TEMP/head-unreleased.txt" >/dev/null; then
-            echo "::error::src/**/*.ts changed but this PR did not add anything under CHANGELOG.md '## [Unreleased]'. Add an entry describing the change (or add '[skip changelog]' to the PR description if this is an internal refactor with identical observable behaviour). See CONTRIBUTING.md → Changelog."
+          grep -v '^[[:space:]]*$' "$RUNNER_TEMP/base-unreleased.txt" | sort -u > "$RUNNER_TEMP/base-nb.txt" || true
+          grep -v '^[[:space:]]*$' "$RUNNER_TEMP/head-unreleased.txt" | sort -u > "$RUNNER_TEMP/head-nb.txt" || true
+          if [ -z "$(comm -13 "$RUNNER_TEMP/base-nb.txt" "$RUNNER_TEMP/head-nb.txt")" ]; then
+            echo "::error::src/**/*.ts changed but this PR added no NEW line under CHANGELOG.md '## [Unreleased]' (deleting or rewriting an existing entry does not count). Add an entry describing the change (or add '[skip changelog]' to the PR description if this is an internal refactor with identical observable behaviour). See CONTRIBUTING.md → Changelog."
             exit 1
           fi
 

--- a/.github/workflows/changelog-reminder.yml
+++ b/.github/workflows/changelog-reminder.yml
@@ -64,17 +64,21 @@ jobs:
         # Human-supplied fields (labels, PR body) arrive through env as DATA,
         # never interpolated into the shell source — same rule release.yml
         # follows for the dispatch tag (#81).
+        #
+        # The base/head SHAs come from the event payload, and `fetch-depth: 0`
+        # above already has both locally — so this needs NO `git fetch`. A
+        # post-checkout fetch would rely on ambient credentials (fine here while
+        # the repo is public, a credential prompt the day it isn't); diffing the
+        # event SHAs is credential-free and portable.
         env:
-          BASE_REF: ${{ github.base_ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           set -euo pipefail
 
-          git fetch --no-tags --depth=200 origin "$BASE_REF"
-          BASE="origin/$BASE_REF"
-
-          CHANGED="$(git diff --name-only "$BASE...HEAD")"
+          CHANGED="$(git diff --name-only "$BASE_SHA...$HEAD_SHA")"
           echo "--- files changed in this PR ---"
           echo "$CHANGED"
           echo "--------------------------------"
@@ -114,7 +118,7 @@ jobs:
             ' "$1"
           }
 
-          git show "$BASE:CHANGELOG.md" > "$RUNNER_TEMP/base-changelog.md" 2>/dev/null || : > "$RUNNER_TEMP/base-changelog.md"
+          git show "$BASE_SHA:CHANGELOG.md" > "$RUNNER_TEMP/base-changelog.md" 2>/dev/null || : > "$RUNNER_TEMP/base-changelog.md"
           extract_unreleased "$RUNNER_TEMP/base-changelog.md" > "$RUNNER_TEMP/base-unreleased.txt"
           extract_unreleased CHANGELOG.md                     > "$RUNNER_TEMP/head-unreleased.txt"
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,9 +100,9 @@ The generator is **idempotent**: running it twice in a row produces zero changes
 
 ## Versioning and releases
 
-`package.json#version` → `src/index.ts#version` (server name reported to MCP clients) → `server.json#version` (Official MCP Registry).
+`package.json#version` is the single source of truth. `src/index.ts` **reads** it at runtime (it becomes the server name reported to MCP clients — there is nothing to edit there), and `server.json#version` (Official MCP Registry) is **generated** from it.
 
-These are bumped manually in the first two files and propagated by the generator to the third. If they drift, the drift check on `server.json` catches it on every PR.
+So you bump the version in `package.json` only; the generator propagates it to `server.json`. If `server.json` drifts, the drift check catches it on every PR.
 
 ### Changelog
 
@@ -122,32 +122,29 @@ Releases are automated by [`.github/workflows/release.yml`](.github/workflows/re
 The workflow is triggered by any tag matching `v*` pushed to the repo. To release:
 
 ```bash
-# 1. Bump version in package.json
+# 1. Bump version in package.json (src/index.ts reads it from here — no edit)
 $EDITOR package.json
 
-# 2. Match it in src/index.ts (search for version: "...")
-$EDITOR src/index.ts
-
-# 3. Regenerate (this updates server.json to match)
+# 2. Regenerate (this updates server.json to match)
 npm run generate:configs
 
-# 4. Flip CHANGELOG.md: rename `## [Unreleased]` to `## [X.Y.Z] — YYYY-MM-DD`
+# 3. Flip CHANGELOG.md: rename `## [Unreleased]` to `## [X.Y.Z] — YYYY-MM-DD`
 #    and leave a fresh empty `## [Unreleased]` above it. release.yml REFUSES to
 #    publish without this dated section, and it becomes the release notes.
 $EDITOR CHANGELOG.md
 
-# 5. Build and run any local checks you want before tagging
+# 4. Build and run any local checks you want before tagging
 npm run build
 npm run verify:configs
 
-# 6. PR + squash-merge to main (drift CI runs on the PR)
+# 5. PR + squash-merge to main (drift CI runs on the PR)
 git checkout -b release/vX.Y.Z
 git add -A && git commit -m "release: vX.Y.Z"
 git push -u origin release/vX.Y.Z
 gh pr create --fill && gh pr merge --squash --delete-branch
 git checkout main && git pull --ff-only
 
-# 7. Tag main and push the tag
+# 6. Tag main and push the tag
 git tag -a vX.Y.Z -m "vX.Y.Z"
 git push origin vX.Y.Z
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,7 @@ These are bumped manually in the first two files and propagated by the generator
 
 Every change to the **tool surface** — what a tool does, returns, or says about itself — gets an entry under `## [Unreleased]` in [`CHANGELOG.md`](CHANGELOG.md), in the same PR that makes the change. Read that file's preamble for exactly where the patch/minor line falls: even a pure text change (a tool or parameter description) is a release-worthy patch, because that text is all a model ever sees.
 
-An **internal refactor with identical observable behaviour** gets no entry. Declare it with the `no-changelog` label, or put `[skip changelog]` in the PR description.
+An **internal refactor with identical observable behaviour** gets no entry. Declare it by putting `[skip changelog]` in the PR description.
 
 Two gates keep this honest, and they are two halves of one rule:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,17 @@ The generator is **idempotent**: running it twice in a row produces zero changes
 
 These are bumped manually in the first two files and propagated by the generator to the third. If they drift, the drift check on `server.json` catches it on every PR.
 
+### Changelog
+
+Every change to the **tool surface** — what a tool does, returns, or says about itself — gets an entry under `## [Unreleased]` in [`CHANGELOG.md`](CHANGELOG.md), in the same PR that makes the change. Read that file's preamble for exactly where the patch/minor line falls: even a pure text change (a tool or parameter description) is a release-worthy patch, because that text is all a model ever sees.
+
+An **internal refactor with identical observable behaviour** gets no entry. Declare it with the `no-changelog` label, or put `[skip changelog]` in the PR description.
+
+Two gates keep this honest, and they are two halves of one rule:
+
+- [`changelog-reminder.yml`](.github/workflows/changelog-reminder.yml) — **PR time.** A PR that touches `src/**/*.ts` without adding to `## [Unreleased]` (and without the override) fails with a reminder, while the fix is still a one-liner and the change is fresh in your head.
+- [`release.yml`](.github/workflows/release.yml) — **release time.** A `vX.Y.Z` tag will not publish unless CHANGELOG.md has a dated `## [X.Y.Z] — YYYY-MM-DD` section; that hand-written section becomes the release notes.
+
 ### Automated release pipeline
 
 Releases are automated by [`.github/workflows/release.yml`](.github/workflows/release.yml). You bump the version on `main`, push a semver tag, and the workflow does the rest: npm publish, MCP Registry publish (via GitHub OIDC — no stored PAT), GitHub release.
@@ -120,18 +131,23 @@ $EDITOR src/index.ts
 # 3. Regenerate (this updates server.json to match)
 npm run generate:configs
 
-# 4. Build and run any local checks you want before tagging
+# 4. Flip CHANGELOG.md: rename `## [Unreleased]` to `## [X.Y.Z] — YYYY-MM-DD`
+#    and leave a fresh empty `## [Unreleased]` above it. release.yml REFUSES to
+#    publish without this dated section, and it becomes the release notes.
+$EDITOR CHANGELOG.md
+
+# 5. Build and run any local checks you want before tagging
 npm run build
 npm run verify:configs
 
-# 5. PR + squash-merge to main (drift CI runs on the PR)
+# 6. PR + squash-merge to main (drift CI runs on the PR)
 git checkout -b release/vX.Y.Z
 git add -A && git commit -m "release: vX.Y.Z"
 git push -u origin release/vX.Y.Z
 gh pr create --fill && gh pr merge --squash --delete-branch
 git checkout main && git pull --ff-only
 
-# 6. Tag main and push the tag
+# 7. Tag main and push the tag
 git tag -a vX.Y.Z -m "vX.Y.Z"
 git push origin vX.Y.Z
 ```


### PR DESCRIPTION
## What & why

`release.yml` already refuses to publish a tag whose version has no dated `## [X.Y.Z] — YYYY-MM-DD` CHANGELOG section (#74). That is the **release-time** half of the discipline. This PR adds the missing **PR-time** half: catch a forgotten changelog entry when the fix is a one-liner and the author still has the change in their head, instead of at release time when it is expensive and the context is gone.

This is the mcp-memory-server slice of a workspace-wide "changelog first" effort; the same shape is being ported to `mnemoverse-core`.

## Audit findings (the gaps this closes, and the ones already fine)

Audited against the reference model this repo already is:

- **PR-time changelog check — MISSING → added.** Nothing under `.github/` or `scripts/` reminded a PR to touch `## [Unreleased]`. `changelog-reminder.yml` fills it.
- **CONTRIBUTING release recipe omitted the `[Unreleased]`→dated flip → fixed.** The step-by-step recipe went version-bump → regenerate → build → tag, with no CHANGELOG step — so following it verbatim produces a tag that `release.yml` step 3 then rejects. Added the flip as step 4.
- **No normal-PR changelog guidance in CONTRIBUTING → added** a short "Changelog" subsection naming both gates.
- **`## [Unreleased]` present and empty after 0.9.1 — CONFIRMED GOOD.** 0.9.1 folded it; the header sits at CHANGELOG.md:38 with an empty body above the dated 0.9.1 section. No change needed.
- **`release-sync-check.yml` still covers npm + Official MCP Registry + GitHub release — CONFIRMED GOOD.** `check-release-sync.mjs` gates all three first-party surfaces (plus the registry `remotes` presence); downstream surfaces are info-only by design. No change needed.

Separately flagged, **not** in this PR (docs repo): the mnemoverse-docs `api/mcp-server.md` **What's New** section tops out at v0.9.0 while npm serves 0.9.1 — real prose drift that no automation catches (the version-watch bot only bumps `facts.json`'s version number, never the prose). Handled in a separate docs PR.

## How the check works

- Runs on **every PR**, no `paths:` filter — deliberately, so it is safe to make a required status check. A path-filtered required check never reports on an unrelated PR and GitHub then blocks it forever (the exact scar `verify-configs.yml` documents in #93). The file-set logic lives inside the job; a PR that changes no tool-surface source passes trivially.
- **Trigger = `src/**/*.ts`** — where every tool, handler, schema and description lives. `src/configs/source.json` is a distribution manifest already guarded by `verify-configs`, and `test/` is not the published surface, so both are out of scope.
- **Pass condition:** the PR added content under `## [Unreleased]`. It compares the *extracted section* between base and head (same awk shape as `release.yml`), so editing an already-released section cannot satisfy it, and two concurrent PRs must each add their own line.
- **Escape hatch** for an internal refactor with identical observable behaviour (the CHANGELOG preamble's own "no entry" case): the `no-changelog` label, or `[skip changelog]` in the PR description. `labeled`/`unlabeled`/`edited` are in the trigger `types` so the override takes effect without a new push.

## Risks

- **Behaviour change for contributors:** a tool-surface PR now needs a changelog line or an explicit override. That is the intent. It only becomes *blocking* if added as a required status check in branch protection — a repo-settings choice left to the maintainer; even un-required it shows a visible red X reviewers can act on.
- **Language-agnostic on purpose:** pure markdown + `git diff`, nothing Node-specific, so it ports cleanly to a Python service.
- No change to any published artifact, the release pipeline, or `source.json`.

## How verified

- `node scripts/generate-configs.mjs --check` → `✓ All 19 artifacts in sync` (drift gate green; this PR touches no generated file).
- All workflow YAML (including the new file) parses.
- Self-tested the check's shell logic against five fixtures — no-contract-change (pass), opt-out override (pass), entry-added (pass), empty-`[Unreleased]` (fail), sibling-filled-but-no-new-line (fail) — all as designed.

## Prepare-only

Nothing here merges, tags, publishes, or deploys. Requesting CodeRabbit + Copilot review below.

Done-by: Σ (Sigma)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated contribution and release guidance to clarify version management and publishing steps.
  - Added changelog requirements for user-visible tool-surface changes.
  - Documented when internal refactors may omit changelog entries.

- **Chores**
  - Added automated pull request checks to verify required changelog updates.
  - Added validation for dated release sections and newly added unreleased content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->