### PR TITLE
fix(security): require https for MNEMOVERSE_API_URL and refuse redirects before the key is sent (#99)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,120 @@ git history and the GitHub releases are the record.
 
 ## [Unreleased]
 
+A BEHAVIOUR change, and therefore MINOR rather than a patch under this file's
+own rules: there are two things `apiFetch` used to do with the API key that it
+no longer does. Both were CodeRabbit findings on #93, both were pre-existing,
+and both were deliberately kept OUT of that release — its entry declares itself
+text-only ("no new request is made"), and a transport change riding inside a
+wording release is exactly what that declaration exists to prevent (#99).
+
+### Security
+
+- **`MNEMOVERSE_API_URL` must address the API over https, or the tool refuses
+  to run (CWE-319).** `apiFetch` attached `X-Api-Key` to whatever the variable
+  held, so a base URL spelled `http://` — a typo, a copied tunnel address, a
+  misread doc — put a live `mk_live_` key in cleartext on every hop between the
+  user and that host, on every single tool call, with nothing anywhere saying
+  so. The key is the whole account: it reads and writes that user's memory. A
+  refused base URL now fails the call **before the request is made**, with:
+
+  > Mnemoverse: this tool did not run, because MNEMOVERSE_API_URL does not
+  > address the API over https — its scheme is `http://` — and sending the API
+  > key to it would put a live `mk_live_` key on the wire in cleartext […] Tell
+  > them to change MNEMOVERSE_API_URL to the https:// form of the same host […]
+  > or, if they are deliberately running the engine on their own machine, to
+  > address it as http://localhost or http://127.0.0.1 […]
+
+  `http://localhost` and `http://127.0.0.1` stay legal, because a self-hosted
+  engine is a real setup. They are compared as literal HOSTNAMES, not as string
+  prefixes: `http://localhost.evil.example` passes a prefix test and
+  `http://evil.localhost` passes a suffix test, and both are somebody else's
+  server. The message names the scheme but never quotes the URL — the URL is
+  where `http://user:pass@host` keeps its credentials.
+
+- **A credential-bearing request no longer follows redirects (CWE-200).**
+  `fetch` defaults to `redirect: "follow"` and Node re-sends request headers to
+  the redirect target — the WHATWG rules strip `Authorization`, `Cookie` and
+  `Proxy-Authorization` on a cross-origin hop and say nothing about a custom
+  header, so `X-Api-Key` rode along. An endpoint answering
+  `302 Location: https://attacker.example` therefore received a live key, and
+  the tool call SUCCEEDED, so nothing looked wrong. `apiFetch` now sends
+  `redirect: "error"`, after the options spread so no call site can opt out.
+  This API serves one stable base path and never redirects legitimately, so the
+  only traffic this refuses is an exfiltration path.
+
+- **A refused redirect says so, instead of being read as a dead network.**
+  Undici reports it as `TypeError: fetch failed`, identical to an unreachable
+  host, so without a branch of its own it would have landed in the transport
+  message and told the user to debug a "connectivity or DNS problem" on a
+  network that is working perfectly. `explainNetworkFailure` now recognises it
+  and names the cause: the API tried to redirect the call, the key was not sent
+  to the target, check `MNEMOVERSE_API_URL`. This is why the fix is three
+  changes and not one line.
+
+- **The startup key probe is covered too — it is the SECOND credential-bearing
+  call site.** `probeApiKeyInBackground` (0.8.4) calls `fetch` directly rather
+  than through `apiFetch`, so neither guard above reached it, and it fires on
+  every server START rather than on a tool call: a user whose
+  `MNEMOVERSE_API_URL` was spelled `http://` leaked the key by launching their
+  editor, and the tool-call guard would then have refused to leak a key that was
+  already out. Closing one call site and not the other would have made this
+  entry's own security claim a half-truth. The probe now makes no request at all
+  against a refused base URL, and sends `redirect: "error"` when it does run.
+  A skipped probe is not silent — silence is the invisible failure the probe
+  exists to end — so stderr, where MCP clients surface connection logs, gets:
+
+  > Mnemoverse: startup key check SKIPPED, and nothing was sent —
+  > MNEMOVERSE_API_URL has the scheme http:// rather than https://, and this
+  > server will not put your API key on the wire in cleartext. Set it to
+  > https://core.mnemoverse.com/api/v1, or to http://localhost or
+  > http://127.0.0.1 if you run the engine yourself. Every memory tool will fail
+  > until it is changed.
+
+  A probe whose redirect is refused stays silent, like every other probe
+  failure: it is fire-and-forget and must never take the server down, and the
+  same redirect meets the first real tool call, which explains it in full.
+
+### Who this breaks
+
+Anyone who deliberately pointed `MNEMOVERSE_API_URL` at a plain-`http://` host
+that is not `localhost` or `127.0.0.1`, and anyone whose endpoint answers a
+redirect. Both were sending the API key somewhere it should not go, which is
+why the break is the fix — but it is a break, and that is what makes this
+release MINOR.
+
+### Known and NOT fixed here
+
+- **`::1` is not in the loopback exemption.** IPv6 loopback is a legitimate
+  self-host address and `http://[::1]:8100` is refused today; a user on it can
+  spell the same engine `http://localhost`. Adding it (and deciding what to do
+  about container hostnames such as `host.docker.internal`) is a follow-up on
+  #99, not part of this change.
+
+### Tests
+
+`test/base-url-guard.test.ts` boots the server once per base URL
+(`vi.resetModules()` plus a dynamic import — the seam `test/startup.test.ts`
+already uses, since `API_URL` is a module-level constant) behind a recording
+`fetch`, so "refused" is asserted as *no request was made and no key was seen*,
+not as *the right sentence came back*. `test/redirect-refusal.test.ts`
+deliberately does NOT stub `fetch`: a stub has no redirect handling, so
+`redirect: "error"` is inert inside one and a test written there would pass with
+the option removed. It stands up two real `node:http` servers on loopback and
+asserts the redirect target is never contacted at all. With the fix reverted,
+that test does not merely fail — it records the attacker's server receiving
+`GET /steal` with the header `x-api-key: mk_live_…`, and the tool answering
+`Stored (importance: 0.90). ID: leaked`.
+
+The startup probe had no tests at all before this change — `test/startup.test.ts`
+*ran* it (autostart calls it) while asserting nothing about it, which is how a
+second credential-bearing call site stayed invisible through two releases. It is
+now covered there, on the autostart path with `fetch` and stderr recorded: no
+request against a refused URL, the skip line pinned verbatim, `redirect: "error"`
+on the request it does make, and — as regression guards, so the fix cannot become
+a mute button — a healthy https URL and a plain-http `localhost` still probed,
+with the key, in silence.
+
 ## [0.9.1] — 2026-08-24
 
 Text under this file's own rules: what a tool returns when it fails. No tool,

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -71,6 +71,12 @@ const KEYS_URL = "https://console.mnemoverse.com/dashboard/keys";
  *  cannot fix is resolved. Same URL the engine puts in its own 429 bodies. */
 const USAGE_URL = "https://console.mnemoverse.com/dashboard/usage";
 
+/** The base URL a user is sent back to when theirs is aimed somewhere wrong.
+ *  Mirrors `DEFAULT_API_URL` in src/index.ts and is duplicated on purpose: this
+ *  module is imported BY index.ts, so reading the value from there would be a
+ *  cycle. Change one, grep for the other. */
+const DEFAULT_API_URL = "https://core.mnemoverse.com/api/v1";
+
 /** Everything known about one failed call, at the moment it failed. */
 export interface ApiFailure {
   /** HTTP status. */
@@ -446,6 +452,42 @@ function rawDetail(f: ApiFailure): string {
 }
 
 /**
+ * Was this transport failure a REDIRECT this client refused to follow?
+ *
+ * `redirect: "error"` (src/index.ts, apiFetch) makes undici reject with
+ * `TypeError: fetch failed` whose `cause` is `Error: unexpected redirect` —
+ * verified by executing the case against a real local 302
+ * (test/redirect-refusal.test.ts, which uses a real server precisely because a
+ * stubbed fetch has no redirect handling to exercise). The literal string is
+ * `makeNetworkError('unexpected redirect')` and is identical in undici 5
+ * (Node 18), 6 (Node 20 / 22) and 7 (Node 24) — read in all three, because the
+ * CI matrix and this package's `engines` span them.
+ *
+ * WITHOUT THIS BRANCH the failure is indistinguishable from a dead host: same
+ * `TypeError: fetch failed`, and the message below would tell the user to debug
+ * a "connectivity or DNS problem" on a network that is working perfectly, while
+ * the actual cause — a base URL aimed at something that bounces — sat in their
+ * config. That is the confident wrong cause this whole module exists against.
+ *
+ * The cause chain is WALKED rather than read at one depth, since the nesting is
+ * undici's to change; the match is the exact sentinel rather than the word
+ * "redirect", because a DNS failure against a host whose NAME contains
+ * "redirect" would otherwise be diagnosed as one. If a future runtime renames
+ * the sentinel this stops firing and the honest generic sentence takes over —
+ * a degradation, not a lie — and the real-server test goes red, which is where
+ * the rename gets noticed.
+ */
+function refusedRedirect(cause: unknown): boolean {
+  let e: unknown = cause;
+  for (let depth = 0; depth < 5; depth++) {
+    if (!(e instanceof Error)) return false;
+    if (e.message.toLowerCase().includes("unexpected redirect")) return true;
+    e = e.cause;
+  }
+  return false;
+}
+
+/**
  * The request never got an answer at all: DNS, connectivity, a host that does
  * not listen, or this client's own probe deadline firing.
  *
@@ -467,6 +509,22 @@ export function explainNetworkFailure(
   const name = cause instanceof Error ? cause.name : "";
   const timedOut = name === "TimeoutError" || name === "AbortError";
   const detail = cause instanceof Error ? `${cause.name}: ${cause.message}` : String(cause);
+  if (refusedRedirect(cause)) {
+    return (
+      `Mnemoverse: ${method} ${path} was answered with a REDIRECT, and this ` +
+      "client refused to follow it — so the API key was never sent to whatever " +
+      "the redirect pointed at. That refusal is the whole point: following a " +
+      "redirect re-sends the request headers to the new host, which hands a " +
+      "live key to whoever answered. This API serves one stable base path and " +
+      "never redirects legitimately, so this means MNEMOVERSE_API_URL is aimed " +
+      "at something else — a proxy, a tunnel, a captive portal, or an address " +
+      "that has been tampered with. It is NOT a rejected key and NOT a broken " +
+      "network: the request arrived somewhere and was answered. Tell the user " +
+      "to check MNEMOVERSE_API_URL and point it straight at the API (the " +
+      `default is ${DEFAULT_API_URL}). Do not retry: the same address will ` +
+      `redirect again.\n\n${rawTransportDetail(method, path, detail)}`
+    );
+  }
   const head = timedOut
     ? `Mnemoverse: the memory service did not answer ${method} ${path} in time.`
     : `Mnemoverse: the memory service could not be reached at all — ${method} ` +
@@ -480,8 +538,14 @@ export function explainNetworkFailure(
     "reply arrived to say anything about either, so do not send the user to " +
     "check their key. One retry is reasonable. If that also fails, tell the " +
     "user memory is unreachable and carry on without it rather than retrying.\n\n" +
-    `Raw detail — request to ${method} ${path} failed: ${detail}`
+    rawTransportDetail(method, path, detail)
   );
+}
+
+/** The debugging half of a transport failure, in one place so the redirect
+ *  branch and the generic one cannot drift into two spellings of it. */
+function rawTransportDetail(method: string, path: string, detail: string): string {
+  return `Raw detail — request to ${method} ${path} failed: ${detail}`;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,8 +97,11 @@ function probeScope(searched: string | undefined): Promise<ReadScope> {
 const require = createRequire(import.meta.url);
 const pkg = require("../package.json") as { version: string };
 
-const API_URL =
-  process.env.MNEMOVERSE_API_URL || "https://core.mnemoverse.com/api/v1";
+/** Where the key goes when the user names no host. Referenced by the base-URL
+ *  refusal below, which has to tell them what to set it back to. */
+const DEFAULT_API_URL = "https://core.mnemoverse.com/api/v1";
+
+const API_URL = process.env.MNEMOVERSE_API_URL || DEFAULT_API_URL;
 const API_KEY = process.env.MNEMOVERSE_API_KEY || "";
 
 // Hard cap on tool result size — required by Claude Connectors Directory
@@ -113,6 +116,115 @@ const MAX_RESULT_CHARS = 24_000 * 4;
 // and clients may browse capabilities before sign-in; a startup exit on a
 // missing key blocks all of that. A tool *invocation* without a key returns a
 // clear, actionable error instead (see apiFetch).
+
+/**
+ * A base URL the key may not go to, spelled for each of its two readers.
+ *
+ * They are computed together, from one parse, so they cannot come to disagree
+ * about why the call was refused — but they are NOT the same sentence, because
+ * the readers differ. A tool result is read by a MODEL and is written as
+ * instructions about the user ("tell them to…"); a startup line is read by the
+ * USER in their client's connection log and addresses them directly.
+ */
+interface BaseUrlRefusal {
+  /** What a tool CALL answers instead of running. */
+  toolCall: string;
+  /** The one line stderr gets at startup, in place of the key probe. */
+  startupLog: string;
+}
+
+/**
+ * Is `MNEMOVERSE_API_URL` an address this client may attach the API key to —
+ * and if not, what does the user have to change (#99, CWE-319)?
+ *
+ * `apiFetch` attaches `X-Api-Key` to whatever this variable holds. Until this
+ * check existed, a base URL spelled `http://` — a typo, a copied tunnel address,
+ * a misread doc — put a live `mk_live_` key in cleartext on every tool call, on
+ * every hop between the user and that host, with nothing anywhere saying so.
+ * The key is the whole account: it reads and writes that user's memory.
+ *
+ * TWO HOSTS ARE EXEMPT, AND ONLY AS LITERAL HOSTNAMES. `http://localhost` and
+ * `http://127.0.0.1` are legitimate — a self-hosted engine, this repo's own test
+ * harness — and a guard that demanded https unconditionally would break them.
+ * The comparison is against `URL.hostname`, NOT a prefix or suffix of the raw
+ * string, because `http://localhost.evil.example` passes a prefix test and
+ * `http://evil.localhost` passes a suffix test while both resolve to somebody
+ * else's server. `::1` is deliberately NOT in the list: it is a follow-up (#99),
+ * not an oversight, and a self-hoster on IPv6 loopback can spell it `localhost`
+ * today. The exemption is also scheme-bound — `ftp://localhost` is refused —
+ * since "aimed at loopback" is not by itself a reason to trust a transport.
+ *
+ * RETURNS A STRING RATHER THAN THROWING, and is called at import rather than
+ * on each request, because a throw at import would take the server down before
+ * `tools/list` — the one thing that is documented to work without any config at
+ * all (registries boot this server to enumerate its tools). The refusal has to
+ * land where the keyless refusal lands: inside a tool CALL.
+ *
+ * THE MESSAGE NEVER QUOTES THE URL, only its scheme. src/errors.ts keeps the
+ * base URL out of every message it builds on the stated grounds that the base
+ * can carry credentials — `http://user:pass@host` is exactly the case this guard
+ * fires on, so the one message whose subject IS the base URL is also the one
+ * most likely to leak it into a model's context and a client's logs. A scheme
+ * is safe to interpolate for a second reason: the URL parser restricts it to
+ * `[a-z0-9+.-]`, so it cannot carry a newline and open its own paragraph in
+ * this file's instruction voice.
+ */
+function refuseInsecureBaseUrl(raw: string): BaseUrlRefusal | undefined {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return {
+      toolCall:
+        "Mnemoverse: this tool did not run, because MNEMOVERSE_API_URL is not " +
+        "a URL this client can parse — so it cannot tell whether sending the " +
+        "API key to it would expose the key, and it will not guess. Nothing " +
+        "was sent. This is the user's configuration: their key, their network " +
+        "and the service are all fine. Tell them to set MNEMOVERSE_API_URL to " +
+        "a complete https:// URL including the scheme and the path — the " +
+        `default is ${DEFAULT_API_URL} — or to unset it and use that default. ` +
+        "A local engine is the one exception and must be addressed as " +
+        "http://localhost or http://127.0.0.1. Do not retry until it is " +
+        "changed; every memory tool will fail the same way until then.",
+      startupLog:
+        "Mnemoverse: startup key check SKIPPED, and nothing was sent — " +
+        "MNEMOVERSE_API_URL is not a URL this server can parse, so it cannot " +
+        "tell whether sending your API key over it would expose it. Set it to " +
+        `a complete https:// URL such as ${DEFAULT_API_URL}, or unset it to ` +
+        "use that default. Every memory tool will fail until it is changed.",
+    };
+  }
+  const loopback = url.hostname === "localhost" || url.hostname === "127.0.0.1";
+  if (url.protocol === "https:" || (url.protocol === "http:" && loopback)) {
+    return undefined;
+  }
+  return {
+    toolCall:
+      "Mnemoverse: this tool did not run, because MNEMOVERSE_API_URL does not " +
+      `address the API over https — its scheme is ${url.protocol}// — and ` +
+      "sending the API key to it would put a live mk_live_ key on the wire in " +
+      "cleartext, readable by anything on the path. Nothing was sent: this " +
+      "client refuses the call instead. This is the user's configuration, not " +
+      "a fault of the key, the network or the service. Tell them to change " +
+      "MNEMOVERSE_API_URL to the https:// form of the same host — the default " +
+      `is ${DEFAULT_API_URL} — or, if they are deliberately running the ` +
+      "engine on their own machine, to address it as http://localhost or " +
+      "http://127.0.0.1, the only two plain-http hosts this client accepts. " +
+      "Do not retry until it is changed; every memory tool will fail the same " +
+      "way until then.",
+    startupLog:
+      "Mnemoverse: startup key check SKIPPED, and nothing was sent — " +
+      `MNEMOVERSE_API_URL has the scheme ${url.protocol}// rather than ` +
+      "https://, and this server will not put your API key on the wire in " +
+      `cleartext. Set it to ${DEFAULT_API_URL}, or to http://localhost or ` +
+      "http://127.0.0.1 if you run the engine yourself. Every memory tool " +
+      "will fail until it is changed.",
+  };
+}
+
+/** The verdict on this process's base URL, computed once. `undefined` means the
+ *  key may go out; anything else is what each surface says instead. */
+const BASE_URL_REFUSAL = refuseInsecureBaseUrl(API_URL);
 
 /**
  * Fetch from the Mnemoverse core API with authentication.
@@ -148,10 +260,29 @@ async function apiFetch<T = unknown>(
         "tool will fail the same way until then.",
     );
   }
+  if (BASE_URL_REFUSAL !== undefined) {
+    // Alongside the key check, and after it: with no key configured there is
+    // nothing to expose, and "set the variable" is the more useful first thing
+    // to tell someone who has set neither. Both are decided from CONFIGURATION
+    // alone, which is why both belong here rather than in a diagnosis of the
+    // response — a guard that fired after fetch would print the right sentence
+    // about a key it had already put on the wire.
+    throw new Error(BASE_URL_REFUSAL.toolCall);
+  }
   let res: Response;
   try {
     res = await fetch(`${API_URL}${path}`, {
       ...options,
+      // AFTER the spread, so no call site can opt out of it. `fetch` defaults to
+      // "follow", and Node re-sends request headers to the redirect target: the
+      // WHATWG rules strip Authorization, Cookie and Proxy-Authorization when
+      // the origin changes and say nothing about a custom header, so
+      // `X-Api-Key` rides along to whoever answered (#99, CWE-200). This API
+      // serves one stable base path and never redirects legitimately, so the
+      // only traffic this refuses is an exfiltration path. The resulting
+      // rejection is named by explainNetworkFailure rather than left to look
+      // like a dead host.
+      redirect: "error",
       headers: {
         "Content-Type": "application/json",
         "X-Api-Key": API_KEY,
@@ -1567,10 +1698,33 @@ server.registerTool(
  */
 function probeApiKeyInBackground(): void {
   if (!API_KEY) return;
+  if (BASE_URL_REFUSAL !== undefined) {
+    // THE SECOND CREDENTIAL-BEARING CALL SITE (#99). This probe predates
+    // apiFetch's base-URL guard and calls `fetch` directly, so the guard does
+    // not reach it — and this one fires on every server START, before any tool
+    // is called. Left alone, a user whose MNEMOVERSE_API_URL is spelled
+    // `http://` would leak the key by launching their editor, and the tool-call
+    // guard would then dutifully refuse to leak the key it had already leaked.
+    //
+    // Saying nothing is not an option either: a silent server whose every tool
+    // then fails is the exact invisible failure mode this probe was added to
+    // end. So it reports the skip on stderr — where MCP clients surface
+    // connection logs — in the user's own register.
+    console.error(BASE_URL_REFUSAL.startupLog);
+    return;
+  }
   void (async () => {
     try {
       const res = await fetch(`${API_URL}/memory/stats`, {
         headers: { "X-Api-Key": API_KEY },
+        // Same reason as apiFetch: following a redirect re-sends this header to
+        // the new host (#99, CWE-200), and this request carries the key just as
+        // a tool call does. The rejection lands in the catch below with every
+        // other probe failure — deliberately, since the probe is fire-and-forget
+        // and must never take the server down. Nothing is lost by the silence:
+        // the same redirect meets the first real tool call, where
+        // explainNetworkFailure names it in full.
+        redirect: "error",
         signal: AbortSignal.timeout(10_000),
       });
       // Drain the body so the connection returns to the pool immediately —

--- a/test/base-url-guard.test.ts
+++ b/test/base-url-guard.test.ts
@@ -1,0 +1,235 @@
+/**
+ * The API key does not go on the wire in cleartext (#99, CWE-319).
+ *
+ * `MNEMOVERSE_API_URL` is a user-supplied env var and `apiFetch` used to attach
+ * `X-Api-Key` to whatever it held. A typo, a copied tunnel URL, or a misread doc
+ * that spells the base `http://` therefore shipped a live `mk_live_` key in
+ * cleartext on every single tool call — with nothing anywhere saying so.
+ *
+ * IT GETS ITS OWN FILE for the same reason test/errors-keyless.test.ts does:
+ * `API_URL` is read into a module-level constant while src/index.ts evaluates,
+ * and the shared harness pins one URL before importing it. A guard that depends
+ * on the base URL can only be tested by booting the module more than once, which
+ * `vi.resetModules()` plus a dynamic import gives us — the same seam
+ * test/startup.test.ts already uses.
+ *
+ * THE TRAP IS THE ASSERTION. Every boot replaces `globalThis.fetch` with a
+ * recorder, so "refused" is not "returned an error message" — it is "no request
+ * was made and no key was seen". A guard that produced the right sentence AFTER
+ * calling fetch would still have leaked the key, and would still pass a test
+ * that only read the sentence.
+ *
+ * WHY THE LOOPBACK EXCEPTION IS SPELLED OUT HOST BY HOST. `http://localhost` and
+ * `http://127.0.0.1` are legitimate (a self-hosted engine, this repo's own test
+ * harness), so the guard cannot simply demand https. The cheap way to write that
+ * exception is a prefix test on the string — and `http://localhost.evil.example`
+ * passes a prefix test while resolving to somebody else's server. The hostname
+ * cases below exist to pin the literal-host comparison that closes it.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+
+/** Shaped like a real key so nothing rejects it for its format. Never sent
+ *  anywhere: fetch is replaced before the module is imported. */
+const KEY = "mk_live_base_url_guard_not_a_secret";
+
+interface Booted {
+  call(
+    name: string,
+    args?: Record<string, unknown>,
+  ): Promise<{ isError?: unknown; text: string }>;
+  /** Tools the server advertises — introspection must survive a refused URL. */
+  toolNames(): Promise<string[]>;
+  /** Every URL that reached fetch. Empty means the guard fired first. */
+  reached: string[];
+  /** Every `X-Api-Key` fetch saw. MUST stay empty for a refused base URL. */
+  keysOnTheWire: string[];
+  close(): Promise<void>;
+}
+
+let booted: Booted | undefined;
+
+afterEach(async () => {
+  await booted?.close();
+  booted = undefined;
+});
+
+/** Boot src/index.ts fresh against `apiUrl`, with fetch recorded rather than
+ *  performed. */
+async function bootWith(apiUrl: string): Promise<Booted> {
+  vi.resetModules();
+  process.env.MNEMOVERSE_MCP_NO_AUTOSTART = "1";
+  process.env.MNEMOVERSE_API_KEY = KEY;
+  process.env.MNEMOVERSE_API_URL = apiUrl;
+
+  const reached: string[] = [];
+  const keysOnTheWire: string[] = [];
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: unknown, init?: RequestInit) => {
+    reached.push(String(input));
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+    const key = headers["X-Api-Key"] ?? headers["x-api-key"];
+    if (key !== undefined) keysOnTheWire.push(key);
+    return new Response(JSON.stringify({ stored: true, atom_id: "a", importance: 0.9 }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof fetch;
+
+  const { server } = await import("../src/index.js");
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "base-url-guard", version: "0.0.0" });
+  await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+
+  const textOf = (content: unknown): string =>
+    (Array.isArray(content) ? content : [])
+      .filter(
+        (c): c is { type: "text"; text: string } =>
+          typeof c === "object" && c !== null && (c as { type?: string }).type === "text",
+      )
+      .map((c) => c.text)
+      .join("\n");
+
+  booted = {
+    reached,
+    keysOnTheWire,
+    async call(name, args = {}) {
+      const res = await client.callTool({ name, arguments: args });
+      return { isError: res.isError, text: textOf(res.content) };
+    },
+    async toolNames() {
+      return (await client.listTools()).tools.map((t) => t.name);
+    },
+    async close() {
+      globalThis.fetch = realFetch;
+      await client.close();
+      await server.close();
+    },
+  };
+  return booted;
+}
+
+// ---------------------------------------------------------------------------
+
+/** Base URLs that must never carry the key, and why each one is here. */
+const REFUSED: ReadonlyArray<readonly [label: string, url: string]> = [
+  ["plain http to a public host", "http://evil.example/api/v1"],
+  // A prefix test on "http://localhost" says yes to this. A hostname
+  // comparison says no. That difference is the whole exception.
+  ["a host that merely BEGINS with localhost", "http://localhost.evil.example/api/v1"],
+  ["a host that merely begins with the loopback IP", "http://127.0.0.1.evil.example/api/v1"],
+  // Same trick from the other end — a suffix test would say yes. RFC 6761 does
+  // ask resolvers to keep `*.localhost` on loopback, but "should" is not
+  // "does", and this client is not the place to gamble a live key on which
+  // resolver the user has.
+  ["a subdomain of localhost", "http://evil.localhost/api/v1"],
+  // Credentials in the base URL are the case where a leak costs most, and the
+  // case where echoing the URL back at the model would itself be the leak.
+  ["http with credentials in the URL", "http://user:hunter2@evil.example/api/v1"],
+  // The loopback exception is for http, not for "anything aimed at loopback".
+  ["a non-http scheme aimed at loopback", "ftp://localhost/api/v1"],
+  // Not a URL at all: the client cannot tell whether this would be safe, and
+  // "cannot tell" is not permission.
+  ["something that is not a URL", "core.mnemoverse.com/api/v1"],
+];
+
+describe("a base URL that would put the key in cleartext is refused before fetch", () => {
+  it.each(REFUSED)("%s — no request, no key", async (_label, url) => {
+    const mcp = await bootWith(url);
+
+    const res = await mcp.call("memory_write", { content: "x" });
+
+    expect(res.isError).toBe(true);
+    // The point of the whole change: the refusal happens BEFORE the request.
+    expect(mcp.reached).toEqual([]);
+    expect(mcp.keysOnTheWire).toEqual([]);
+  });
+
+  it("says what is wrong, whose problem it is, and what to change", async () => {
+    const mcp = await bootWith("http://evil.example/api/v1");
+
+    const res = await mcp.call("memory_write", { content: "x" });
+
+    // Attributable, like every other message this server produces.
+    expect(res.text.startsWith("Mnemoverse: ")).toBe(true);
+    expect(res.text).toContain("MNEMOVERSE_API_URL");
+    expect(res.text).toContain("https://");
+    // The user's own local engine is a legitimate reason to be on http, and the
+    // message has to say which spellings of it survive — otherwise a self-hoster
+    // reads this as "Mnemoverse refuses to talk to my server".
+    expect(res.text).toContain("http://localhost");
+    expect(res.text).toContain("http://127.0.0.1");
+    expect(res.text).toContain("Do not retry");
+    // The wrong causes this must never suggest: nothing was rejected and
+    // nothing was unreachable — no request was made at all.
+    expect(res.text).not.toContain("rejected");
+    expect(res.text).not.toContain("connectivity");
+  });
+
+  it("does not echo the base URL back — that is where the credentials are", async () => {
+    // src/errors.ts keeps the full URL out of every message it builds, on the
+    // stated grounds that the base can carry credentials. A guard whose whole
+    // subject IS the base URL is the one place most tempted to quote it.
+    const mcp = await bootWith("http://user:hunter2@evil.example/api/v1");
+
+    const res = await mcp.call("memory_write", { content: "x" });
+
+    expect(res.text).not.toContain("hunter2");
+    expect(res.text).not.toContain("evil.example");
+  });
+
+  it("answers the same way for every tool", async () => {
+    const mcp = await bootWith("http://evil.example/api/v1");
+
+    for (const [tool, args] of [
+      ["memory_read", { query: "x" }],
+      ["memory_write", { content: "x" }],
+      ["memory_stats", {}],
+      ["memory_list_rooms", {}],
+      ["vault_list", {}],
+    ] as const) {
+      const res = await mcp.call(tool, args);
+      expect(res.isError, tool).toBe(true);
+      expect(res.text, tool).toContain("MNEMOVERSE_API_URL");
+    }
+    expect(mcp.reached).toEqual([]);
+    expect(mcp.keysOnTheWire).toEqual([]);
+  });
+
+  it("tools still LIST — a bad base URL must not break introspection", async () => {
+    // Same property the keyless path is held to: registries boot this server to
+    // enumerate its tools, and a guard that moved the failure to startup or to
+    // tools/list would break that for everyone who set the variable wrong.
+    const mcp = await bootWith("http://evil.example/api/v1");
+
+    expect(await mcp.toolNames()).toContain("memory_write");
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+/** Base URLs that must keep working. A guard that breaks these is worse than
+ *  the hole it closes: self-hosting and this repo's own harness live here. */
+const ALLOWED: ReadonlyArray<readonly [label: string, url: string]> = [
+  ["the production default", "https://core.mnemoverse.com/api/v1"],
+  ["https to any other host — the scheme is what is policed", "https://example.test/api/v1"],
+  ["a local engine by name", "http://localhost:8100/api/v1"],
+  ["a local engine by loopback IP", "http://127.0.0.1:8100/api/v1"],
+  // Exactly what test/harness.ts pins. If this row goes red the whole suite is
+  // about to, and this is the file that says why.
+  ["the harness's own black-hole URL", "http://127.0.0.1:1/api/v1"],
+];
+
+describe("the URLs that must keep working", () => {
+  it.each(ALLOWED)("%s — the request goes out, with the key", async (_label, url) => {
+    const mcp = await bootWith(url);
+
+    const res = await mcp.call("memory_write", { content: "x" });
+
+    expect(res.isError).toBeFalsy();
+    expect(mcp.reached).toEqual([`${url}/memory/write`]);
+    expect(mcp.keysOnTheWire).toEqual([KEY]);
+  });
+});

--- a/test/redirect-refusal.test.ts
+++ b/test/redirect-refusal.test.ts
@@ -1,0 +1,165 @@
+/**
+ * A credential-bearing request does not follow a redirect (#99, CWE-200).
+ *
+ * `fetch` defaults to `redirect: "follow"`, and Node re-sends request headers to
+ * the redirect target — the WHATWG rules strip `Authorization`, `Cookie` and
+ * `Proxy-Authorization` when the origin changes, and say nothing about a custom
+ * header, so `X-Api-Key` rides along. An endpoint that answers
+ * `302 Location: https://attacker.example` therefore receives a live `mk_live_`
+ * key, and the tool call succeeds, so nothing anywhere looks wrong.
+ *
+ * THIS TEST DOES NOT STUB fetch, AND THAT IS THE POINT. test/harness.ts replaces
+ * `globalThis.fetch` with a recorder that returns a `Response` object — a stub
+ * has no redirect handling at all, so `redirect: "error"` is inert inside it and
+ * a test written there would pass with the option removed. Following a redirect
+ * is undici's behaviour, so proving we do not follow one means going through
+ * undici: two real `node:http` servers on loopback, ephemeral ports, and the
+ * server's own fetch.
+ *
+ * The base URL is `http://127.0.0.1:<port>` because that is what a local server
+ * can be reached at — and it is one of the two hosts the base-URL guard added in
+ * the same change lets through on plain http (see test/base-url-guard.test.ts).
+ * The two halves of #99 meet here.
+ *
+ * WHAT RED LOOKS LIKE, before the fix: the tool call SUCCEEDS (the target
+ * answers 200 with a JSON body), and `targetSaw` holds one request carrying the
+ * key. That is the vulnerability, executed.
+ */
+
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+
+const KEY = "mk_live_redirect_refusal_not_a_secret";
+
+/** What the redirect target managed to see. Every field here is something the
+ *  attacker in the CWE-200 story gets for free. */
+interface Seen {
+  method: string;
+  url: string;
+  apiKey: string | undefined;
+}
+
+const targetSaw: Seen[] = [];
+let api: http.Server;
+let target: http.Server;
+let close: () => Promise<void>;
+/** The one tool result under test — taken once, asserted from several angles. */
+let result: { isError?: unknown; text: string };
+
+function listen(server: http.Server): Promise<number> {
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      resolve((server.address() as AddressInfo).port);
+    });
+  });
+}
+
+function shutdown(server: http.Server): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+beforeAll(async () => {
+  // The attacker's endpoint: answers 200 so that a followed redirect would look
+  // like a perfectly successful write, and records what it was handed.
+  target = http.createServer((req, res) => {
+    targetSaw.push({
+      method: req.method ?? "",
+      url: req.url ?? "",
+      apiKey: req.headers["x-api-key"] as string | undefined,
+    });
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ stored: true, atom_id: "leaked", importance: 0.9 }));
+  });
+  const targetPort = await listen(target);
+
+  // What MNEMOVERSE_API_URL points at: a compromised or misconfigured endpoint
+  // that bounces every call somewhere else. A DIFFERENT PORT is a different
+  // origin, which is exactly the cross-origin case where the spec's header
+  // stripping does not cover X-Api-Key.
+  api = http.createServer((_req, res) => {
+    res.writeHead(302, { Location: `http://127.0.0.1:${targetPort}/steal` });
+    res.end();
+  });
+  const apiPort = await listen(api);
+
+  // Set BEFORE the import: src/index.ts reads both into module-level constants
+  // while it evaluates.
+  process.env.MNEMOVERSE_MCP_NO_AUTOSTART = "1";
+  process.env.MNEMOVERSE_API_KEY = KEY;
+  process.env.MNEMOVERSE_API_URL = `http://127.0.0.1:${apiPort}/api/v1`;
+
+  const { server } = await import("../src/index.js");
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "redirect-refusal", version: "0.0.0" });
+  await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+
+  const res = await client.callTool({ name: "memory_write", arguments: { content: "x" } });
+  result = {
+    isError: res.isError,
+    text: (Array.isArray(res.content) ? res.content : [])
+      .filter(
+        (c): c is { type: "text"; text: string } =>
+          typeof c === "object" && c !== null && (c as { type?: string }).type === "text",
+      )
+      .map((c) => c.text)
+      .join("\n"),
+  };
+
+  close = async () => {
+    await client.close();
+    await server.close();
+    await shutdown(api);
+    await shutdown(target);
+  };
+});
+
+afterAll(async () => {
+  await close();
+});
+
+describe("a 302 does not carry the API key anywhere", () => {
+  it("the redirect target is never contacted at all", () => {
+    // Not "was contacted without the key" — not contacted. `redirect: "error"`
+    // rejects the request rather than issuing a second one, so there is no
+    // second request to sanitise and nothing depends on which headers a future
+    // Node decides to strip.
+    expect(targetSaw).toEqual([]);
+  });
+
+  it("and specifically, it never sees the key", () => {
+    // Stated separately from the line above because this is the CWE, and a
+    // future change that legitimately contacts a redirect target must still
+    // fail here rather than quietly re-open the leak.
+    expect(targetSaw.filter((s) => s.apiKey !== undefined)).toEqual([]);
+  });
+
+  it("the call fails instead of quietly succeeding against a stranger", () => {
+    // The pre-fix behaviour was a SUCCESSFUL write — the target answers 200, so
+    // the user is told their memory was stored while it went to whoever
+    // answered the redirect. A leak that reports success is the worst shape.
+    expect(result.isError).toBe(true);
+    expect(result.text).not.toContain("leaked");
+  });
+
+  it("names the redirect, so nobody debugs their wifi over a config problem", () => {
+    // Without a branch of its own this lands in the generic transport failure —
+    // undici reports a refused redirect as `TypeError: fetch failed`, exactly
+    // like a dead host — and the message would say "connectivity or DNS
+    // problem", sending the user to check a network that is working fine.
+    expect(result.text.startsWith("Mnemoverse: ")).toBe(true);
+    expect(result.text).toContain("redirect");
+    expect(result.text).toContain("MNEMOVERSE_API_URL");
+    expect(result.text).toContain("Do not retry");
+    expect(result.text).not.toContain("connectivity or DNS problem");
+    // And it must not blame the key, which is the one thing that is fine.
+    expect(result.text).not.toContain("check their key");
+  });
+
+  it("keeps the raw transport detail for whoever has to debug it", () => {
+    expect(result.text).toContain("POST /memory/write");
+    expect(result.text).toContain("fetch failed");
+  });
+});

--- a/test/startup.test.ts
+++ b/test/startup.test.ts
@@ -73,6 +73,167 @@ async function transportsOpenedWith(value: string | undefined): Promise<number> 
   return stdio.constructed;
 }
 
+// ---------------------------------------------------------------------------
+
+/**
+ * The startup key probe is a SECOND credential-bearing call site (#99).
+ *
+ * `probeApiKeyInBackground` calls `fetch` directly rather than through
+ * `apiFetch`, so the base-URL guard and the redirect refusal added to `apiFetch`
+ * do not reach it. Left alone it would send `X-Api-Key` to whatever
+ * `MNEMOVERSE_API_URL` holds — in cleartext over `http://`, and onward to
+ * wherever a 302 pointed — once per server start, before any tool is ever
+ * called. A user whose config is wrong leaks the key by launching their editor.
+ *
+ * These live in THIS file rather than in test/base-url-guard.test.ts because the
+ * probe only runs on the autostart path, which that file switches off, and
+ * because this file already mocks the stdio transport — without that mock a real
+ * one seizes the runner's stdin and stdout.
+ */
+
+/** One request the startup path made, as the trap saw it. */
+interface ProbeCall {
+  url: string;
+  apiKey: string | undefined;
+  redirect: RequestRedirect | undefined;
+}
+
+interface Startup {
+  calls: ProbeCall[];
+  stderr: string[];
+}
+
+const PROBE_KEY = "mk_live_probe_call_site_not_a_secret";
+
+/** Boot the module on the AUTOSTART path against `apiUrl`, with fetch and
+ *  stderr recorded rather than performed, and let the background probe settle.
+ *
+ *  `key` is `null` for "no key configured", NOT `undefined`: passing `undefined`
+ *  for an optional parameter selects its DEFAULT, so the keyless case would
+ *  silently run with a key. It did, in this file's first red run. */
+async function startupWith(apiUrl: string, key: string | null = PROBE_KEY): Promise<Startup> {
+  vi.resetModules();
+  stdio.constructed = 0;
+  delete process.env[VAR];
+  process.env.MNEMOVERSE_API_URL = apiUrl;
+  if (key === null) delete process.env.MNEMOVERSE_API_KEY;
+  else process.env.MNEMOVERSE_API_KEY = key;
+
+  const calls: ProbeCall[] = [];
+  const stderr: string[] = [];
+  const realFetch = globalThis.fetch;
+  const realError = console.error;
+  globalThis.fetch = (async (input: unknown, init?: RequestInit) => {
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+    calls.push({
+      url: String(input),
+      apiKey: headers["X-Api-Key"] ?? headers["x-api-key"],
+      redirect: init?.redirect,
+    });
+    return new Response(JSON.stringify({ total_atoms: 0 }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof fetch;
+  console.error = (...args: unknown[]) => {
+    stderr.push(args.map(String).join(" "));
+  };
+
+  try {
+    await import("../src/index.js");
+    // `main()` is async and deliberately unawaited by the module, and the probe
+    // itself is fire-and-forget inside it. Drain a few turns so both a
+    // synchronous refusal and a completed request have landed.
+    for (let i = 0; i < 5; i++) await new Promise((resolve) => setTimeout(resolve, 0));
+  } finally {
+    globalThis.fetch = realFetch;
+    console.error = realError;
+    process.env.MNEMOVERSE_API_URL = "http://127.0.0.1:1/api/v1";
+    process.env.MNEMOVERSE_API_KEY = "mk_live_startup_test";
+  }
+
+  return { calls, stderr };
+}
+
+describe("the startup key probe does not leak the key either", () => {
+  it("an insecure base URL: no request is made at all", async () => {
+    const { calls } = await startupWith("http://evil.example/api/v1");
+
+    // Not "made a request without the key" — made none. The probe has exactly
+    // one job and it cannot be done safely against this URL.
+    expect(calls).toEqual([]);
+    expect(calls.filter((c) => c.apiKey !== undefined)).toEqual([]);
+  });
+
+  it("and it says on stderr that it skipped, and why", async () => {
+    // stderr is where an MCP client surfaces connection logs — the place a user
+    // actually looks. Silence here would mean a server that quietly does
+    // nothing while every tool call fails, which is the invisible failure mode
+    // the 0.8.4 probe was added to end.
+    const { stderr } = await startupWith("http://evil.example/api/v1");
+
+    expect(stderr).toHaveLength(1);
+    expect(stderr[0]).toBe(
+      "Mnemoverse: startup key check SKIPPED, and nothing was sent — " +
+        "MNEMOVERSE_API_URL has the scheme http:// rather than https://, and " +
+        "this server will not put your API key on the wire in cleartext. Set " +
+        "it to https://core.mnemoverse.com/api/v1, or to http://localhost or " +
+        "http://127.0.0.1 if you run the engine yourself. Every memory tool " +
+        "will fail until it is changed.",
+    );
+  });
+
+  it("a URL that is not a URL is skipped too, and says so in its own words", async () => {
+    const { calls, stderr } = await startupWith("core.mnemoverse.com/api/v1");
+
+    expect(calls).toEqual([]);
+    expect(stderr).toHaveLength(1);
+    expect(stderr[0]).toContain("startup key check SKIPPED");
+    expect(stderr[0]).toContain("not a URL this server can parse");
+    // The scheme sentence would be a lie here — there is no parsed scheme.
+    expect(stderr[0]).not.toContain("rather than https://");
+  });
+
+  it("refuses redirects, so a 302 cannot forward the key", async () => {
+    // The probe is fire-and-forget and swallows its own failures, so the only
+    // thing a test can pin is the instruction it hands fetch — which is the
+    // thing that decides whether the key is forwarded.
+    const { calls } = await startupWith("https://core.mnemoverse.com/api/v1");
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.redirect).toBe("error");
+  });
+
+  it("a healthy base URL still gets probed, with the key — the fix is not a mute button", async () => {
+    const { calls, stderr } = await startupWith("https://core.mnemoverse.com/api/v1");
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe("https://core.mnemoverse.com/api/v1/memory/stats");
+    expect(calls[0]?.apiKey).toBe(PROBE_KEY);
+    // 2xx: a quiet startup is the healthy one.
+    expect(stderr).toEqual([]);
+  });
+
+  it("localhost on plain http still gets probed — self-hosting is not broken", async () => {
+    const { calls, stderr } = await startupWith("http://localhost:8100/api/v1");
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.apiKey).toBe(PROBE_KEY);
+    expect(stderr).toEqual([]);
+  });
+
+  it("no key, no probe and no complaint — keyless startup is documented behaviour", async () => {
+    const { calls, stderr } = await startupWith("http://evil.example/api/v1", null);
+
+    expect(calls).toEqual([]);
+    // Nothing to leak and nothing to check: a registry enumerating tools must
+    // not be told off about a URL it will never send anything to.
+    expect(stderr).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+
 describe("the published CLI still starts itself", () => {
   it("opens stdio when the variable is unset — the default is unchanged", async () => {
     expect(await transportsOpenedWith(undefined)).toBe(1);


### PR DESCRIPTION
Closes #99.

## What

`apiFetch` attached `X-Api-Key` to whatever `MNEMOVERSE_API_URL` held (CWE-319) and followed redirects with that header attached (CWE-200): an `http://` base URL or a single 302 put a live `mk_live_` key on the wire — the redirect case *while reporting a successful write* (the RED test run captured exactly that: the key arrived at the redirect target and the tool answered `Stored`). Both are now refused **before** any request is made:

- **HTTPS guard**: `https:` on any host, or `http:` only for the literal hostnames `localhost` / `127.0.0.1` (`URL.hostname` comparison — `http://localhost.evil.example` and `http://evil.localhost` are both refused; the exemption is scheme-bound, so `ftp://localhost` is refused too). The refusal message never quotes the URL — `http://user:pass@host` is precisely a case it fires on — only the scheme, which the URL parser confines to `[a-z0-9+.-]`.
- **`redirect: "error"`** placed after the options spread so no call site can opt out. The refusal gets its own diagnosis in `explainNetworkFailure`: without it, the failure is byte-for-byte a "connectivity or DNS problem" (same `TypeError: fetch failed`; only `cause.message` — the undici sentinel `unexpected redirect` — tells them apart, verified against a real local 302 and read in undici 5/6/7 sources for the Node 18/20/22/24 span).
- **The second credential-bearing call site is closed in the same PR**: the 0.8.4 startup probe calls `fetch` directly, past `apiFetch`, once per server start. Against a refused base URL it now sends nothing and prints an honest stderr line in its place; when it runs, it carries `redirect: "error"`. Left open, launching an editor would leak the key that the tool-call guard then dutifully refuses to leak again.

## Deliberate scope edges

- `::1` and container hosts (`host.docker.internal`) stay **outside** the plain-http exemption — recorded in CHANGELOG as the follow-up, not an oversight; an IPv6-loopback self-hoster can spell it `localhost` today.
- The guard returns instead of throwing at import: `tools/list` is documented to work with no config at all (registries boot the server to enumerate tools), so the refusal lands where the keyless refusal lands — inside a tool call.

## Self-review (reviewer voice)

- TDD held: 14 red tests first, including one that *executed* the exfiltration (key received by the redirect target, success reported to the user). RED also caught a bug in the test itself (an explicit `undefined` selects the default parameter — the keyless sentinel became `null`, with a comment telling the story).
- The probe had **zero** tests before this PR (`startup.test.ts` executed it but asserted nothing about it — how the second call site stayed invisible for two releases); it now has seven, including two regression guards pinning that healthy https and plain-http localhost still probe, with the key, silently — so the fix cannot rot into a mute button.
- The redirect detector walks the cause chain and matches the exact sentinel, not the word "redirect" — a DNS failure on a host *named* "redirect" stays a DNS failure. If a runtime renames the sentinel, the honest generic sentence takes over (degradation, not a lie) and the real-server test goes red.
- Gate mirrored the full CI matrix locally: `tsc --noEmit`, `typecheck:test`, tests ×3 timezones (443/443), `verify:configs` (19 artifacts in sync), build + stdio smoke — plus a live run of the built artifact against `http://evil.example` (stderr line printed, zero requests made).

Done-by: Σ
