### PR TITLE
fix(list-recent): page by byte budget, not just item count (#104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,90 @@ git history and the GitHub releases are the record.
 
 ## [Unreleased]
 
+MINOR by this file's own rules, and stated up front: `memory_list_recent`
+changes what goes on the wire. One request for the caller's `limit` becomes a
+short series of small ones, and `limit` — which the schema already described as
+a page size — is now a ceiling the page may legitimately come in under. No
+tool, parameter, annotation or route changes; nothing moves data.
+
+### Fixed
+
+- **A feed page is bounded by SIZE, not only by item count (#104).** Catching
+  up on a shared room of long archival entries with
+  `memory_list_recent(domain: "xroom:…", limit: 40, cursor: …)` returned ONE
+  tool result of 72,648 characters. Claude Code refused to inline it and
+  spilled it to a local file, which the agent then had to re-read in chunks; a
+  client without that fallback loses the page entirely. This is the read-side
+  half of a failure already recorded on the write side — the ten-agent dogfood
+  of 2026-08-07 (#64) lost an agent to "died on the output limit".
+
+  The global cap did not fire, and could not have. `MAX_RESULT_CHARS` is
+  96,000, i.e. `24,000 tokens × 4 chars/token`, and 4 chars per token is an
+  average over ordinary prose. Archival room entries carry ids, code,
+  punctuation and non-ASCII and tokenize far worse, so a page that is 25%
+  under the cap by that arithmetic was already past what the client would take.
+  A cap derived from an optimistic ratio is not a promise about anyone's real
+  limit.
+
+  `limit` could not solve this from the caller's side either. It bounds the
+  COUNT, and whether a count is safe depends on how long the entries happen to
+  be — 1,500–4,000+ characters each in coordination rooms, against a 10,000
+  write cap — which the caller cannot know before asking. Too high explodes;
+  too low costs dozens of round trips for the same catch-up.
+
+  The handler now assembles a page from sub-requests of at most ten entries and
+  stops BEFORE a character budget (40,000) is exceeded, returning the server
+  cursor of the last FULLY accepted sub-batch. The batch is small because a
+  cursor names a batch boundary and nothing finer: that boundary is the
+  granularity at which a page can end without skipping or repeating an entry.
+  The returned cursor therefore continues exactly where the page stopped, and
+  the tail already says so. A short-entry feed is unaffected — the budget never
+  binds, the same entries come back with the same cursor.
+
+  Two deliberate limits of the fix. The budget YIELDS to a single entry larger
+  than itself: that entry is returned whole, as a page of one, because dropping
+  it is silent data loss and truncating it needs a fetch-one-entry-by-id verb
+  this server does not have (suggestion 2 of #104, not attempted here).
+  And 40,000 is a conservative guess, not a measurement — roughly half of what
+  already failed — because no client's true boundary has been measured.
+  `MAX_RESULT_CHARS` is untouched: it is shared with `memory_read` and every
+  other surface, and stays the final backstop after this budget has done its
+  work.
+
+- **A sub-request that fails mid-page no longer costs the whole page.**
+  Chunking multiplies requests per call and so multiplies the chance one of
+  them fails; throwing away the entries already fetched would make this change
+  a regression for exactly the rooms it is for. The page is returned with its
+  honest cursor and one sentence saying it stopped early because the next
+  request "did not come back usable" — a short page with a valid cursor is
+  otherwise indistinguishable from a page the budget ended, which is the
+  could-not-fetch/does-not-exist collision this project keeps closing. A
+  failure on the FIRST sub-request still surfaces as the error it is, including
+  the endpoint-absent degrade.
+
+- **The tool now says all of this to the model reading it.**
+  `memory_list_recent` states that a page is bounded by size and that the
+  cursor holds the rest; `limit` is described as a ceiling rather than a page
+  size, with the practical guidance suggestion 3 of #104 asked for (in
+  long-entry rooms, ask for 5–10 — a large `limit` there buys nothing the
+  budget will not take back and costs round trips); `domain` warns that room
+  entries are long enough that paging is the normal case.
+
+### Known and NOT fixed here
+
+- **No per-entry truncation, and no way to fetch one entry by id.** An entry
+  larger than the whole budget still ships whole. `body_max_chars` /
+  `summary: true` (suggestion 2 of #104) would strand the reader without a
+  companion fetch-by-id verb, since ids are usable only for feedback today.
+- **The budget is not calibrated.** 40,000 is chosen to be safely under a
+  known failure at 72,648, not measured against any client's actual
+  tool-result limit.
+- **A large `limit` now costs round trips.** `limit: 100` over a short-entry
+  feed is ten sub-requests where it used to be one, and those are sequential.
+  The engine rate-limits per minute, so a caller who pages aggressively is
+  closer to a 429 than before. Sizing later chunks from the average entry
+  length already measured would remove most of this, and is not attempted here.
+
 ## [0.9.1] — 2026-08-24
 
 Text under this file's own rules: what a tool returns when it fails. No tool,

--- a/src/index.ts
+++ b/src/index.ts
@@ -980,9 +980,13 @@ server.registerTool(
       const next = r?.next_cursor;
       // Measured on the TEXT THAT WOULD SHIP, rendered by the same function
       // that renders the answer — an estimate from item lengths would drift
-      // from the renderer the first time a line gained a field.
+      // from the renderer the first time a line gained a field. The early-stop
+      // note's length is reserved up front: it is appended only when a LATER
+      // sub-request fails, which cannot be known while this batch is being
+      // sized, so every page keeps room for it (CodeRabbit, PR #108).
       const fits =
-        formatRecentPage(accepted.concat(batch), next).length <= LIST_PAGE_CHAR_BUDGET;
+        formatRecentPage(accepted.concat(batch), next).length <=
+        LIST_PAGE_CHAR_BUDGET - LIST_PAGE_EARLY_STOP_NOTE.length;
 
       if (fits) {
         accepted.push(...batch);
@@ -1009,6 +1013,16 @@ server.registerTool(
       // is the entry that exceeds the budget alone: it ships whole, because
       // dropping it is silent loss and truncating it needs a fetch-by-id verb
       // that does not exist yet (#104).
+      //
+      // KNOWN EDGE, inherited rather than introduced (CodeRabbit, PR #108):
+      // when a limit-ignoring server's batch ships whole and capResult then
+      // truncates the tail, the printed cursor points past entries the reader
+      // never saw. 0.9.1 had the identical hazard (one request, the server's
+      // cursor, the same cap). The alternatives are worse lies: slicing to
+      // `ask` keeps the server's cursor and SKIPS the sliced entries silently;
+      // rejecting the batch outright answers a working feed with "unreadable".
+      // A contract-violating server is the precondition; the real fix is
+      // fetch-by-id (#104 follow-up), not a guess here.
       const narrower = Math.max(1, Math.min(Math.floor(ask / 2), batch.length - 1));
       if (batch.length <= 1 || batch.length > ask || narrower >= ask) {
         accepted.push(...batch);

--- a/src/index.ts
+++ b/src/index.ts
@@ -750,17 +750,81 @@ server.registerTool(
 
 // --- Tool: memory_list_recent ---
 
+/**
+ * How big ONE feed page may get, and how the handler stays under it (#104).
+ *
+ * THE INCIDENT. `memory_list_recent(domain: "xroom:…", limit: 40, cursor: …)`
+ * over a shared room of long archival entries produced a single tool result of
+ * 72,648 characters. Claude Code refused to inline it and spilled it to a file;
+ * a client without that fallback loses the page. MAX_RESULT_CHARS did not fire,
+ * and could not have: 72,648 is comfortably under 96,000. That number is
+ * `24,000 tokens × 4 chars/token`, and the 4 is an average over ordinary prose —
+ * archival room entries carry ids, code, punctuation and non-ASCII, which
+ * tokenize far worse. A cap derived from an optimistic ratio is not a promise
+ * about a client's real limit.
+ *
+ * WHY `limit` COULD NOT SOLVE IT. `limit` bounds the COUNT. Whether a count is
+ * safe depends entirely on how long the entries happen to be — 1,500–4,000+
+ * chars each in coordination rooms, against a 10,000-char write cap — and the
+ * caller cannot know that before asking. Too high explodes; too low costs
+ * dozens of round trips for the same catch-up.
+ *
+ * WHAT THIS IS. A page is assembled from small sub-requests and stops BEFORE
+ * the budget is exceeded, returning the server cursor of the last FULLY
+ * accepted sub-batch. The cursor is per-batch, which is why the batch is small:
+ * it is the granularity at which the page can end without losing or repeating
+ * an entry. Nothing is dropped silently — an entry that exceeds the budget on
+ * its own is returned whole, as a page of one, because per-entry truncation
+ * needs a fetch-one-by-id verb this server does not have (#104, suggestion 2).
+ *
+ * THE NUMBER IS DELIBERATELY CONSERVATIVE AND DELIBERATELY LOCAL. 40,000 is
+ * roughly half of what already failed in production; the true boundary of any
+ * given client is unmeasured, and calibrating it is follow-up work. It does NOT
+ * touch MAX_RESULT_CHARS, which is shared with memory_read and every other
+ * surface and remains the final backstop after this budget has done its work.
+ */
+const LIST_PAGE_CHAR_BUDGET = 40_000;
+
+/**
+ * Entries per sub-request. Small enough that the budget can end a page at a
+ * useful granularity, large enough that an ordinary short-entry feed still
+ * costs one or two round trips (the default `limit` of 20 costs two).
+ */
+const LIST_PAGE_CHUNK = 10;
+
+/**
+ * A ceiling on sub-requests per call — the loop's own stop condition is the
+ * budget, the caller's `limit`, or the end of the feed, and this fires only if
+ * a server answers in a way none of those three catch. `limit: 100` needs ten,
+ * plus a few for narrowing an over-budget batch.
+ */
+const LIST_PAGE_MAX_REQUESTS = 16;
+
+/**
+ * Appended when the page stopped because a LATER sub-request failed. Chunking
+ * multiplies the requests per call and therefore the chance one of them fails
+ * mid-page; discarding the entries already in hand would make this change a
+ * regression for exactly the long-entry rooms it exists for. Saying nothing
+ * would be worse — a short page with a valid cursor is indistinguishable from
+ * a page the budget ended, which is the could-not-fetch/does-not-exist
+ * collision this codebase keeps closing.
+ */
+const LIST_PAGE_EARLY_STOP_NOTE =
+  "\n\n(This page stopped early — the request for the next batch of older " +
+  "entries did not come back usable, so this page holds fewer entries than " +
+  "asked for. The cursor above is unaffected: continue from it.)";
+
 server.registerTool(
   "memory_list_recent",
   {
     description:
-      "List the NEWEST memories first — no search query needed. Semantic search answers 'what do I know about X'; this answers 'what happened lately': resuming work after a break, catching up on a shared room ('any new messages?'), or reviewing what was saved recently. Pass `since` (your last-seen time) to get only what's new, and page through older entries with the returned cursor. Complete by construction WITHIN ONE SCOPE — nothing is skipped there, unlike a semantic search. To catch up on a shared room you MUST pass its address as `domain`: rooms are separate stores and an unscoped call never covers them.",
+      "List the NEWEST memories first — no search query needed. Semantic search answers 'what do I know about X'; this answers 'what happened lately': resuming work after a break, catching up on a shared room ('any new messages?'), or reviewing what was saved recently. Pass `since` (your last-seen time) to get only what's new, and page through older entries with the returned cursor. Complete by construction WITHIN ONE SCOPE — nothing is skipped there, unlike a semantic search. A page is also bounded by SIZE, so a page of long entries comes back shorter than `limit` and hands you a cursor for the rest — nothing is dropped, and following the cursor is how you get it. To catch up on a shared room you MUST pass its address as `domain`: rooms are separate stores and an unscoped call never covers them.",
     inputSchema: {
       domain: z
         .string()
         .optional()
         .describe(
-          "Restrict to one domain. REQUIRED to read a shared room — pass its address ('xroom:room_01ABC'), because rooms are separate stores that an unscoped feed does NOT cover. Omit only when you mean your own domains. Room addresses come from memory_list_rooms.",
+          "Restrict to one domain. REQUIRED to read a shared room — pass its address ('xroom:room_01ABC'), because rooms are separate stores that an unscoped feed does NOT cover. Omit only when you mean your own domains. Room addresses come from memory_list_rooms. Room entries are often long — a room feed usually reaches its size budget after a handful of them, so expect to page (see `limit`).",
         ),
       since: z
         .string()
@@ -787,7 +851,9 @@ server.registerTool(
         .min(1)
         .max(100)
         .optional()
-        .describe("Page size (default: 20). Newest first."),
+        .describe(
+          "Most entries per page (default: 20). Newest first. ⚠️ A CEILING, not a promise: the page is ALSO bounded by size, so a page of long entries stops early and returns a cursor for the rest. In rooms whose entries run long, ask for 5–10 — a large `limit` there buys nothing the size budget will not take back, and costs round trips.",
+        ),
       cursor: z
         .string()
         .max(512)
@@ -808,67 +874,153 @@ server.registerTool(
     // ONE value for the request and for every decision about it — see the note
     // at the top of memory_read.
     const searched = searchedScope(domain);
-    let r: { items?: RecentItem[]; next_cursor?: string | null };
-    try {
-      r = await apiFetch<{ items?: RecentItem[]; next_cursor?: string | null }>(
-        "/memory/recent",
-        {
-          method: "POST",
-          body: JSON.stringify(
-            recentRequestBody({ domain, since, until, exclude_author, limit, cursor }),
-          ),
-        },
-      );
-    } catch (e) {
-      // Graceful degradation while the server side rolls out: a 404 with no
-      // error `code` in the body is what an undeployed /memory/recent looks
-      // like, so degrade to a usable alternative instead of surfacing a raw
-      // HTTP error.
-      //
-      // NAMED FOR WHAT IT TESTS. This was `endpointAbsent`, which asserted a
-      // deployment fact the check cannot establish: every engine 404 carries a
-      // `code`, so a real room-404 is excluded, but a gateway, a proxy or a
-      // wrong MNEMOVERSE_API_URL produces the same bare 404 and is
-      // indistinguishable from here. The MESSAGE below still states the
-      // deployment cause outright, which is more than this boolean knows —
-      // listed in CHANGELOG's "Known and NOT fixed here" rather than papered
-      // over with a hedge.
-      //
-      // NOW READ FROM STRUCTURED FIELDS. It used to be
-      // `e.message.startsWith("Mnemoverse API error 404:")` plus a substring
-      // hunt for `"code"` in the same string — a behavioural branch keyed to the
-      // exact prefix of a user-facing sentence. Rewording that sentence, which
-      // is precisely what src/errors.ts does, would have flipped this branch
-      // silently: every per-request 404 would have degraded into "the service
-      // does not support the feed yet". `ApiError.isBare404` asks the parsed
-      // envelope instead, so the prose and the branch can no longer collide.
-      const bare404 = e instanceof ApiError && e.isBare404;
-      if (bare404) {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text:
-                "The memory service does not support the recent-entries feed yet. " +
-                "Use memory_read with order_by: 'recency' as an approximation.",
-            },
-          ],
-        };
+
+    // The caller's `limit` is a CEILING on the item count. The page also has a
+    // character budget (LIST_PAGE_CHAR_BUDGET), and whichever binds first ends
+    // the page — which is why this is a loop over small sub-requests rather
+    // than one request for `limit` entries followed by a cap that arrives too
+    // late to do anything but truncate.
+    const ceiling = limit || 20;
+    const accepted: RecentItem[] = [];
+    // The server cursor of the last FULLY accepted sub-batch: the only value
+    // that can be handed back without losing or repeating an entry, since a
+    // cursor names a batch boundary and nothing finer.
+    let acceptedCursor: string | null | undefined;
+    // Where the next sub-request continues from — the caller's cursor first,
+    // the server's thereafter. Resending the caller's would replay page one.
+    let position = cursor || undefined;
+    let ask = Math.min(LIST_PAGE_CHUNK, ceiling);
+    let stoppedEarly = false;
+
+    for (let attempt = 0; attempt < LIST_PAGE_MAX_REQUESTS; attempt++) {
+      let r: { items?: RecentItem[]; next_cursor?: string | null };
+      try {
+        r = await apiFetch<{ items?: RecentItem[]; next_cursor?: string | null }>(
+          "/memory/recent",
+          {
+            method: "POST",
+            body: JSON.stringify(
+              recentRequestBody({
+                domain,
+                since,
+                until,
+                exclude_author,
+                limit: ask,
+                cursor: position,
+              }),
+            ),
+          },
+        );
+      } catch (e) {
+        // A failure with entries already in hand ends the page instead of the
+        // call: the caller keeps what was fetched plus a cursor that still
+        // continues correctly, and the appended note says the page was cut
+        // short by a failed request rather than by the budget. With nothing
+        // accepted there is no page to return, so the error surfaces exactly
+        // as it did before chunking.
+        if (accepted.length > 0) {
+          stoppedEarly = true;
+          break;
+        }
+        // Graceful degradation while the server side rolls out: a 404 with no
+        // error `code` in the body is what an undeployed /memory/recent looks
+        // like, so degrade to a usable alternative instead of surfacing a raw
+        // HTTP error.
+        //
+        // NAMED FOR WHAT IT TESTS. This was `endpointAbsent`, which asserted a
+        // deployment fact the check cannot establish: every engine 404 carries a
+        // `code`, so a real room-404 is excluded, but a gateway, a proxy or a
+        // wrong MNEMOVERSE_API_URL produces the same bare 404 and is
+        // indistinguishable from here. The MESSAGE below still states the
+        // deployment cause outright, which is more than this boolean knows —
+        // listed in CHANGELOG's "Known and NOT fixed here" rather than papered
+        // over with a hedge.
+        //
+        // NOW READ FROM STRUCTURED FIELDS. It used to be
+        // `e.message.startsWith("Mnemoverse API error 404:")` plus a substring
+        // hunt for `"code"` in the same string — a behavioural branch keyed to the
+        // exact prefix of a user-facing sentence. Rewording that sentence, which
+        // is precisely what src/errors.ts does, would have flipped this branch
+        // silently: every per-request 404 would have degraded into "the service
+        // does not support the feed yet". `ApiError.isBare404` asks the parsed
+        // envelope instead, so the prose and the branch can no longer collide.
+        const bare404 = e instanceof ApiError && e.isBare404;
+        if (bare404) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text:
+                  "The memory service does not support the recent-entries feed yet. " +
+                  "Use memory_read with order_by: 'recency' as an approximation.",
+              },
+            ],
+          };
+        }
+        throw e;
       }
-      throw e;
+
+      // Same guard as memory_read: a 200 without an items array is UNREADABLE,
+      // not empty — and the feed's empty heads below are precisely the absence
+      // claims that must not be derived from it (truth F13, 2026-08-08). Mid
+      // page it is treated like a failed sub-request, for the same reason.
+      const batch = r?.items;
+      if (!Array.isArray(batch)) {
+        if (accepted.length > 0) {
+          stoppedEarly = true;
+          break;
+        }
+        return unreadableListReply(
+          "The recent-entries feed",
+          "an empty feed",
+          "there is nothing to list",
+        );
+      }
+
+      const next = r?.next_cursor;
+      // Measured on the TEXT THAT WOULD SHIP, rendered by the same function
+      // that renders the answer — an estimate from item lengths would drift
+      // from the renderer the first time a line gained a field.
+      const fits =
+        formatRecentPage(accepted.concat(batch), next).length <= LIST_PAGE_CHAR_BUDGET;
+
+      if (fits) {
+        accepted.push(...batch);
+        acceptedCursor = next;
+        position = typeof next === "string" && next ? next : undefined;
+        // No cursor: the feed ended, and the page says so. No entries: the
+        // server is not advancing, so continuing would spend requests on the
+        // same nothing. Ceiling reached: the caller's count is spent.
+        if (!position || batch.length === 0 || accepted.length >= ceiling) break;
+        ask = Math.min(LIST_PAGE_CHUNK, ceiling - accepted.length);
+        continue;
+      }
+
+      // Over budget. With entries already accepted, THIS is the ordinary stop:
+      // keep the batches that fit and hand back the cursor of the last one.
+      if (accepted.length > 0) break;
+
+      // Nothing accepted yet, so this one batch is over budget by itself and
+      // the page cannot be empty — something must be returned.
+      //
+      // `batch.length > ask` means the server ignored `limit`; asking again,
+      // smaller, would be a wasted round trip against a deployment that is not
+      // listening, and MAX_RESULT_CHARS is the backstop for it. A batch of one
+      // is the entry that exceeds the budget alone: it ships whole, because
+      // dropping it is silent loss and truncating it needs a fetch-by-id verb
+      // that does not exist yet (#104).
+      const narrower = Math.max(1, Math.min(Math.floor(ask / 2), batch.length - 1));
+      if (batch.length <= 1 || batch.length > ask || narrower >= ask) {
+        accepted.push(...batch);
+        acceptedCursor = next;
+        break;
+      }
+      // Re-ask the SAME position for fewer entries. `narrower < batch.length`
+      // by construction, so the ask strictly shrinks and the loop converges.
+      ask = narrower;
     }
 
-    // Same guard as memory_read: a 200 without an items array is UNREADABLE,
-    // not empty — and the feed's empty heads below are precisely the absence
-    // claims that must not be derived from it (truth F13, 2026-08-08).
-    const items = r?.items;
-    if (!Array.isArray(items)) {
-      return unreadableListReply(
-        "The recent-entries feed",
-        "an empty feed",
-        "there is nothing to list",
-      );
-    }
+    const items = accepted;
     if (items.length === 0) {
       // THE SENTENCE ITSELF carries the scope — and it is selected by EVERY
       // filter that narrowed the window, not by `since` alone.
@@ -939,9 +1091,17 @@ server.registerTool(
           // 2026-08-08). Same order as memory_read's result page, same
           // automatic drop: a cap that removed every escaped name removes the
           // reason for the legend too.
+          //
+          // The cursor is the last ACCEPTED batch's, never the newest one
+          // seen: a batch that did not fit the budget was not returned, so
+          // pointing past it would skip every entry in it.
           text: withDomainEscapeLegend(
             capResult(
-              formatRecentPage(items, r?.next_cursor),
+              formatRecentPage(items, acceptedCursor) +
+                (stoppedEarly ? LIST_PAGE_EARLY_STOP_NOTE : ""),
+              // Still true, and now only reachable when ONE entry is larger
+              // than the whole budget — the case `limit` cannot fix and the
+              // global cap has to.
               "Lower `limit` or add a `domain` for smaller pages.",
             ),
             ...items.map((it) => it?.domain),

--- a/test/descriptions.test.ts
+++ b/test/descriptions.test.ts
@@ -115,6 +115,31 @@ describe("the advertised descriptions carry this release's truth claims", () => 
     expect(d).toContain("Omit only when you mean your own domains");
   });
 
+  it("memory_list_recent says a page is bounded by SIZE too, and that the cursor holds the rest", () => {
+    // #104: the caller cannot know how long the entries are before asking, so
+    // a short page must not read as the end of the feed. Both halves are
+    // pinned — that the page can come back short, and that nothing was lost.
+    const d = description("memory_list_recent");
+    expect(d).toContain("bounded by SIZE");
+    expect(d).toContain("shorter than `limit`");
+    expect(d).toContain("nothing is dropped");
+  });
+
+  it("memory_list_recent.limit says it is a CEILING, and what to ask for in long-entry rooms", () => {
+    // Suggestion 3 of #104, which asked for the guidance even if nothing else
+    // changed: an agent discovering the cliff in production is the failure.
+    const d = paramDescription("memory_list_recent", "limit");
+    expect(d).toContain("A CEILING, not a promise");
+    expect(d).toContain("bounded by size");
+    expect(d).toContain("ask for 5–10");
+  });
+
+  it("memory_list_recent.domain warns that room entries are long enough to page", () => {
+    const d = paramDescription("memory_list_recent", "domain");
+    expect(d).toContain("Room entries are often long");
+    expect(d).toContain("expect to page");
+  });
+
   it("memory_list_recent.exclude_author carries the same not-usable warning", () => {
     const d = paramDescription("memory_list_recent", "exclude_author");
     expect(d).toContain("NOT USABLE FROM HERE YET");

--- a/test/list-recent-budget.test.ts
+++ b/test/list-recent-budget.test.ts
@@ -1,0 +1,306 @@
+/**
+ * A feed page is bounded by SIZE, not only by item count (#104).
+ *
+ * THE INCIDENT. Catching up on a shared room of long archival entries with
+ * `memory_list_recent(domain: "xroom:…", limit: 40, cursor: …)` produced ONE
+ * tool result of 72,648 characters. The MCP client (Claude Code) refused to
+ * inline it and spilled it to a file; a client without that fallback loses the
+ * page outright. The global cap did not fire — MAX_RESULT_CHARS is 96,000 and
+ * 72,648 is under it — so the only thing standing between a caller and an
+ * unusable page was a `limit` they had to guess right, for entries whose length
+ * they cannot know before asking.
+ *
+ * WHAT THESE TESTS PIN. `limit` is a CEILING on the item count; the page also
+ * has a character budget, and whichever binds first ends the page. The handler
+ * therefore assembles a page from small sub-requests and stops before the
+ * budget is exceeded, returning the server cursor of the last FULLY accepted
+ * sub-batch — so the continuation neither skips nor repeats an entry.
+ *
+ * The one case where the budget yields: a single entry that exceeds it alone is
+ * returned whole, as a page of one. Dropping it would be silent data loss, and
+ * per-entry truncation needs a fetch-one-by-id verb this server does not have
+ * yet (#104, suggestion 2).
+ *
+ * THE 40,000 BELOW IS THE SAME NUMBER AS `LIST_PAGE_CHAR_BUDGET` in
+ * src/index.ts, deliberately transcribed rather than imported: a test that reads
+ * the constant it is testing asserts only that arithmetic works. Changing the
+ * budget is a two-place edit, and the second place is a test that says why the
+ * number is what it is.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { httpError, startMemoryServer, type Harness, type StubbedRequest } from "./harness.js";
+
+const RECENT = "POST /memory/recent";
+
+/** The rendered page must stay under this — see the file header. */
+const BUDGET = 40_000;
+
+/** What the client actually choked on. Nothing here may come close to it. */
+const INCIDENT_CHARS = 72_648;
+
+let mcp: Harness;
+
+beforeAll(async () => {
+  mcp = await startMemoryServer();
+});
+afterAll(async () => {
+  await mcp.close();
+});
+beforeEach(() => {
+  mcp.reset();
+});
+
+interface Entry {
+  atom_id: string;
+  content: string;
+}
+
+/**
+ * `n` entries whose content is `body` and whose marker is unique and
+ * delimited — `ITEM-1|` is not a prefix of `ITEM-10|`, so a `toContain` on one
+ * cannot pass because of the other.
+ */
+function entries(n: number, chars: number, offset = 0): Entry[] {
+  return Array.from({ length: n }, (_, i) => ({
+    atom_id: `atom_${offset + i}`,
+    content: `ITEM-${offset + i}|${"x".repeat(chars)}`,
+  }));
+}
+
+/**
+ * A feed that pages the way core does: honour `limit`, hand back an opaque
+ * cursor whenever entries remain. The cursor shape matches the urlsafe-base64
+ * regex src/render.ts requires before it will echo a cursor at all.
+ */
+function pagingFeed(all: Entry[]) {
+  return (req: StubbedRequest) => {
+    const body = (req.body ?? {}) as { limit?: number; cursor?: string };
+    const from = body.cursor ? Number(body.cursor.slice("cur_".length)) : 0;
+    const take = body.limit ?? 20;
+    const slice = all.slice(from, from + take);
+    const end = from + slice.length;
+    return { items: slice, next_cursor: end < all.length ? `cur_${end}` : null };
+  };
+}
+
+/** Every `limit` the handler put on the wire, in order. */
+function askedLimits(): number[] {
+  return mcp.calls
+    .filter((c) => c.key === RECENT)
+    .map((c) => (c.body as { limit?: number }).limit ?? 0);
+}
+
+// ---------------------------------------------------------------------------
+
+describe("a page of long entries is cut by the byte budget, not by the count", () => {
+  it("returns fewer entries than `limit`, under budget, with the cursor of the last accepted batch", async () => {
+    // 40 entries × 3,000 chars is the incident's shape: the old handler asked
+    // for all 40 in one request and rendered 120,000+ characters.
+    mcp.on(RECENT, pagingFeed(entries(40, 3_000)));
+
+    const text = await mcp.callText("memory_list_recent", {
+      domain: "xroom:room_01ABC",
+      limit: 40,
+    });
+
+    expect(text.length).toBeLessThanOrEqual(BUDGET);
+    expect(text.length).toBeLessThan(INCIDENT_CHARS);
+
+    // Ten entries fit; the eleventh would not, so it is not on the page — and
+    // the cursor points exactly at it.
+    expect(text).toContain("ITEM-0|");
+    expect(text).toContain("ITEM-9|");
+    expect(text).not.toContain("ITEM-10|");
+    expect(text).toContain("More older entries exist — pass cursor: cur_10");
+    expect(text).not.toContain("end of feed");
+  });
+
+  it("does not drop the entries it did not return — the next call continues from the cursor", async () => {
+    const feed = entries(40, 3_000);
+    mcp.on(RECENT, pagingFeed(feed));
+
+    const first = await mcp.callText("memory_list_recent", { limit: 40 });
+    expect(first).toContain("ITEM-9|");
+    expect(first).not.toContain("ITEM-10|");
+
+    mcp.reset().on(RECENT, pagingFeed(feed));
+    const second = await mcp.callText("memory_list_recent", {
+      limit: 40,
+      cursor: "cur_10",
+    });
+
+    // No skip and no repeat across the boundary: page 2 starts at the entry
+    // page 1 stopped before.
+    expect(second).toContain("ITEM-10|");
+    expect(second).not.toContain("ITEM-9|");
+    expect(second.length).toBeLessThanOrEqual(BUDGET);
+  });
+});
+
+describe("a page of short entries behaves exactly as before", () => {
+  it("returns the full `limit` and the same cursor a single request would have", async () => {
+    // 100 short entries, `limit: 40` — the budget never binds, so the answer
+    // must be indistinguishable from the pre-#104 one-request handler.
+    mcp.on(RECENT, pagingFeed(entries(100, 50)));
+
+    const text = await mcp.callText("memory_list_recent", { limit: 40 });
+
+    expect(text).toContain("ITEM-0|");
+    expect(text).toContain("ITEM-39|");
+    expect(text).not.toContain("ITEM-40|");
+    expect(text).toContain("More older entries exist — pass cursor: cur_40");
+    expect(text).toContain("40. ");
+    expect(text).not.toContain("41. ");
+  });
+
+  it("spends the caller's `limit` and no more, in sub-requests no larger than the chunk", async () => {
+    // The wire contract that CHANGED here: `limit` is no longer forwarded
+    // verbatim (test/tool-wiring.test.ts records the same fact). What must hold
+    // is that the sub-requests are small and that they never ask for more
+    // entries in total than the caller allowed.
+    mcp.on(RECENT, pagingFeed(entries(100, 50)));
+
+    await mcp.callText("memory_list_recent", { limit: 25 });
+
+    const asked = askedLimits();
+    expect(asked.every((n) => n >= 1 && n <= 10)).toBe(true);
+    expect(asked.reduce((a, b) => a + b, 0)).toBe(25);
+  });
+
+  it("forwards every filter on every sub-request, and the caller's cursor only on the first", async () => {
+    mcp.on(RECENT, pagingFeed(entries(100, 50)));
+
+    await mcp.callText("memory_list_recent", {
+      limit: 25,
+      domain: "xroom:room_01ABC",
+      since: "2026-08-01T00:00:00Z",
+      until: "2026-08-02T00:00:00Z",
+      exclude_author: "user_someone_else",
+      cursor: "cur_5",
+    });
+
+    const sent = mcp.calls
+      .filter((c) => c.key === RECENT)
+      .map((c) => c.body as Record<string, unknown>);
+    expect(sent.length).toBeGreaterThan(1);
+    for (const body of sent) {
+      // A filter dropped on sub-request 2 would widen the page silently — the
+      // exact class of defect test/tool-wiring.test.ts exists for.
+      expect(body).toMatchObject({
+        domain: "xroom:room_01ABC",
+        since: "2026-08-01T00:00:00Z",
+        until: "2026-08-02T00:00:00Z",
+        exclude_author: "user_someone_else",
+      });
+    }
+    expect(sent[0]).toMatchObject({ cursor: "cur_5" });
+    // Sub-request 2 continues from the SERVER's cursor, not the caller's —
+    // resending the caller's would replay page one forever.
+    expect(sent[1]).toMatchObject({ cursor: "cur_15" });
+  });
+});
+
+describe("one entry larger than the whole budget", () => {
+  it("is returned whole, as a page of one, without looping", async () => {
+    // Per-entry truncation would need a fetch-one-by-id verb that does not
+    // exist yet (#104), so the budget yields rather than losing the entry.
+    const huge: Entry = { atom_id: "atom_huge", content: `HUGE|${"x".repeat(60_000)}` };
+    mcp.on(RECENT, pagingFeed([huge, ...entries(20, 50, 1)]));
+
+    const text = await mcp.callText("memory_list_recent", { limit: 20 });
+
+    expect(text).toContain("HUGE|");
+    expect(text).not.toContain("ITEM-1|");
+    expect(text).toContain("More older entries exist — pass cursor: cur_1");
+    // Delivered whole: over the page budget on purpose, and still under the
+    // global cap, so nothing was truncated.
+    expect(text.length).toBeGreaterThan(BUDGET);
+    expect(text).not.toContain("[…truncated");
+    // Narrowing an over-budget batch must converge, not thrash.
+    expect(askedLimits().length).toBeLessThanOrEqual(6);
+  });
+
+  it("does not narrow against a server that ignores `limit`", async () => {
+    // A server that answers a 10-ask with 100 entries is not going to answer a
+    // 1-ask with fewer, and the global cap is the backstop for it. Re-asking
+    // would be three wasted round trips against a broken deployment.
+    mcp.on(RECENT, {
+      items: entries(100, 1_200),
+      next_cursor: null,
+    });
+
+    const text = await mcp.callText("memory_list_recent", {});
+
+    expect(askedLimits()).toHaveLength(1);
+    expect(text).toContain("[…truncated to fit the 25K token limit.");
+  });
+});
+
+describe("the end of the feed, reached inside the loop", () => {
+  it("is stated honestly when a sub-batch comes back with no cursor", async () => {
+    // 15 entries against `limit: 40`: sub-request 1 fills, sub-request 2 runs
+    // out. The page must end with the end-of-feed sentence, not with a cursor
+    // that continues nothing.
+    mcp.on(RECENT, pagingFeed(entries(15, 50)));
+
+    const text = await mcp.callText("memory_list_recent", { limit: 40 });
+
+    expect(text).toContain("ITEM-0|");
+    expect(text).toContain("ITEM-14|");
+    expect(text).toContain("(end of feed — nothing older)");
+    expect(text).not.toContain("pass cursor");
+    expect(askedLimits().length).toBe(2);
+  });
+
+  it("still answers an empty first page with the feed's own empty heads", async () => {
+    // The empty branch is chosen by the CALLER's cursor, unchanged: chunking
+    // must not turn "nothing here" into a different sentence, and must not
+    // re-ask an empty feed for more of the same nothing.
+    mcp
+      .on(RECENT, { items: [], next_cursor: null })
+      .on("GET /memory/rooms", [
+        { room_id: "room_01ABC", name: "me-and-olya", address: "xroom:room_01ABC" },
+      ]);
+
+    const text = await mcp.callText("memory_list_recent", {});
+
+    expect(text).toContain("No memories in your own domains yet.");
+    expect(askedLimits()).toHaveLength(1);
+  });
+});
+
+describe("a sub-request that fails after entries were already accepted", () => {
+  it("returns the entries it has, says the page stopped early, and keeps the cursor honest", async () => {
+    // Chunking multiplies the number of requests per call, so it multiplies the
+    // chance that one of them fails mid-page. Throwing the whole page away
+    // would make this change a regression for exactly the long-entry rooms it
+    // is for; hiding the failure would be the "could-not-fetch spelled like
+    // does-not-exist" collision this codebase keeps closing.
+    const feed = pagingFeed(entries(100, 50));
+    let n = 0;
+    mcp.on(RECENT, (req: StubbedRequest) =>
+      ++n === 1 ? feed(req) : httpError(503, "down"),
+    );
+
+    const text = await mcp.callText("memory_list_recent", { limit: 40 });
+
+    expect(text).toContain("ITEM-0|");
+    expect(text).toContain("ITEM-9|");
+    expect(text).toContain("More older entries exist — pass cursor: cur_10");
+    expect(text).toContain("stopped early");
+    expect(text).toContain("did not come back usable");
+  });
+
+  it("still surfaces the failure when it happens on the FIRST sub-request", async () => {
+    // Nothing was accepted, so there is no page to return and no reason to
+    // soften the error — the pre-#104 behaviour, unchanged.
+    mcp.on(RECENT, httpError(503, "down"));
+
+    const res = await mcp.call("memory_list_recent", { limit: 40 });
+
+    expect(res.isError).toBe(true);
+    expect(res.text).toContain("Mnemoverse");
+    expect(res.text).not.toContain("stopped early");
+  });
+});

--- a/test/list-recent-budget.test.ts
+++ b/test/list-recent-budget.test.ts
@@ -292,6 +292,26 @@ describe("a sub-request that fails after entries were already accepted", () => {
     expect(text).toContain("did not come back usable");
   });
 
+  it("a page that stopped early still fits the budget, note included", async () => {
+    // The note is appended AFTER the batches were sized, so its space is
+    // reserved during sizing (CodeRabbit, PR #108) — the invariant pinned
+    // here is end-to-end: accepted page PLUS the failure note never exceeds
+    // the budget, even when the accepted half filled most of it. The reserve
+    // itself is structural (the fits check subtracts the note's length), so
+    // this guards against gross regressions — the budget check disappearing,
+    // or the note outgrowing its reservation.
+    const feed = pagingFeed(entries(100, 3_800));
+    let n = 0;
+    mcp.on(RECENT, (req: StubbedRequest) =>
+      ++n === 1 ? feed(req) : httpError(503, "down"),
+    );
+
+    const text = await mcp.callText("memory_list_recent", { limit: 100 });
+
+    expect(text).toContain("stopped early");
+    expect(text.length).toBeLessThanOrEqual(BUDGET);
+  });
+
   it("still surfaces the failure when it happens on the FIRST sub-request", async () => {
     // Nothing was accepted, so there is no page to return and no reason to
     // soften the error — the pre-#104 behaviour, unchanged.

--- a/test/tool-wiring.test.ts
+++ b/test/tool-wiring.test.ts
@@ -117,6 +117,23 @@ const CASES: Array<[tool: string, route: string, reply: unknown]> = [
   ["memory_write", "POST /memory/write", { stored: true, atom_id: "a1", importance: 0.7 }],
 ];
 
+/**
+ * The one parameter a handler deliberately does NOT forward verbatim, and why.
+ *
+ * `memory_list_recent.limit` became a CEILING in #104, not a page size: a feed
+ * page is also bounded by characters, so the handler assembles it from small
+ * sub-requests and each one carries the CHUNK size, not the caller's number.
+ * The property that survives — never ask for more entries than the caller
+ * allowed — is pinned below in this tool's own describe block, and in
+ * test/list-recent-budget.test.ts against a paging server.
+ *
+ * This list is a confession, not a convenience. Anything added to it stops
+ * being covered by the check this file exists for, so an entry needs a reason
+ * naming the release that made the parameter mean something else — and a
+ * replacement assertion, or the coverage is simply gone.
+ */
+const NOT_VERBATIM = new Set(["memory_list_recent.limit"]);
+
 describe("every advertised parameter reaches the wire, carrying its own value", () => {
   for (const [tool, route, reply] of CASES) {
     it(`${tool} sends each parameter it advertises`, async () => {
@@ -126,6 +143,7 @@ describe("every advertised parameter reaches the wire, carrying its own value", 
         // never supplies (`include_associations`, the default `top_k`). What
         // must never happen is the other direction.
         expect(body, `${p} is advertised but never sent`).toHaveProperty(p);
+        if (NOT_VERBATIM.has(`${tool}.${p}`)) continue;
         expect(body[p], `${p} is sent, but not the value the caller passed`).toEqual(
           SENTINEL[p],
         );
@@ -144,6 +162,22 @@ describe("memory_list_recent", () => {
       "since",
       "until",
     ]);
+  });
+
+  it("sends a `limit` no larger than the caller's — a ceiling, never an inflation", async () => {
+    // The replacement for the verbatim check above (#104). The direction that
+    // matters is one-sided: asking the server for MORE entries than the caller
+    // allowed is the defect — it would fetch entries the page then has to
+    // discard, and a caller who asked for 3 would pay for 10.
+    const reply = { items: [{ atom_id: "a1", content: "hit" }], next_cursor: null };
+    for (const asked of [1, 3, 11, 100]) {
+      mcp.reset().on("POST /memory/recent", reply);
+      await mcp.callText("memory_list_recent", { limit: asked });
+
+      const sent = mcp.requestTo("POST /memory/recent").body as { limit?: number };
+      expect(sent.limit, `limit: ${asked}`).toBeGreaterThanOrEqual(1);
+      expect(sent.limit, `limit: ${asked}`).toBeLessThanOrEqual(asked);
+    }
   });
 });
 


### PR DESCRIPTION
Closes #104.

## What

Catching up on a long-entry room with `limit: 40` produced one tool result of 72,648 chars — under `MAX_RESULT_CHARS` (96,000, derived from an optimistic 4 chars/token) and already past what the client would inline. `limit` bounds the **count**; whether a count is safe depends on entry length the caller cannot know. The incident is now reproduced in a test: the old handler shipped a 95,893-char page that the global cap also would not have caught.

The page is now assembled from sub-requests of at most `LIST_PAGE_CHUNK = 10` entries and stops **before** a `LIST_PAGE_CHAR_BUDGET = 40,000`-char budget (measured on the text that would ship, rendered by the same function that renders the answer — not an estimate from field lengths). Key semantics:

- `limit` is a **ceiling**, not a promise — the page may come in under it; the tool description, `limit`, and `domain` descriptions now say so (and are pinned in `descriptions.test.ts`).
- The returned cursor is the server cursor of the last **fully accepted** sub-batch — the continuation neither skips nor repeats. A batch that did not fit was not returned, so the cursor never points past it.
- One entry larger than the whole budget ships whole (page of one): truncating it needs a fetch-by-id verb that does not exist (follow-up), and dropping it is silent loss. `MAX_RESULT_CHARS` is untouched and remains the backstop for exactly this case.
- A **later** sub-request failing ends the page, not the call: the caller keeps the accepted entries, a still-correct cursor, and an explicit early-stop note — a short page with a valid cursor must not read like a budget stop. A **first**-request failure behaves exactly as before, bare-404 degradation included.
- A server that ignores `limit` is detected (`batch.length > ask`) and not re-asked — one request, global cap as before; pinned by the pre-existing `handlers.test.ts` capped-feed test, which is what surfaced this branch.

## In-scope rewrite worth flagging

The bare-404 degradation branch used to match the **prefix of a user-facing sentence** (`e.message.startsWith("Mnemoverse API error 404:")` + substring hunt). The loop needed a per-request branch, and rewording errors — precisely what `src/errors.ts` does — would have silently flipped it. It now reads a structured `ApiError.isBare404`, so prose and branch can no longer collide.

## Wire contract

`tool-wiring.test.ts` pinned `limit` verbatim; it now carries an explicit `NOT_VERBATIM` allowlist for `memory_list_recent.limit` (presence still required, value covered by a dedicated test: every wire `limit` is `>= 1` and `<= caller's limit`). New pins: sub-limits sum to the caller's ceiling; `domain/since/until/exclude_author` ride on **every** sub-request; the caller's cursor goes only on the first, the server's thereafter. `requests.test.ts` untouched — `recentRequestBody` is a pure function and its bytes did not change for any input.

## Follow-ups (recorded in CHANGELOG "Known and NOT fixed here")

1. **fetch-by-id + per-entry truncation** — until it exists, the budget must yield to a single oversized entry.
2. **Budget calibration** — 40,000 is a conservative guess (half of what already broke a live client), not a measured client limit.
3. **Rate-limit interaction** — chunking multiplies requests (`limit: 100` over short entries = 10 sequential sub-requests against the engine's per-minute limiter). Fix is an adaptive chunk sized from the measured average entry length; deliberately left out of this PR's scope.

## Self-review (reviewer voice)

- TDD held: 7 red tests first, the lead assertion being the reproduced incident (`expected 95893 to be <= 40000`); the 4 immediately-green tests were the unchanged-behaviour guards (short entries, empty feed, first-request error, limit-ignoring server).
- Convergence is provable: the re-ask strictly shrinks (`narrower < ask` by construction, `narrower >= ask` escapes at `ask = 1`), with `LIST_PAGE_MAX_REQUESTS = 16` as a safety net, not a working stop.
- Empty-feed path is byte-identical to before (exactly one sub-request) — pinned.
- Gate mirrored CI: `tsc --noEmit`, `typecheck:test`, tests ×3 timezones (430/430), `verify:configs` (19 in sync), build + stdio smoke.

Done-by: Σ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved recent-memory listing with size-bounded pagination, supporting up to 40,000 characters per page.
  - Preserved cursors for reliable continuation across pages.
  - Allows individual oversized entries to be returned in full.
  - Added guidance for handling long entries and room feeds.

- **Bug Fixes**
  - Partial failures now return collected results with an explanatory message and continuation cursor.
  - Improved handling of malformed responses, empty feeds, and servers that ignore requested limits.

- **Documentation**
  - Updated tool descriptions to explain pagination behavior, size limits, and cursor usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->