### PR TITLE
fix(render): tell 'nothing older' apart from 'cursor could not be printed' at end of feed (#67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,29 @@ git history and the GitHub releases are the record.
 
 ## [Unreleased]
 
+A MINOR change under this file's own rule: a new branch, not just reworded
+text — see "A patch may NOT change SHAPE or ROUTING" above. `formatRecentPage`
+now decides its tail on three states instead of two, so this is a behaviour
+change even though every touched line is prose.
+
+### Fixed
+
+- **The recent-feed's end-of-feed line no longer conflates "nothing older"
+  with "cursor could not be printed"** (#67). `formatRecentPage`
+  (`src/render.ts`) used to decide the tail with one boolean: cursor absent,
+  and cursor present-but-failing-the-opaque-shape-check, both printed
+  `(end of feed — nothing older)`. That is could-not-render spelled exactly
+  like does-not-exist — the collision 0.8.1 fixed everywhere else, recorded
+  there as "Known and NOT fixed here" (see the 0.8.1 entry below). The
+  shape check itself is unchanged (CN-032 defense-in-depth stays as strict as
+  it was); only what gets said when a cursor fails it does. There are now
+  three branches: no cursor still says `(end of feed — nothing older)`; a
+  cursor that fails the shape check now says "More entries exist but the
+  continuation token could not be displayed — narrow the window with
+  since/until instead" (`since`/`until` are already parameters on
+  `memory_list_recent`, so the advice is actionable today); a cursor that
+  passes still says "More older entries exist — pass cursor: …".
+
 ## [0.9.1] — 2026-08-24
 
 Text under this file's own rules: what a tool returns when it fails. No tool,

--- a/src/render.ts
+++ b/src/render.ts
@@ -203,18 +203,27 @@ export function formatRecentPage(items: RecentItem[], nextCursor?: string | null
   // interpolated into instructional text — only echo it when it matches the
   // opaque urlsafe-base64 shape ours always has. Core mirrors the same regex on
   // its side, so a cursor that fails here is a contract violation, not a value.
+  // The regex itself is UNCHANGED (#67 fixed what gets said when it fails,
+  // not what it accepts).
   //
-  // KNOWN DEFECT, not fixed in 0.8.1 and recorded in the CHANGELOG: this one
-  // boolean decides an existence claim about a different thing. `false` means
-  // EITHER "the server said there is nothing older" OR "the server said there IS
-  // more and I refuse to print the token", and both print `(end of feed —
-  // nothing older)`. That is could-not-render spelled exactly like does-not-
-  // exist — the collision this release is about, surviving in the one place the
-  // fix did not reach. It needs a third branch and therefore a new sentence,
-  // which is a behaviour change.
-  const cursorOk = nextCursor != null && /^[A-Za-z0-9_=-]{1,512}$/.test(nextCursor);
-  const tail = cursorOk
-    ? `\n\nMore older entries exist — pass cursor: ${nextCursor}`
-    : `\n\n(end of feed — nothing older)`;
+  // Three outcomes, not two (#67, fixed here — was a single `cursorOk`
+  // boolean that conflated the last two): no cursor at all means the server
+  // says there is nothing older; a cursor that fails the shape check above
+  // means the server says there IS more but this client refuses to print an
+  // untrusted-shaped token; only a cursor that passes it is an actual
+  // continuation. The first two used to share one sentence —
+  // could-not-render read exactly like does-not-exist, the same collision
+  // 0.8.1 fixed everywhere else and recorded here as "Known and NOT fixed
+  // here". The middle case now says entries exist and points at since/until
+  // (already on memory_list_recent) as the way to keep going without the
+  // token.
+  let tail: string;
+  if (nextCursor == null) {
+    tail = `\n\n(end of feed — nothing older)`;
+  } else if (/^[A-Za-z0-9_=-]{1,512}$/.test(nextCursor)) {
+    tail = `\n\nMore older entries exist — pass cursor: ${nextCursor}`;
+  } else {
+    tail = `\n\nMore entries exist but the continuation token could not be displayed — narrow the window with since/until instead`;
+  }
   return lines.join("\n\n") + tail;
 }

--- a/test/render.test.ts
+++ b/test/render.test.ts
@@ -20,9 +20,11 @@
  *    (src/index.ts) appends the legend AFTER capResult, so truncation cannot
  *    eat it (truth F6; behavioural pins in test/handlers.test.ts).
  *
- * Not pinned here: `formatRecentPage`'s end-of-feed wording, beyond the two
- * happy paths below — see the known defect noted at `cursorOk` in
- * src/render.ts.
+ * 7. `formatRecentPage`'s end-of-feed tail is a real three-way branch (#67):
+ *    no cursor, a cursor that fails the opaque-shape check, and a cursor that
+ *    passes it each get their own sentence — a malformed/oversized cursor no
+ *    longer prints the same "(end of feed — nothing older)" as an actually
+ *    empty feed.
  */
 import { describe, expect, it } from "vitest";
 
@@ -124,6 +126,30 @@ describe("formatRecentItem / formatRecentPage", () => {
       null,
     );
     expect(page).toContain("(end of feed — nothing older)");
+  });
+
+  it("page with an oversized cursor (fails the opaque-shape check) does NOT claim the feed is empty (#67)", () => {
+    // 513 chars — one past the regex's {1,512} cap.
+    const oversized = "a".repeat(513);
+    const page = formatRecentPage(
+      [{ atom_id: ID, content: "a", created_at: "2026-08-02T10:00:00Z" }],
+      oversized,
+    );
+    expect(page).toContain(
+      "More entries exist but the continuation token could not be displayed — narrow the window with since/until instead",
+    );
+    expect(page).not.toContain("(end of feed — nothing older)");
+  });
+
+  it("page with a cursor carrying disallowed characters does NOT claim the feed is empty (#67)", () => {
+    const page = formatRecentPage(
+      [{ atom_id: ID, content: "a", created_at: "2026-08-02T10:00:00Z" }],
+      "abc 123/../<script>",
+    );
+    expect(page).toContain(
+      "More entries exist but the continuation token could not be displayed — narrow the window with since/until instead",
+    );
+    expect(page).not.toContain("(end of feed — nothing older)");
   });
 });
 


### PR DESCRIPTION
Closes #67.

## What

`formatRecentPage` decided the feed tail with one boolean, so a real cursor that failed the CN-032 opaque-shape check printed the same `(end of feed — nothing older)` as an actually empty feed — could-not-render spelled exactly like does-not-exist, the collision 0.8.1 fixed everywhere else and recorded here as "Known and NOT fixed here".

Now three honest branches:

1. no cursor → `(end of feed — nothing older)` (unchanged);
2. cursor present but failing the shape check → **"More entries exist but the continuation token could not be displayed — narrow the window with since/until instead"** (wording taken verbatim from the issue; `since`/`until` already exist on `memory_list_recent`, so the advice is actionable today);
3. valid cursor → the existing continuation invite (unchanged).

## What did NOT change

The CN-032 regex is untouched, and a failing cursor is still never interpolated into output — the new sentence names the situation without echoing the token.

## Self-review (reviewer voice)

- TDD order held: the two new tests (oversized 513-char cursor; disallowed-characters cursor) were written first and failed against main with the old lying phrase in the assertion diff.
- The two pre-existing tail tests kept their meaning; comment debt cleaned (the `KNOWN DEFECT` block in `render.ts` and the "Not pinned here" disclaimer in the test header now describe what *is*, not what is missing).
- The historical 0.8.1 CHANGELOG entry was deliberately left alone — it is a correct snapshot of that release, not a current lie.
- CHANGELOG classifies this as MINOR under the file's own shape/routing rule (new branch, not a rewording).
- Local gate mirrored CI: `tsc --noEmit`, `typecheck:test`, `vitest` — 417/417 green.

Done-by: Σ
