### PR TITLE
fix(render): wire values cannot crash, shift or overflow what the reader sees (bug hunt, pre-0.9.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,51 @@ git history and the GitHub releases are the record.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A value with the wrong wire type can no longer kill the tool call it
+  appears in.** `safeInline` was `(s ?? "").replace(…)`, which throws on
+  anything that is not a string — and the MCP SDK turns a thrown Error into the
+  ENTIRE result. So one numeric `agent_name` on one item of fifty replaced a
+  page of memories with `(s ?? "").replace is not a function`: no `Mnemoverse: `
+  prefix, no diagnosis, nothing to act on — the one shape every other failure in
+  0.9.1 was rewritten to avoid. Five call sites took a wire value unnarrowed
+  (the author tag on every read and feed line; `address` and `room_id` on
+  memory_create_room; `scope` and `address` on memory_join_room; `alias` and
+  `context` on vault_list). `asRoom` had already closed this class for the room
+  list and recorded it as "a latent crash fixed"; this is the same fix, applied
+  where that one did not reach. A field that cannot be read now costs the reader
+  that field — an absent author tag, `(no alias)`, "the server did not return a
+  room address" — and nothing else.
+
+- **A timestamp without an offset is read as UTC, which is what the engine
+  means by it.** `new Date("2026-08-01T23:30:00")` reads the value as LOCAL
+  time, and `toISOString()` then printed the local reading with a `Z` — so the
+  same stored atom carried a different clock time in every timezone a client sat
+  in, and west of UTC a different DAY: `2026-08-01 23:30Z` in UTC, `14:30Z` in
+  Asia/Tokyo, `2026-08-02 06:30Z` in America/Los_Angeles. The convention was
+  already written down twice (both `since` descriptions, core's schema) and
+  implemented once, in the future-watermark note; the renderer read the same
+  wire value the other way. `parseAsUtc` now lives in `src/time.ts` and both
+  modules use it — one convention, one implementation. A `created_at` that
+  arrives as a number is no longer rendered as a date the contract does not
+  promise.
+
+- **memory_stats can no longer exceed the 25K-token result cap.** It was the
+  one surface that never went through `capResult`, and its `Domains:` line is
+  linear in the number of stores — 4,000 domains rendered 100,391 characters
+  against a 96,000 cap, deterministically, with no hostile input involved. The
+  fix bounds the LIST rather than the message, because a blind cap truncates
+  from the end and would have taken the average-quality line and the reminder
+  that rooms are separate stores down with the wall of names. What is cut is
+  counted and says why, in its own clause: `(+400 more names not shown — the
+  list is longer than one tool result can carry, so a name you do not see here
+  may still exist)` — kept separate from the existing "cannot be printed
+  exactly" count, because those are different facts about different names. This
+  tool's own description sends readers here to confirm a store's exact name, so
+  a silently shortened list would have answered that question with a false
+  negative. `capResult` is now wired here too, as a second belt.
+
 ## [0.9.1] — 2026-08-24
 
 Text under this file's own rules: what a tool returns when it fails. No tool,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1120,6 +1120,15 @@ server.registerTool(
     // zero-width character are all visible, Cyrillic stays Cyrillic, and two
     // different names can no longer print as one. Assembly lives in
     // src/names.ts, where it is unit-tested against those exact inputs.
+    //
+    // The assembly also BOUNDS the list (MAX_DOMAIN_LIST_CHARS), which is what
+    // makes this handler respect the 25K-token cap every other surface already
+    // respected. The line is linear in the number of stores and nothing bounded
+    // it: 4,000 domains rendered past 100,000 characters — deterministically,
+    // with no hostile input involved. Bounding the LIST rather than leaning on
+    // capResult alone is the point: capResult truncates from the END, so the
+    // wall of names would have taken the average-quality line and the rooms
+    // reminder down with it, leaving the answer nothing but names.
     const domains = formatDomainList(r?.domains);
 
     const text = [
@@ -1148,8 +1157,22 @@ server.registerTool(
           // arrives over the wire, and spreading a non-iterable object would
           // throw here — turning a malformed payload into a dead tool instead
           // of the "none reported" it degrades to two lines up.
+          //
+          // capResult is the second belt, not the mechanism: the domain list is
+          // already bounded above, so this only fires if some future line grows
+          // unboundedly. It stays because this was the ONE tool result with no
+          // cap at all, and "every surface is capped" is worth being an
+          // invariant rather than an argument about which surfaces can grow.
+          // Its hint names a control this no-input tool actually has — none —
+          // rather than the read tool's "use a more specific query".
+          //
+          // Legend AFTER the cap, as everywhere else: it must describe the names
+          // that SURVIVED, and it is appended at the end, where the cap cuts.
           text: withDomainEscapeLegend(
-            text,
+            capResult(
+              text,
+              "The domain list was truncated — some domain names are not shown.",
+            ),
             ...(Array.isArray(r?.domains) ? r.domains : []),
           ),
         },

--- a/src/names.ts
+++ b/src/names.ts
@@ -176,6 +176,18 @@ export function roomNamePhrase(name: unknown): string {
 }
 
 /**
+ * How many characters of NAMES the `Domains:` line may spend.
+ *
+ * Sized against the tool-result cap it exists to respect: `MAX_RESULT_CHARS` in
+ * src/index.ts is 96,000, and the reserve covers the four other stats lines, the
+ * escape legend, and the truncation notice `capResult` appends if it ever fires.
+ * The relationship is pinned behaviourally — "memory_stats fits the result cap
+ * without losing its tail", test/handlers.test.ts — so this number cannot drift
+ * away from that one in silence.
+ */
+export const MAX_DOMAIN_LIST_CHARS = 90_000;
+
+/**
  * The `Domains:` line of memory_stats — the surface this tool's own
  * description sends the reader to "to confirm the exact domain name before
  * writing to it", which it could not do while the names went through
@@ -188,23 +200,64 @@ export function roomNamePhrase(name: unknown): string {
  * one surface whose job is the opposite. An absent or empty list keeps the
  * existing "none reported", which is honest about both of the states core can
  * produce (no key on a non-core 200, or a genuinely empty bucket).
+ *
+ * `maxChars` bounds the NAMES, and it is the reason memory_stats is no longer
+ * the one tool result that could exceed the 25K-token Connectors Directory cap.
+ * This line is linear in the number of stores and nothing bounded it: 4,000
+ * domains rendered past 100,000 characters, every time, with no hostile input
+ * involved. Cutting the list here rather than capping the whole message is
+ * deliberate — `capResult` truncates from the END, so a blind cap would have
+ * eaten the average-quality line and the reminder that rooms are separate
+ * stores, i.e. the parts of the answer that are not the wall of names.
+ *
+ * What is cut is COUNTED and its cause is NAMED, in a clause kept separate from
+ * the unprintable one: "the list is too long" and "this name cannot be
+ * reproduced" are different facts about different names, and merging them would
+ * put the wrong cause on both.
  */
 export function formatDomainList(
   domains: unknown,
   emptyLabel = "none reported",
+  maxChars = MAX_DOMAIN_LIST_CHARS,
 ): string {
   if (!Array.isArray(domains) || domains.length === 0) return emptyLabel;
   const rendered = domains.map((d) => exactLiteral(d as string));
   const named = rendered.filter((x): x is ExactLiteral => x !== null);
   const unnamed = rendered.length - named.length;
+
+  // First N that fit, in order — not "every one that fits", which would print a
+  // list whose gaps follow no rule a reader could describe.
+  const shown: string[] = [];
+  let used = 0;
+  for (const x of named) {
+    const cost = (shown.length > 0 ? 2 : 0) + x.literal.length;
+    if (used + cost > maxChars) break;
+    used += cost;
+    shown.push(x.literal);
+  }
+  const overflow = named.length - shown.length;
+
   // "cannot be printed exactly", not "too long": length is the reachable cause,
   // but a value that is not a string at all lands here too, and naming the wrong
   // cause is the habit this release exists to break.
-  const tail =
-    unnamed > 0
-      ? `${named.length > 0 ? " " : ""}(+${unnamed} name${unnamed === 1 ? "" : "s"} not shown — cannot be printed exactly)`
-      : "";
-  return named.map((x) => x.literal).join(", ") + tail;
+  const clauses: string[] = [];
+  if (unnamed > 0) {
+    clauses.push(
+      `(+${unnamed} name${unnamed === 1 ? "" : "s"} not shown — cannot be printed exactly)`,
+    );
+  }
+  // Says outright what a shortened list would otherwise imply. This tool's own
+  // description sends a reader here to confirm a store's exact name before
+  // writing to it, so a name that is merely absent from the line must not read
+  // as a store that is absent from the account.
+  if (overflow > 0) {
+    clauses.push(
+      `(+${overflow} more name${overflow === 1 ? "" : "s"} not shown — the list is ` +
+        `longer than one tool result can carry, so a name you do not see here may ` +
+        `still exist)`,
+    );
+  }
+  return [shown.join(", "), ...clauses].filter((s) => s !== "").join(" ");
 }
 
 /**

--- a/src/render.ts
+++ b/src/render.ts
@@ -12,6 +12,7 @@
  */
 
 import { MAX_DOMAIN_TAG_LITERAL, exactLiteral } from "./names.js";
+import { parseAsUtc } from "./time.js";
 
 /** CN-001 server-stamped authorship, as returned nested on read/feed items. */
 export type Provenance = {
@@ -61,9 +62,27 @@ export type RecentItem = {
  * quoted as "Zo" — a different name presented as the name. The exact literal
  * is single-line with quotes and invisibles escaped, so it carries the same
  * anti-injection property without the renaming.
+ *
+ * `s` is `unknown` — like `roomNamePhrase` and `exactLiteral`, and for the same
+ * reason. Every call site reads a field off the wire where the response types
+ * are aspirational, and this was `(s ?? "").replace(…)`, which throws on
+ * anything that is not a string. The SDK turns a thrown Error into the WHOLE
+ * tool result, so one numeric `agent_name` on one item of fifty replaced a page
+ * of memories with `(s ?? "").replace is not a function` — no `Mnemoverse: `
+ * prefix, no diagnosis, nothing to act on. `asRoom` (src/scope.ts) narrowed the
+ * room list for exactly this reason and recorded it as "a latent crash fixed";
+ * the five remaining call sites (the author tag here, and address / room_id /
+ * scope / alias / context in src/index.ts) are closed by the guard below.
+ *
+ * A non-string sanitises to "" rather than to `String(s)`: this output is
+ * interpolated into sentences that are already written to handle a missing
+ * value — an absent author tag, "(no alias)", "the server did not return a room
+ * address" — and every one of those is true of a field we cannot read, while
+ * `"[object Object]"` as an author would not be.
  */
-export function safeInline(s: string | undefined | null, cap = 200): string {
-  return (s ?? "")
+export function safeInline(s: unknown, cap = 200): string {
+  if (typeof s !== "string") return "";
+  return s
     .replace(/[^\w .@:+/-]/g, " ")
     .replace(/\s+/g, " ")
     .trim()
@@ -118,12 +137,27 @@ export function formatDomainTag(domain?: string): string {
  * ` · 2026-08-01 21:04Z` — minute-precision UTC, compact enough for a line
  * tail, precise enough to order a same-day room conversation by eye.
  * Empty for legacy atoms without a timestamp.
+ *
+ * The `Z` is an ASSERTION, and until now it was made about a number this
+ * function had not established. `new Date(createdAt)` reads an offset-less
+ * `created_at` as LOCAL time — the reading core's schema and this server's own
+ * `since` descriptions both contradict — and `toISOString()` then stamped the
+ * local reading with a `Z`. So one stored atom rendered a different clock time
+ * in every timezone the client happened to sit in: `2026-08-01T23:30:00` was
+ * `23:30Z` in UTC, `14:30Z` in Asia/Tokyo, and `2026-08-02 06:30Z` in
+ * America/Los_Angeles — a memory dated to a day it was not written, on the tag
+ * a reader uses to order a conversation and to decide what is recent.
+ *
+ * `parseAsUtc` (src/time.ts) is the same reader src/scope.ts uses for the
+ * future-watermark note, which is the point: the convention is now implemented
+ * once. It also rejects a non-string, so a `created_at` that arrives as epoch
+ * millis degrades to no tag rather than to a date the contract does not
+ * promise.
  */
 export function formatDateTag(createdAt?: string): string {
-  if (!createdAt) return "";
-  const d = new Date(createdAt);
-  if (Number.isNaN(d.getTime())) return "";
-  const iso = d.toISOString();
+  const t = parseAsUtc(createdAt);
+  if (t === null) return "";
+  const iso = new Date(t).toISOString();
   return ` · ${iso.slice(0, 10)} ${iso.slice(11, 16)}Z`;
 }
 

--- a/src/scope.ts
+++ b/src/scope.ts
@@ -32,6 +32,11 @@ import {
   roomNamePhrase,
   withDomainEscapeLegend,
 } from "./names.js";
+// "naive = UTC" is the convention core's schema and both `since` descriptions
+// state; it used to be implemented here and nowhere else, which is how the
+// renderer came to read the same wire value as local time. One implementation,
+// two readers (src/time.ts).
+import { parseAsUtc } from "./time.js";
 
 /**
  * How to NAME the scope inside a sentence, so the sentence is true on its own
@@ -99,29 +104,6 @@ export function futureSinceNote(since: string | undefined, nowMs: number): strin
     `(the server's may differ slightly). Check the watermark you passed — a timezone ` +
     `slip is the usual cause.`
   );
-}
-
-/**
- * Parse an ISO-8601 instant the way the SERVER does: an offset-less value is
- * UTC, not local time.
- *
- * `Date.parse("2026-08-08T13:00:00")` returns LOCAL midnight-relative millis,
- * while both tool descriptions here and core's schema say "naive = UTC". The
- * mismatch made this note lie in both directions (review, 2026-08-08): west of
- * UTC a perfectly sane watermark was declared to be in the future and every
- * clause of the note was false; east of UTC a genuinely future watermark was
- * shifted into the past and the note stayed silent, missing the one case it
- * exists for.
- *
- * Date-only values ("2026-08-08") are already parsed as UTC by spec, so only
- * date-TIME values without an offset need the Z.
- */
-function parseAsUtc(iso: string): number | null {
-  const s = iso.trim();
-  const hasOffset = /(?:Z|[+-]\d{2}:?\d{2})$/i.test(s);
-  const isDateTime = /\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}/.test(s);
-  const t = Date.parse(isDateTime && !hasOffset ? `${s.replace(" ", "T")}Z` : s);
-  return Number.isNaN(t) ? null : t;
 }
 
 /**

--- a/src/time.ts
+++ b/src/time.ts
@@ -1,0 +1,47 @@
+/**
+ * The one place that decides what an offset-less timestamp MEANS.
+ *
+ * This module exists because the answer was written down twice and implemented
+ * once. Both `since` parameter descriptions and core's own schema say a naive
+ * ISO-8601 value is UTC; `Date.parse("2026-08-08T13:00:00")` says it is local
+ * time. The gap was closed for the future-watermark note in 0.8.1 (src/scope.ts)
+ * and left open in the renderer (src/render.ts), so the same wire value decided
+ * one thing on the way in and another on the way out — a convention two modules
+ * read differently is not a convention.
+ *
+ * It lives on its own rather than in scope.ts because render.ts must not depend
+ * on scope.ts: the dependency deliberately runs the other way (scope.ts takes
+ * `safeInline` as an injected parameter precisely to avoid importing the
+ * renderer), and names.ts is about printing names, not about reading clocks.
+ */
+
+/**
+ * Parse an ISO-8601 instant the way the SERVER does: an offset-less value is
+ * UTC, not local time. Returns epoch milliseconds, or `null` for anything that
+ * cannot be read as an instant.
+ *
+ * The mismatch this fixes is not cosmetic — it moved dates. West of UTC a
+ * perfectly sane watermark was declared to be in the future and every clause of
+ * the future-watermark note was false; east of UTC a genuinely future watermark
+ * was shifted into the past and the note stayed silent, missing the one case it
+ * exists for (review, 2026-08-08). On a rendered result line the same reading
+ * printed `2026-08-01T23:30:00` as `2026-08-02 06:30Z` in America/Los_Angeles:
+ * a memory dated to a day it was not written, with a `Z` asserting it was UTC.
+ *
+ * Date-only values ("2026-08-08") are already parsed as UTC by spec, so only
+ * date-TIME values without an offset need the Z.
+ *
+ * `value` is `unknown` because both call sites read it off the wire, where the
+ * response types are aspirational: `created_at` is typed as a string and can
+ * arrive as a number. A value that is not a string is not an ISO-8601 instant,
+ * so it is `null` here rather than a guess — `new Date(1754082281605)` is a
+ * perfectly good date for a field whose contract says it is text.
+ */
+export function parseAsUtc(value: unknown): number | null {
+  if (typeof value !== "string") return null;
+  const s = value.trim();
+  const hasOffset = /(?:Z|[+-]\d{2}:?\d{2})$/i.test(s);
+  const isDateTime = /\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}/.test(s);
+  const t = Date.parse(isDateTime && !hasOffset ? `${s.replace(" ", "T")}Z` : s);
+  return Number.isNaN(t) ? null : t;
+}

--- a/test/handlers.test.ts
+++ b/test/handlers.test.ts
@@ -1545,3 +1545,155 @@ describe("the room lifecycle tools, invoked", () => {
     expect(res.text).not.toContain("Invite ready");
   });
 });
+
+// ---------------------------------------------------------------------------
+
+/**
+ * A FIELD with the wrong wire type must cost the reader that field, not the
+ * whole answer.
+ *
+ * `safeInline` was `(s ?? "").replace(…)`, which throws on anything that is not
+ * a string, and the MCP SDK turns a thrown Error into the entire tool result.
+ * So a single numeric `agent_name` — or an `address` that arrived as a number —
+ * replaced a page of memories with `(s ?? "").replace is not a function`: no
+ * `Mnemoverse: ` prefix (the property `what every error message owes the reader`
+ * pins in test/errors.test.ts), no diagnosis, nothing to retry. `asRoom`
+ * (src/scope.ts) had closed this class for the room list only.
+ *
+ * These are behavioural on purpose: the unit cases in test/render.test.ts prove
+ * the helper no longer throws, and these prove that the four handlers holding
+ * the other call sites answer with something a reader can use.
+ */
+describe("a field with the wrong wire type costs that field, not the tool call", () => {
+  it("memory_read: one broken item does not take the other forty-nine with it", async () => {
+    const items = Array.from({ length: 50 }, (_, i) => ({
+      atom_id: `atom_${i}`,
+      content: `note ${i}`,
+      // Item 7 is the hostile/buggy connector: `agent_name` typed as a string,
+      // sent as a number.
+      ...(i === 7 ? { provenance: { agent_name: 12345, is_external: true } } : {}),
+    }));
+    mcp.on(READ, { items, search_time_ms: 3 });
+
+    const res = await mcp.call("memory_read", { query: "everything" });
+
+    expect(res.isError).toBeFalsy();
+    expect(res.text).toContain("1. note 0");
+    expect(res.text).toContain("8. note 7");
+    expect(res.text).toContain("50. note 49");
+    expect(res.text).not.toContain("is not a function");
+  });
+
+  it("memory_join_room: an unusable address is said to be missing, not thrown", async () => {
+    mcp.on(JOIN, { address: 123, name: "me-and-olya", scope: { level: "read" } });
+
+    const text = await mcp.callText("memory_join_room", { code: "mnvr_abc" });
+
+    // The name is printed exactly (it is a string), the scope falls back to the
+    // neutral word, and the address takes the branch that already existed for a
+    // server that returned none — instead of the whole call dying.
+    expect(text).toContain('Joined "me-and-olya" (member).');
+    expect(text).toContain("The server did not return a room address");
+    expect(text).not.toContain('domain="123"');
+  });
+
+  it("memory_create_room: same, on the surface that hands back an address", async () => {
+    mcp.on(CREATE_ROOM, { room_id: { id: 7 }, address: 123, name: "me-and-olya" });
+
+    const text = await mcp.callText("memory_create_room", { name: "me-and-olya" });
+
+    expect(text).toContain(
+      'Room "me-and-olya" was created but the server did not return a usable address',
+    );
+    expect(text).not.toContain("is not a function");
+  });
+
+  it("vault_list: a broken alias is one anonymous row, not a dead tool", async () => {
+    mcp.on(VAULT, {
+      secrets: [{ alias: 7, context: "CI deploys" }, { alias: "openai-key", context: 42 }],
+    });
+
+    const text = await mcp.callText("vault_list");
+
+    expect(text).toContain("Your Vault secrets (2) — alias and purpose only, never the value:");
+    expect(text).toContain("- (no alias) — CI deploys");
+    expect(text).toContain("- openai-key");
+    expect(text).not.toContain("is not a function");
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+/**
+ * THE ONE SURFACE WITH NO SIZE CAP.
+ *
+ * Every other tool result goes through `capResult` — the 25K-token bound the
+ * Claude Connectors Directory requires. `memory_stats` did not, and its
+ * `Domains:` line is linear in the number of stores: `formatDomainList`
+ * deliberately drops nothing, so an account with a few thousand domains
+ * produced a result past the cap every single time. Not a hostile-input edge —
+ * arithmetic.
+ *
+ * The fix truncates the LIST rather than the message, because a plain cap would
+ * cut from the end and take the two lines a reader needs most with it: the
+ * average-quality line and the reminder that rooms are separate stores. The cap
+ * stays on as a second belt.
+ */
+describe("memory_stats fits the result cap without losing its tail", () => {
+  // 4000 stores × a 21-character name renders past 100K characters — the
+  // MAX_RESULT_CHARS bound in src/index.ts is 24,000 tokens × 4 = 96,000.
+  const MAX_RESULT_CHARS = 24_000 * 4;
+  const many = Array.from(
+    { length: 4000 },
+    (_, i) => `team-${String(i).padStart(4, "0")}-engineering`,
+  );
+
+  it("stays inside the cap and keeps every line after the domain list", async () => {
+    mcp.on(STATS, {
+      total_atoms: 91_000,
+      episodes: 90_000,
+      prototypes: 1_000,
+      hebbian_edges: 250_000,
+      domains: many,
+      avg_valence: 0.42,
+      avg_importance: 0.61,
+    });
+
+    const text = await mcp.callText("memory_stats");
+
+    expect(text.length).toBeLessThan(MAX_RESULT_CHARS);
+    // The list is cut from its own end, so the head of the answer is intact…
+    expect(text).toContain("Memories: 91000 (90000 episodes, 1000 prototypes)");
+    expect(text).toContain('Domains: "team-0000-engineering", "team-0001-engineering"');
+    // …and so is everything after it, which is what a blind cap would have eaten.
+    expect(text).toContain("Avg quality: valence 0.42");
+    expect(text).toContain("importance 0.61");
+    expect(text).toContain(
+      "Counts cover your own domains. Shared rooms are separate stores and are not included",
+    );
+  });
+
+  it("says how many names it did not print, so a missing one is not an absence", async () => {
+    mcp.on(STATS, { total_atoms: 1, domains: many });
+
+    const text = await mcp.callText("memory_stats");
+
+    // This tool's own description sends a reader here to confirm a store's exact
+    // name before writing to it. A silently shortened list would answer that
+    // question with a false negative, on the one surface built to prevent it.
+    expect(text).toMatch(
+      /\(\+\d+ more names not shown — the list is longer than one tool result can carry, so a name you do not see here may still exist\)/,
+    );
+    expect(text).not.toContain('"team-3999-engineering"');
+  });
+
+  it("an ordinary account is untouched — no truncation clause, no notice", async () => {
+    mcp.on(STATS, { total_atoms: 12, domains: ["general", "engineering", "проект:acme"] });
+
+    const text = await mcp.callText("memory_stats");
+
+    expect(text).toContain('Domains: "general", "engineering", "проект:acme"');
+    expect(text).not.toContain("not shown");
+    expect(text).not.toContain("truncated");
+  });
+});

--- a/test/names.test.ts
+++ b/test/names.test.ts
@@ -236,6 +236,51 @@ describe("formatDomainList — the memory_stats line", () => {
     expect(formatDomainList([])).toBe("none reported");
     expect(formatDomainList({ nope: true })).toBe("none reported");
   });
+
+  /**
+   * The line is linear in the number of stores and nothing bounded it, so
+   * memory_stats was the one tool result that could exceed the 25K-token cap
+   * the Connectors Directory requires — deterministically, on any account with
+   * a few thousand domains. Truncating the LIST (rather than capping the whole
+   * message, which cuts from the end) is what keeps the lines BELOW it —
+   * average quality, and the reminder that rooms are separate stores.
+   */
+  it("stops at the character budget and counts what it did not print", () => {
+    // `"alpha"` is 7 characters, `, "beta"` another 8 — 15 of the 16 allowed.
+    // `gamma` would need 9 more, so it and everything after it are counted.
+    expect(formatDomainList(["alpha", "beta", "gamma"], "none reported", 16)).toBe(
+      '"alpha", "beta" (+1 more name not shown — the list is longer than one ' +
+        "tool result can carry, so a name you do not see here may still exist)",
+    );
+  });
+
+  it("keeps the two reasons apart — cut for space is not cannot-be-printed", () => {
+    const long = "x".repeat(500);
+    expect(formatDomainList(["alpha", long, "beta", "gamma"], "none reported", 16)).toBe(
+      '"alpha", "beta" (+1 name not shown — cannot be printed exactly) ' +
+        "(+1 more name not shown — the list is longer than one tool result can " +
+        "carry, so a name you do not see here may still exist)",
+    );
+  });
+
+  it("never claims a store does not exist, even when nothing fit", () => {
+    // A budget too small for the first name still leaves a true sentence:
+    // "there are names here that I did not print", never an empty list.
+    const line = formatDomainList(["engineering", "design"], "none reported", 1);
+    expect(line).toBe(
+      "(+2 more names not shown — the list is longer than one tool result can " +
+        "carry, so a name you do not see here may still exist)",
+    );
+    expect(line).not.toBe("none reported");
+  });
+
+  it("bounds the default budget below the tool-result cap", () => {
+    // MAX_RESULT_CHARS in src/index.ts is 24,000 tokens × 4 = 96,000, and the
+    // stats message carries four more lines plus, sometimes, the escape legend.
+    // The behavioural pin is in test/handlers.test.ts; this is the arithmetic.
+    const many = Array.from({ length: 4000 }, (_, i) => `team-${i}-engineering`);
+    expect(formatDomainList(many).length).toBeLessThan(24_000 * 4 - 2_000);
+  });
 });
 
 describe("withDomainEscapeLegend", () => {

--- a/test/render.test.ts
+++ b/test/render.test.ts
@@ -19,6 +19,9 @@
  * 6. The renderers return the page BODY with no escape legend — the caller
  *    (src/index.ts) appends the legend AFTER capResult, so truncation cannot
  *    eat it (truth F6; behavioural pins in test/handlers.test.ts).
+ * 7. A value that arrives with the wrong WIRE TYPE degrades the part of the
+ *    line it belongs to, and nothing else: it neither throws nor moves a
+ *    timestamp into another day (the two cases below).
  *
  * Not pinned here: `formatRecentPage`'s end-of-feed wording, beyond the two
  * happy paths below — see the known defect noted at `cursorOk` in
@@ -148,6 +151,110 @@ describe("author/date/sanitizer edges", () => {
   it("safeInline keeps the CN-032 charset/cap contract", () => {
     expect(safeInline("  a   b  ", 200)).toBe("a b");
     expect(safeInline("x".repeat(300), 200)).toHaveLength(200);
+  });
+});
+
+/**
+ * WHAT THE WIRE ACTUALLY SENDS, versus what the response types say it sends.
+ *
+ * `ReadItem`, `RecentItem` and every `apiFetch<{…}>` shape in src/index.ts are
+ * aspirational: they describe the payload core is supposed to produce, and
+ * nothing narrows the payload that arrives. `asRoom` (src/scope.ts) already
+ * closed this class for the room list, where the same defect was recorded as
+ * "a latent crash fixed" — these are the renderer-side call sites that fix did
+ * not reach.
+ *
+ * The blast radius is the whole tool call, not the field: the MCP SDK turns a
+ * thrown Error into the ENTIRE result, so one numeric `agent_name` on one item
+ * of fifty replaced the page with `(s ?? "").replace is not a function` — a
+ * message with no `Mnemoverse: ` prefix (the property every error owes the
+ * reader, test/errors.test.ts) and nothing an agent can act on.
+ */
+describe("a non-string where the type promised a string", () => {
+  /** A value as the WIRE sends it, cast into the slot the types describe. */
+  const wire = <T,>(v: unknown): T => v as T;
+
+  it("safeInline renders nothing rather than throwing", () => {
+    for (const v of [123, 0, true, false, {}, [], { toString: () => "x" }]) {
+      expect(safeInline(v)).toBe("");
+    }
+    // The two it always handled stay handled.
+    expect(safeInline(null)).toBe("");
+    expect(safeInline(undefined)).toBe("");
+  });
+
+  it("formatAuthorTag drops the tag instead of killing the line", () => {
+    expect(formatAuthorTag(wire({ agent_name: 12345 }))).toBe("");
+    expect(formatAuthorTag(wire({ agent: { id: 7 } }))).toBe("");
+    // The preference order is NOT re-ordered around an unrenderable value: if
+    // the server said the agent's name is `12345`, this line has no name to
+    // print and says nothing, rather than quietly promoting a different field
+    // to "the author".
+    expect(formatAuthorTag(wire({ agent_name: 12345, agent: "codex" }))).toBe("");
+    // A field that is absent rather than broken still falls through, as before.
+    expect(formatAuthorTag({ agent_name: null, agent: "codex" })).toBe(" [by codex]");
+  });
+
+  it("a broken item renders as a line, not as an exception", () => {
+    expect(formatReadItem(wire({ content: "x", provenance: { agent_name: 5 } }), 0)).toBe(
+      "1. x",
+    );
+  });
+
+  it("formatDateTag refuses a non-string timestamp instead of guessing", () => {
+    // `new Date(1754082281605)` is a perfectly good date, so the old code
+    // printed one — for a field whose contract is an ISO-8601 string. A value
+    // that cannot be read as the contract says degrades to no tag, exactly like
+    // a legacy atom with no timestamp at all.
+    expect(formatDateTag(wire(1754082281605))).toBe("");
+    expect(formatDateTag(wire({}))).toBe("");
+  });
+});
+
+/**
+ * THE ZONE BUG: `new Date("2026-08-01T21:04:41").toISOString()` reads an
+ * offset-less timestamp as LOCAL time and then prints it with a `Z`, so the
+ * same atom rendered a different clock time in every timezone — and, west of
+ * UTC, a different DAY.
+ *
+ * The convention is written down twice and was implemented once: the `since`
+ * parameter descriptions say naive means UTC, and `parseAsUtc` (src/time.ts,
+ * extracted from src/scope.ts where the same fix landed for the future-
+ * watermark note in 0.8.1) implements it. This renderer read the same wire
+ * value the other way.
+ *
+ * These cases are invisible under TZ=UTC — with the bug in place they pass —
+ * which is why the CI matrix pins a zone east of UTC and one west of it.
+ */
+describe("formatDateTag reads a naive timestamp as UTC, as the engine does", () => {
+  it("does not restamp a local reading as Z", () => {
+    expect(formatDateTag("2026-08-01T21:04:41")).toBe(" · 2026-08-01 21:04Z");
+    // Core's `created_at` is also seen with a space separator.
+    expect(formatDateTag("2026-08-01 21:04:41")).toBe(" · 2026-08-01 21:04Z");
+  });
+
+  it("does not move a late-evening memory into another day", () => {
+    // The case a reader would actually notice: in America/Los_Angeles this
+    // printed `2026-08-02 06:30Z`, dating a memory to a day it was not written.
+    expect(formatDateTag("2026-08-01T23:30:00")).toBe(" · 2026-08-01 23:30Z");
+    expect(formatDateTag("2026-08-01T00:30:00")).toBe(" · 2026-08-01 00:30Z");
+  });
+
+  it("still honours an explicit offset, and a date-only value", () => {
+    expect(formatDateTag("2026-08-01T21:04:41Z")).toBe(" · 2026-08-01 21:04Z");
+    expect(formatDateTag("2026-08-01T23:04:41+02:00")).toBe(" · 2026-08-01 21:04Z");
+    expect(formatDateTag("2026-08-01T17:04:41-04:00")).toBe(" · 2026-08-01 21:04Z");
+    // Date-only is already UTC by spec — unchanged.
+    expect(formatDateTag("2026-08-01")).toBe(" · 2026-08-01 00:00Z");
+  });
+
+  it("carries into both item lines", () => {
+    expect(formatReadItem({ content: "x", created_at: "2026-08-01T23:30:00" }, 0)).toBe(
+      "1. x · 2026-08-01 23:30Z",
+    );
+    expect(formatRecentItem({ content: "x", created_at: "2026-08-01T23:30:00" }, 0)).toBe(
+      "1. [2026-08-01 23:30Z] x",
+    );
   });
 });
 


### PR DESCRIPTION
Bug-hunt findings (pre-0.9.2): three deterministic defects in the render layer, found by reading it against the payload it actually receives rather than the types that describe it. None needs a hostile connector — only a field that is not what the response type says.

## What

1. **A non-string killed the whole tool call.** `safeInline` was `(s ?? "").replace(…)`; the SDK turns the thrown TypeError into the ENTIRE result, so one numeric `agent_name` on one item of fifty replaced a page of memories with a bare `(s ?? "").replace is not a function` — no `Mnemoverse:` prefix, no diagnosis (the exact shape 0.9.1 rewrote every error to avoid). Now `safeInline(s: unknown)` narrows first, the same fix `asRoom` already applied for the room list ("a latent crash fixed"). A field we cannot read costs the reader **that field and nothing else** — and the `agent_name || agent || client_env` chain deliberately does **not** reorder: a broken name drops the tag rather than silently presenting a different field as the author (pinned by test).
2. **A naive timestamp was read as local and printed with a Z.** `new Date("2026-08-01T23:30:00").toISOString()` rendered the same stored atom as `23:30Z` in UTC, `14:30Z` in Tokyo and `2026-08-02 06:30Z` in Los Angeles — a different **day**, on the tag readers use to order a conversation. The "naive = UTC" convention was written down twice and implemented once; `parseAsUtc` moves to a new `src/time.ts` (render must not depend on scope — that dependency deliberately points the other way) and both readers now share it. Epoch-millis `created_at` no longer renders as a plausible date the contract does not promise — it degrades to no tag.
3. **`memory_stats` was the one surface with no size cap.** Its `Domains:` line is linear in the number of stores: 4,000 domains rendered 100,391 chars against the 96,000-char Connectors Directory cap, every time. The **list** is now bounded rather than the message (`capResult` cuts from the end and would have eaten the avg-quality line and the rooms reminder): what is cut is counted and says why — `(+400 more names not shown — the list is longer than one tool result can carry, so a name you do not see here may still exist)` — in its own clause, kept apart from the existing cannot-be-printed count. `capResult` is wired too, as a second belt.

## Self-review (reviewer voice)

- TDD held: 17 red tests first (`expected 100391 to be less than 96000`; `expected ' · 2026-08-02 06:30Z' to be ' · 2026-08-01 23:30Z'`; the bare TypeError as an entire tool answer). The zone cases are invisible under TZ=UTC — they pass with the bug in place — so the suite ran under UTC, Asia/Tokyo **and America/Los_Angeles** (west of UTC, where the date shift shows).
- `formatRecentPage` is untouched (0 occurrences in the diff) — no collision with #106.
- `formatDomainTag` needed no fix — `exactLiteral` already narrows; verified rather than assumed.
- Gate mirrored CI: `tsc --noEmit`, `typecheck:test`, 434/434 in all three zones, `verify:configs` 19/19, build + stdio handshake, plus `check:release-sync`.

Done-by: Σ
