### PR TITLE
fix(feedback): the count is read honestly and the fade promise is gone (bug hunt, pre-0.9.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,53 @@ git history and the GitHub releases are the record.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`memory_feedback` reads its own count honestly.** `r?.updated_count ?? 0`
+  folded three different failures onto the same number:
+
+  - **A count the service did not send was reported as zero.** A 200 without
+    the field, an explicit `null`, and a 204 (which `apiFetch` turns into `{}`)
+    all became `0` — and `0` prints *"No feedback was recorded — none of those
+    ids matched a memory in your own domains"* followed by three causes for it.
+    That is an absence claim read out of a body that carried no claim, and
+    against core's async path — which acks before the worker runs — it can be
+    a flat lie about a rating that was applied. The rule `memory_stats` already
+    states in its own source now holds here too: a field the server did not
+    send is UNKNOWN, not zero, and unknown gets its own sentence that diagnoses
+    nothing.
+  - **A string `"0"` is not `0`,** so `??` passed it through and the ±1
+    branches printed *"The service reports 0 memories updated — they should
+    surface sooner next time"*: two clauses contradicting each other inside one
+    sentence. A negative passed through the same way (*"reports -2 memories
+    updated"*). Only a non-negative integer is now treated as a count.
+  - **A partial application was reported as an unqualified success.**
+    `atom_ids.length` was never compared with the count, so five ids and
+    `updated_count: 2` printed the success line and three silent misses — the
+    typical shape of the room case, where half the ids came off a room read
+    this tool cannot reach. The answer now says how many missed and why, reusing
+    the zero branch's causes verbatim so the two cannot drift. A shortfall can
+    only come from core's SYNC path (the async ack is exactly
+    `len(atom_ids)`), where the number is the authoritative count of atoms that
+    existed — so the diagnosis is sound, not a guess. A count LARGER than the
+    ids sent is no shape core produces, but `MNEMOVERSE_API_URL` points
+    wherever it is pointed: it is now named as not-a-per-id-result rather than
+    printed as nine of the caller's memories rated.
+
+- **"Negative feedback lets it fade" is gone from the three surfaces that
+  outlived its own retraction (#95).** 0.9.1's own entry above records the
+  claim as withdrawn — nothing time-decays, nothing is auto-deleted, and
+  deletion has been administrative-only since 0.9.0 — and the README lost it.
+  The `memory_feedback` tool description, the sentence the handler prints after
+  every downvote (*"they should fade"*), and `llms.txt` all kept it. All three
+  now carry the wording that release put in its place: a downvoted memory is
+  **out-ranked, not erased**. `llms.txt` is hand-written — it is not one of the
+  19 artifacts `verify:configs` checks, which is exactly how it went unnoticed
+  — so it is now covered by the withdrawn-claims ban in
+  `test/descriptions.test.ts`, which bans the word corpus-wide.
+
+  Text-only, and one internal branch — a PATCH by this file's own rule.
+
 ## [0.9.1] — 2026-08-24
 
 Text under this file's own rules: what a tool returns when it fails. No tool,

--- a/llms.txt
+++ b/llms.txt
@@ -42,7 +42,7 @@ Parameters:
 Returns: Entries newest-first with created_at, author tag, and id; plus a cursor line when older entries exist.
 
 ### memory_feedback
-Report whether a retrieved memory was helpful. Positive feedback strengthens recall. Negative lets memories fade.
+Report whether a retrieved memory was helpful. Positive feedback re-ranks recall so it surfaces sooner; negative lowers it so other memories out-rank it — nothing is erased.
 
 Parameters:
 - atom_ids (string[], required): IDs of memories to give feedback on.

--- a/src/index.ts
+++ b/src/index.ts
@@ -954,11 +954,34 @@ server.registerTool(
 
 // --- Tool: memory_feedback ---
 
+/**
+ * Why ids can miss, listed once and used by both branches that need it — the
+ * total miss (`updated_count: 0`) and the partial one (a count short of the
+ * ids sent). They are the same event at two scales, and when the sentence
+ * lived inline in the zero branch only, the partial case got no explanation at
+ * all.
+ *
+ * No frequency claim. "Most often that means…" was a statistic we do not have
+ * (review, 2026-08-08); the causes are listed as possibilities, with the one
+ * the caller cannot otherwise guess first because it is invisible from the
+ * tool surface — this tool takes no `domain`, so a room atom is unreachable
+ * from it by construction.
+ */
+const FEEDBACK_MISS_CAUSES =
+  "Possible causes: the ids came from a shared room (this tool takes no domain " +
+  "argument and cannot reach room atoms, so rating them is a no-op); the memory " +
+  "was deleted; or the id came from somewhere other than a memory_read result.";
+
 server.registerTool(
   "memory_feedback",
   {
     description:
-      "Report whether memories returned by memory_read were actually helpful. This is a learning signal, not a log: positive feedback raises a memory's ranking so it surfaces faster next time (across all of the user's tools), negative feedback lets it fade. Call it right after you act on (or reject) recalled memories, passing the ids from the memory_read results. NOTE: this reaches your own domains only — it takes no domain argument, so rating a memory that lives in a shared room silently does nothing.",
+      // "negative feedback lets it fade" was withdrawn as false by 0.9.1
+      // (#95) — and survived here, in the sentence every connected model
+      // reads. Nothing time-decays and nothing is auto-deleted: a downvoted
+      // memory is OUT-RANKED, and deletion has been administrative-only since
+      // 0.9.0. The replacement is the wording that release put on the README.
+      "Report whether memories returned by memory_read were actually helpful. This is a learning signal, not a log: positive feedback raises a memory's ranking so it surfaces faster next time (across all of the user's tools), negative feedback lowers it so other memories out-rank it — nothing is erased and nothing decays with time. Call it right after you act on (or reject) recalled memories, passing the ids from the memory_read results. NOTE: this reaches your own domains only — it takes no domain argument, so rating a memory that lives in a shared room silently does nothing.",
     inputSchema: {
       atom_ids: z
         .array(z.string())
@@ -992,7 +1015,73 @@ server.registerTool(
       body: JSON.stringify({ atom_ids, outcome }),
     });
 
-    const count = r?.updated_count ?? 0;
+    // A FIELD THE SERVER DID NOT SEND IS UNKNOWN, NOT ZERO — the rule
+    // memory_stats already applies with `num()`, broken here by
+    // `r?.updated_count ?? 0` in three directions at once:
+    //
+    //   1. A 200 with the field absent, an explicit null, and a 204 (which
+    //      apiFetch turns into `{}`) all became 0, and 0 prints "No feedback
+    //      was recorded" plus three causes for it — an absence claim read out
+    //      of a body that carried no claim. Under core's async path the
+    //      rating may well have been applied while the ack said nothing.
+    //   2. A string "0" is not 0, so `??` passed it straight through and the
+    //      ±1 branches printed "The service reports 0 memories updated — they
+    //      should surface sooner next time": two clauses contradicting each
+    //      other in one sentence.
+    //   3. Nothing rejected a negative: "reports -2 memories updated".
+    //
+    // So: usable means a non-negative integer. Anything else is UNKNOWN and
+    // gets its own sentence, which diagnoses nothing — the causes of a miss
+    // belong to a reported zero, not to a number we never received.
+    const reported: unknown = r?.updated_count;
+    const count =
+      typeof reported === "number" && Number.isInteger(reported) && reported >= 0
+        ? reported
+        : undefined;
+
+    // Direction is echoed for every outcome, including the ones with no count
+    // to report: the same four words for +1 and -1 gave a caller no evidence
+    // the loop did anything, which is why nobody calls it twice.
+    const sent =
+      outcome > 0
+        ? `Rating sent: +${outcome} (helpful).`
+        : outcome < 0
+          ? `Rating sent: ${outcome} (unhelpful).`
+          : "Rating sent: 0.";
+    // Zero has no effect clause to offer — promising "this shifts how they
+    // rank" for outcome 0 would be a claim we cannot make (dogfooding saw a
+    // neutral rating move a score UP by about five points, CodeRabbit #65) —
+    // so it offers the one thing that is actionable instead.
+    //
+    // WHAT 0 ACTUALLY DOES, restated against core#493 (merged 2026-08-13). The
+    // valence step used to be `sign(outcome) * |prediction error|`, so outcome
+    // 0 took the POSITIVE branch and pushed valence UP — which is what
+    // dogfooding saw, and what the previous version of this comment recorded.
+    // That is no longer true: core now uses the SIGNED error,
+    // `pe = outcome - valence` (memory_engine.py:5167-5169), so a 0 against a
+    // positive valence moves it DOWN, toward neutral. Either way 0 is not a
+    // no-op and the line must not imply one — but the old explanation is now
+    // backwards, and it ships verbatim inside dist/index.js, so it cannot be
+    // left to rot in a comment.
+    const pickADirection =
+      outcome === 0
+        ? " Use +1 (helpful) or -1 (harmful/wrong) to express a clear direction."
+        : "";
+
+    if (count === undefined) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text:
+              `${sent} The service accepted the call but did not report how many ` +
+              `memories it updated, so whether any changed is unknown from here. ` +
+              `That is not evidence of a failure — do not re-send the same rating ` +
+              `on the strength of it.` + pickADirection,
+          },
+        ],
+      };
+    }
 
     // "Feedback recorded for 0 memories." is one character away from the
     // success line and reads like one. But the DIAGNOSIS matters as much as
@@ -1011,32 +1100,17 @@ server.registerTool(
           {
             type: "text" as const,
             text:
-              // No frequency claim. "Most often that means…" was a statistic
-              // we do not have (review, 2026-08-08); the causes are listed as
-              // possibilities, with the one the caller cannot otherwise guess
-              // first because it is invisible from the tool surface.
               "No feedback was recorded — none of those ids matched a memory in your own " +
-              "domains. Possible causes: the ids came from a shared room (this tool takes " +
-              "no domain argument and cannot reach room atoms, so rating them is a no-op); " +
-              "the memory was deleted; or the id came from somewhere other than a " +
-              "memory_read result.",
+              `domains. ${FEEDBACK_MISS_CAUSES}`,
           },
         ],
       };
     }
 
-    // Echo the DIRECTION, not just the count: the same four words for +1 and
-    // -1 gave a caller no evidence the loop did anything, which is why nobody
-    // calls it twice.
-    //
-    // The effect clause is per-direction. Promising "this shifts how they
-    // rank" for outcome 0 would be a claim we cannot make — dogfooding saw a
-    // neutral rating move a score UP by about five points, so neither "no
-    // change" nor "ranks higher" is safe to assert (CodeRabbit, #65).
     // WHOSE NUMBER THIS IS (#68). `updated_count` is the count of memories the
     // service says it touched — and that is true only while core runs
     // `feedback_async = False`. Under async it returns the number of ids
-    // SUBMITTED, not applied (core schemas.py:689-695, memory_engine.py:4490),
+    // SUBMITTED, not applied (core schemas.py:826-838, memory_engine.py:4898-4902),
     // and nothing in the response says which mode ran. A server-side config
     // flip would therefore turn a confident sentence here false on every
     // installed client, silently. So the number is reported as the SERVICE'S
@@ -1045,28 +1119,54 @@ server.registerTool(
     // (mnemoverse-mcp-remote#38); one number, one degree of confidence,
     // whichever surface a model reaches it through.
     const noun = `${count} memor${count === 1 ? "y" : "ies"}`;
-    const text =
+    const effect =
       outcome > 0
-        ? `Rating sent: +${outcome} (helpful). The service reports ${noun} updated — they should surface sooner next time.`
+        ? " — they should surface sooner next time."
         : outcome < 0
-          ? `Rating sent: ${outcome} (unhelpful). The service reports ${noun} updated — they should fade.`
-          // Zero claims only what is knowable from here: the rating was sent,
-          // the service reported a count, and ±1 send a clear signal.
-          //
-          // WHAT 0 ACTUALLY DOES, restated against core#493 (merged
-          // 2026-08-13). The valence step used to be
-          // `sign(outcome) * |prediction error|`, so outcome 0 took the
-          // POSITIVE branch and pushed valence UP — which is what dogfooding
-          // saw, and what the previous version of this comment recorded. That
-          // is no longer true: core now uses the SIGNED error,
-          // `pe = outcome - valence` (memory_engine.py:4986-4988), so a 0
-          // against a positive valence moves it DOWN, toward neutral. Either
-          // way 0 is not a no-op and the line must not imply one — but the old
-          // explanation is now backwards, and it ships verbatim inside
-          // dist/index.js, so it cannot be left to rot in a comment.
-          : `Rating sent: 0. The service reports ${noun} updated. Use +1 (helpful) or -1 (harmful/wrong) to express a clear direction.`;
+          // No fade. 0.9.1 (#95) withdrew "lets it fade" as false — nothing
+          // time-decays, nothing is auto-deleted, and deletion has been
+          // administrative-only since 0.9.0 — and this line kept promising it
+          // after the release that deleted the claim from the README.
+          ? " — they should rank lower next time. Out-ranked, not erased: nothing is deleted and nothing decays with time."
+          : ".";
+
+    // WHAT THE COUNT IS NOT: a guarantee that every id landed. `atom_ids.length`
+    // was never compared with it, so five ids and `updated_count: 2` printed
+    // the unqualified success line and three silent misses — the typical shape
+    // of the room case, where half the ids came off a room read this tool
+    // cannot reach. A SHORTFALL can only come from core's sync path (the async
+    // ack is exactly `len(atom_ids)`, memory_engine.py:4898-4902), where the
+    // number is the authoritative count of atoms that existed — so the same
+    // causes as the zero branch apply, at a smaller scale, and the string is
+    // shared so the two cannot drift apart.
+    //
+    // An EXCESS is not a shape core produces at all (sync counts one per id
+    // that resolved, async counts the ids). But MNEMOVERSE_API_URL points
+    // wherever it is pointed, and "reports 9 memories updated" for one id
+    // would otherwise read as nine of the caller's memories rated. Say what it
+    // cannot be rather than pass it off as a per-id result.
+    const idsSent = `${atom_ids.length} id${atom_ids.length === 1 ? "" : "s"} you sent`;
+    const mismatch =
+      count < atom_ids.length
+        ? ` That is fewer than the ${idsSent}: ${atom_ids.length - count} of them ` +
+          `matched nothing in your own domains. ${FEEDBACK_MISS_CAUSES}`
+        : count > atom_ids.length
+          ? ` That is more than the ${idsSent}, so it cannot be a per-id result — ` +
+            `read it as the service's own tally, not as how many of your memories ` +
+            `were rated.`
+          : "";
+
     return {
-      content: [{ type: "text" as const, text }],
+      content: [
+        {
+          type: "text" as const,
+          // Order: what was sent, what the service reported, what that means
+          // for the ids — then the advice. Putting `pickADirection` before the
+          // mismatch clause interrupted the report with a suggestion and
+          // resumed it afterwards.
+          text: `${sent} The service reports ${noun} updated${effect}${mismatch}${pickADirection}`,
+        },
+      ],
     };
   },
 );

--- a/test/descriptions.test.ts
+++ b/test/descriptions.test.ts
@@ -27,6 +27,7 @@
  * without booting a stdio server.
  */
 
+import { readFileSync } from "node:fs";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { SERVER_INSTRUCTIONS } from "../src/teaching.js";
@@ -129,6 +130,14 @@ describe("the advertised descriptions carry this release's truth claims", () => 
     );
   });
 
+  it("memory_feedback states what a downvote does: out-ranks, never erases (#95)", () => {
+    // The claim 0.9.1 put in its place, pinned so the true half cannot be
+    // deleted along with the false one. The ban on the false half is in the
+    // withdrawn-claims block below.
+    const d = description("memory_feedback");
+    expect(d).toContain("other memories out-rank it — nothing is erased");
+  });
+
   it("vault_list promises aliases only — the value is never returned", () => {
     const d = description("vault_list");
     expect(d).toContain("the secret VALUE is never returned");
@@ -179,6 +188,13 @@ describe("withdrawn claims stay withdrawn on every advertised surface", () => {
     // exist, which is the kind of mismatch Anthropic's directory policy fails
     // a submission for.
     [/a tool that consumes it/i, "the phantom secret-consumer claim"],
+    // "negative feedback lets it fade" — withdrawn from the README by 0.9.1
+    // (#95) as false for a reason that has nothing to do with the re-ranking
+    // fix: nothing time-decays and nothing is auto-deleted, so a downvoted
+    // memory is out-ranked, not erased. It nevertheless survived the release
+    // on three surfaces a model reads, this one included. The whole word is
+    // banned because no true sentence about this engine needs it.
+    [/\bfades?\b/i, "the 'lets it fade' time-decay claim"],
   ];
 
   it("no tool or parameter description carries one", () => {
@@ -213,6 +229,19 @@ describe("withdrawn claims stay withdrawn on every advertised surface", () => {
         SERVER_INSTRUCTIONS,
         `SERVER_INSTRUCTIONS restores ${why}`,
       ).not.toMatch(banned);
+    }
+  });
+
+  // llms.txt is hand-written — it is NOT one of the 19 artifacts
+  // scripts/generate-configs.mjs emits, so `npm run verify:configs` never
+  // looks at it and no other test did either. That is exactly how it kept
+  // describing feedback as "Negative lets memories fade" through a release
+  // whose own CHANGELOG deletes the claim. It is a surface a model reads;
+  // it gets the same ban as the wire.
+  it("the hand-written llms.txt carries none either", () => {
+    const llms = readFileSync(new URL("../llms.txt", import.meta.url), "utf8");
+    for (const [banned, why] of WITHDRAWN) {
+      expect(llms, `llms.txt restores ${why}`).not.toMatch(banned);
     }
   });
 });

--- a/test/handlers.test.ts
+++ b/test/handlers.test.ts
@@ -20,6 +20,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import {
   httpError,
   networkDown,
+  noContent,
   startMemoryServer,
   type Route,
   type Harness,
@@ -837,7 +838,15 @@ describe("the load-bearing sentences, as returned", () => {
     // `updated_count` is the number of ids SUBMITTED and this client cannot
     // tell which mode ran. Direction is still echoed, which is what this test
     // is here to protect.
-    expect(await mcp.callText("memory_feedback", { atom_ids: ["a"], outcome: 1 })).toBe(
+    //
+    // TWO ids, not one. This fixture used to send `["a"]` and stub a count of
+    // 2 — a response no deployment of core can produce (the async ack is
+    // exactly `len(atom_ids)`, the sync count is at most that), and the one
+    // shape whose answer now carries an extra clause. The impossible fixture
+    // is exercised on purpose in its own test below.
+    expect(
+      await mcp.callText("memory_feedback", { atom_ids: ["a", "b"], outcome: 1 }),
+    ).toBe(
       "Rating sent: +1 (helpful). The service reports 2 memories updated — they should surface sooner next time.",
     );
 
@@ -858,6 +867,96 @@ describe("the load-bearing sentences, as returned", () => {
     expect(neutral).not.toContain("neither useful nor wrong");
     expect(neutral).not.toContain("should surface sooner");
     expect(neutral).not.toContain("should fade");
+  });
+
+  it("a count the service did not send is UNKNOWN, not zero", async () => {
+    // `r?.updated_count ?? 0` folded six different "no usable number" shapes
+    // onto the ZERO branch — the branch that states outright that nothing was
+    // recorded and then offers three causes for it. That is an absence claim
+    // read out of a body that carried no claim, which is the same defect
+    // memory_stats fixed with `num()`: a field the server did not send is
+    // unknown, not zero. And it can be a flat lie — the rating may well have
+    // been applied by core's async path while the ack said nothing usable.
+    for (const [label, reply] of [
+      ["the field absent", {}],
+      ["an explicit null", { updated_count: null }],
+      // 204 and a zero-length body both reach the handler as `{}` (apiFetch).
+      ["204 No Content", noContent()],
+      // A string "0" is not 0: `?? 0` passes it through, and the ±1 branches
+      // then printed "The service reports 0 memories updated — they should
+      // surface sooner next time", two clauses that contradict each other.
+      ["a string", { updated_count: "0" }],
+      ["a float", { updated_count: 1.5 }],
+      // Nothing rejects a negative either: "reports -2 memories updated".
+      ["a negative", { updated_count: -2 }],
+    ] as Array<[string, Route]>) {
+      mcp.reset().on(FEEDBACK, reply);
+      const text = await mcp.callText("memory_feedback", {
+        atom_ids: ["a"],
+        outcome: 1,
+      });
+
+      expect(text, label).toContain("Rating sent: +1 (helpful).");
+      expect(text, label).toContain("did not report how many memories it updated");
+      // No absence claim, and none of the zero branch's diagnosis: the body
+      // said nothing, so the causes of a nothing it never reported are not
+      // ours to list.
+      expect(text, label).not.toContain("No feedback was recorded");
+      expect(text, label).not.toContain("shared room");
+      expect(text, label).not.toContain("deleted");
+      // And no number invented out of the unusable value.
+      expect(text, label).not.toMatch(/-?[\d.]+ memor/);
+    }
+  });
+
+  it("a count SHORT of the ids sent says which ids missed", async () => {
+    // The defect: `atom_ids.length` was never compared with the count, so
+    // five ids and `updated_count: 2` printed the unqualified success line and
+    // three silent misses. It is the typical shape of the room case — half the
+    // ids off a room read, which this tool cannot reach — and the caller has
+    // no way to see it. A shortfall can only come from core's SYNC path (the
+    // async ack is exactly `len(atom_ids)`), where the number is the
+    // authoritative count of atoms that existed, so the diagnosis is sound.
+    mcp.on(FEEDBACK, { updated_count: 2 });
+
+    const text = await mcp.callText("memory_feedback", {
+      atom_ids: ["a", "b", "c", "d", "e"],
+      outcome: 1,
+    });
+
+    expect(text).toContain("The service reports 2 memories updated");
+    expect(text).toContain("fewer than the 5 ids you sent");
+    expect(text).toContain("3 of them matched nothing in your own domains");
+    // Same causes, same order as the zero branch — one story, two scales.
+    expect(text).toContain("cannot reach room atoms");
+  });
+
+  it("a count LARGER than the ids sent is not passed off as a per-id result", async () => {
+    mcp.on(FEEDBACK, { updated_count: 9 });
+
+    const text = await mcp.callText("memory_feedback", {
+      atom_ids: ["a"],
+      outcome: -1,
+    });
+
+    expect(text).toContain("more than the 1 id you sent");
+    expect(text).toContain("cannot be a per-id result");
+  });
+
+  it("negative feedback promises no fade: out-ranked, not erased (#95)", async () => {
+    // 0.9.1 retired this claim from the README as false — nothing time-decays
+    // and nothing is auto-deleted — and it survived here, in the sentence a
+    // model actually reads after every downvote.
+    mcp.on(FEEDBACK, { updated_count: 1 });
+
+    const text = await mcp.callText("memory_feedback", {
+      atom_ids: ["a"],
+      outcome: -1,
+    });
+
+    expect(text).not.toContain("fade");
+    expect(text).toContain("Out-ranked, not erased");
+    expect(text).toContain("nothing is deleted and nothing decays with time");
   });
 
   it("memory_stats distinguishes unknown from zero", async () => {


### PR DESCRIPTION
Bug-hunt findings (pre-0.9.2), all three on the `memory_feedback` surface — sentences a model reads and acts on.

## What

1. **A count the service did not send is UNKNOWN, not zero.** `r?.updated_count ?? 0` turned a field-less 200, an explicit `null`, and a 204 (apiFetch's `{}`) into `0` — and `0` prints "No feedback was recorded" plus three causes: an absence claim read out of a body that carried no claim, and a flat lie whenever core's async path acked before its worker ran. A string `"0"` sailed through `??` into "reports 0 memories updated — they should surface sooner next time" (two clauses contradicting each other in one sentence); a negative printed "reports -2 memories updated". Only a non-negative integer is a count now; anything else gets its own sentence that diagnoses nothing and forbids blind re-sending.
2. **Partial application is named, not passed off as success.** Five ids and `updated_count: 2` used to print the unqualified success line; now the answer says how many ids missed and why, reusing the zero branch's causes verbatim (one `FEEDBACK_MISS_CAUSES` constant — the two branches cannot drift). The diagnosis is sound, not a guess: a shortfall can only come from core's **sync** path — the async ack is exactly `len(atom_ids)` — where the number is the authoritative count of atoms that existed. A count **larger** than the ids sent (no shape core produces, but `MNEMOVERSE_API_URL` points wherever it is pointed) is named as not-a-per-id-result.
3. **"Negative feedback lets it fade" outlived its own retraction.** 0.9.1 withdrew the claim as false and stripped it from the README (#95) — but it survived in the tool description, in the line printed after every downvote, and in `llms.txt`. All three now carry the replacement wording: **out-ranked, not erased — nothing decays with time**. `llms.txt` is hand-written and outside the 19 artifacts `verify:configs` checks (exactly how this went unnoticed), so it is now covered by the withdrawn-claims ban in `test/descriptions.test.ts`, which greps the file on disk.

## Self-review (reviewer voice)

- TDD held: 7 red tests first across descriptions/handlers, the lead failures being the zero branch answering "No feedback was recorded" to a body that reported nothing, and the downvote line promising "they should fade".
- One pre-existing fixture pinned an **impossible** response (`updated_count: 2` for a single id — no deployment of core produces it); corrected, and the impossible shape is now exercised on purpose as the excess-count test.
- A stale comment about `outcome: 0` was updated against core#493: the valence step now uses the signed error, so the old "0 pushes valence UP" explanation had become backwards — and it ships verbatim inside `dist/index.js`, so it could not be left to rot.
- Direction is echoed on every outcome (`Rating sent: +1/-1/0.`), so even the unknown-count answer carries evidence the loop did something.
- Gate mirrored CI: `tsc --noEmit`, `typecheck:test`, tests 421/421 ×3 timezones, `verify:configs` 19/19, build + real stdio initialize/tools-list against `dist` (wire description carries no "fade").

Known neighbour: `package.json` keyword `"forgetting"` is the same withdrawn claim on the npm surface — deliberately left to the descriptions PR to avoid a collision.

Done-by: Σ
