### PR TITLE
fix(descriptions): say only what is true — scope-aware room usage, byte-for-byte domains (bug hunt, pre-0.9.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,38 @@ git history and the GitHub releases are the record.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The room usage line names what the membership scope actually allows.**
+  `memory_join_room`'s description and its usage sentence, and
+  `memory_list_rooms`'s per-room tail, all used to say "use domain=... [on
+  memory_write / memory_read] to read and write the shared room" — true for a
+  `read_write` membership, false for a `read` one: core refuses that member's
+  `memory_write` with a 403 "Read-only membership cannot write to this room".
+  All three surfaces now name `memory_read` unconditionally and only promise
+  `memory_write` where the scope is `read_write`; a `read` membership is told
+  the write will be refused, and a scope the response did not report at all
+  gets no promise about write either way. Text-only.
+- **`memory_write.domain` now says names are matched byte-for-byte.** The
+  handler has long refused to trim or normalise a domain — a leading space
+  opens a separate, permanent store beside the intended one — and
+  `memory_read.domain` already explained its half of the same rule. This is
+  the one place the fork actually gets CREATED, and it was the only silent
+  one; the description now says so and points at `memory_stats` for the exact
+  name, and names the room-address escape hatch. Text-only.
+- **The npm package keyword list no longer claims "forgetting".** 0.9.1
+  retracted "learns and forgets" from the README as false — unhelpful
+  memories are out-ranked, not erased, and deletion is administrative-only
+  since 0.9.0 — but the same claim survived as an npm keyword. Removed as
+  part of the same retraction.
+- **`llms.txt`'s install command now pins `@latest`,** matching every other
+  install snippet in this repo. The bare form npm caches indefinitely and
+  stops re-checking the registry (README, "Why `@latest`?") — an agent
+  following `llms.txt` verbatim would have installed once and silently
+  stopped receiving updates. `llms.txt` is hand-maintained (confirmed against
+  `scripts/generate-configs.mjs`'s `OUTPUTS` list, which does not include it),
+  so the fix is direct.
+
 ## [0.9.1] — 2026-08-24
 
 Text under this file's own rules: what a tool returns when it fails. No tool,

--- a/llms.txt
+++ b/llms.txt
@@ -101,7 +101,7 @@ Returns: Alias and purpose per secret, never the value.
 ## Setup
 Environment: MNEMOVERSE_API_KEY — optional to install and inspect (the server starts and lists its tools without it), but every tool call fails without one; get a free key at https://console.mnemoverse.com. MNEMOVERSE_API_URL (optional, default https://core.mnemoverse.com/api/v1)
 Transport: stdio
-Command: npx @mnemoverse/mcp-memory-server
+Command: npx -y @mnemoverse/mcp-memory-server@latest
 
 ## Links
 - Docs: https://mnemoverse.com/docs/api/mcp-server

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "cross-tool",
     "model-context-protocol",
     "hosted-memory",
-    "forgetting",
     "vendor-neutral"
   ],
   "author": "Mnemoverse <hello@mnemoverse.com>",

--- a/src/index.ts
+++ b/src/index.ts
@@ -328,6 +328,28 @@ function isRoomDomain(domain: string | undefined): boolean {
   return typeof domain === "string" && domain.startsWith("xroom:");
 }
 
+/**
+ * The three outcomes this client will ever print a WRITE promise about for a
+ * room membership. Core grants exactly two scopes — "read" and "read_write"
+ * (rooms_routes.py `_VALID_SCOPES`) — and refuses a read-only member's
+ * memory_write with a 403 "Read-only membership cannot write to this room"
+ * (src/errors.ts). Anything else on the wire (missing field, a Copilot-shaped
+ * partial body) is UNSPECIFIED: the server did not say what memory_write would
+ * do for this membership, so this client does not guess either — it is treated
+ * like "read" for the purpose of NOT promising write, but is not told it is
+ * read-only, because that is also a claim the response did not make.
+ *
+ * Bug hunt (pre-0.9.2, P2): memory_join_room's usage sentence and
+ * memory_list_rooms's per-row tail both used to print "use domain=... [on
+ * memory_write / memory_read] to read and write" unconditionally — true for a
+ * read_write membership, false for a read-only one.
+ */
+function roomScopeVerdict(scope: string | undefined): "read_write" | "read" | "unspecified" {
+  if (scope === "read_write") return "read_write";
+  if (scope === "read") return "read";
+  return "unspecified";
+}
+
 // --- Tool: memory_write ---
 
 server.registerTool(
@@ -353,7 +375,12 @@ server.registerTool(
         .string()
         .optional()
         .describe(
-          "Namespace to organize memories (e.g. 'engineering', 'user:alice', 'project:acme')",
+          "Namespace to organize memories (e.g. 'engineering', 'user:alice', 'project:acme')." +
+            " Matched byte-for-byte — a leading space, a different case, or an invisible" +
+            " character opens a SEPARATE, permanent store, so reuse an exact name from" +
+            " memory_stats rather than retyping one. To write into a shared room, pass its" +
+            " address here instead (e.g. 'xroom:room_01ABC'). Find room addresses with" +
+            " memory_list_rooms.",
         ),
     },
     annotations: {
@@ -1296,7 +1323,7 @@ server.registerTool(
   "memory_join_room",
   {
     description:
-      "Join a shared memory room using an invite code (starts with 'mnvr_'). Use when the user pastes an invite code or says something like 'join room with code ...'. After joining, use the returned address as the `domain` on memory_write/memory_read to read and write the shared room.",
+      "Join a shared memory room using an invite code (starts with 'mnvr_'). Use when the user pastes an invite code or says something like 'join room with code ...'. After joining, use the returned address as the `domain` on memory_read to read the shared room — the result names your membership scope, and memory_write to that address is only allowed when it is read_write; a read-only membership has that write refused.",
     inputSchema: {
       code: z.string().min(1).max(200).describe("The invite code (mnvr_...)."),
     },
@@ -1331,9 +1358,18 @@ server.registerTool(
       ? `You're already a member of ${roomName}.`
       : `Joined ${roomName} (${scope}).`;
     // Don't print broken `domain=""` guidance if no address came back (Copilot).
-    const usage = address
-      ? `Use it: pass domain="${address}" on memory_write / memory_read to read and write the shared room.`
-      : `The server did not return a room address — retry, or check that your API key is set.`;
+    // The write half of this sentence is scope-gated (roomScopeVerdict, above
+    // isRoomDomain): a "read" invite gets told memory_write will be refused
+    // rather than offered it, and a scope the response did not report at all
+    // gets no promise about write either way.
+    const verdict = roomScopeVerdict(r?.scope);
+    const usage = !address
+      ? `The server did not return a room address — retry, or check that your API key is set.`
+      : verdict === "read_write"
+        ? `Use it: pass domain="${address}" on memory_write / memory_read to read and write the shared room.`
+        : verdict === "read"
+          ? `Use it: pass domain="${address}" on memory_read to read it; this membership is read-only, so memory_write to that address will be refused.`
+          : `Use it: pass domain="${address}" on memory_read to read it — the server did not report this membership's write access, so whether memory_write to that address would succeed is unknown.`;
     return {
       content: [
         {
@@ -1352,7 +1388,7 @@ server.registerTool(
   "memory_list_rooms",
   {
     description:
-      "List the shared memory rooms you can use — the ones you OWN plus the ones you've JOINED — each with the address to pass as `domain` on memory_write / memory_read. Use this to RE-FIND a room in a new session (e.g. 'what rooms do I have?', 'resume the room with Olya') instead of having to create or re-join it.",
+      "List the shared memory rooms you can use — the ones you OWN plus the ones you've JOINED — each with the address to pass as `domain` on memory_read, and on memory_write too where your membership scope is read_write; a read-only membership has that write refused. Use this to RE-FIND a room in a new session (e.g. 'what rooms do I have?', 'resume the room with Olya') instead of having to create or re-join it.",
     inputSchema: {},
     annotations: {
       title: "List rooms",
@@ -1412,13 +1448,24 @@ server.registerTool(
       // src/scope.ts), so that clause was an instruction to make a call that
       // cannot succeed. The address stays visible — it is the room's identity —
       // but the line says what a read against it will do.
+      //
+      // For a live room, the write half is scope-gated the same way
+      // memory_join_room's usage sentence is (roomScopeVerdict, near
+      // isRoomDomain): this used to say "use domain=..." with no operation
+      // named, which read as an unqualified read+write invitation even for a
+      // "read" member — false, since core refuses that member's memory_write.
+      const verdict = roomScopeVerdict(scope);
       const tail = r?.archived
         ? address
           ? ` [archived] — address ${address}, but every read is refused while it is archived`
           : ` [archived] — every read is refused while it is archived`
-        : address
-          ? ` — use domain="${address}"`
-          : "";
+        : !address
+          ? ""
+          : verdict === "read_write"
+            ? ` — use domain="${address}" to read and write it`
+            : verdict === "read"
+              ? ` — use domain="${address}" on memory_read only; this membership is read-only, so memory_write to it will be refused`
+              : ` — use domain="${address}" on memory_read; this membership's write access was not reported`;
       return `- ${name} (${role}${scope ? `, ${scope}` : ""})${tail}`;
     });
     const text = `Your shared rooms (${list.length}):\n${lines.join("\n")}`;

--- a/test/descriptions.test.ts
+++ b/test/descriptions.test.ts
@@ -137,6 +137,42 @@ describe("the advertised descriptions carry this release's truth claims", () => 
     // survives in any rewrite, so on its own it asserts nothing about this one.
     expect(d).toContain("no tool on this server returns it");
   });
+
+  it("memory_join_room does not unconditionally promise write on the room it describes", () => {
+    // Bug hunt (pre-0.9.2): the OLD description said "use ... on
+    // memory_write/memory_read to read and write the shared room" —
+    // unconditionally, even though invite scope can be "read" (core refuses
+    // that member's memory_write with a 403, src/errors.ts). The static
+    // description cannot know the scope at advertise time, so it must not
+    // promise write at all — it can only say the runtime answer will.
+    const d = description("memory_join_room");
+    expect(d).toContain("memory_read");
+    expect(d).toMatch(/read.?only/);
+    expect(d).not.toMatch(/to read and write the shared room/);
+  });
+
+  it("memory_list_rooms does not promise write for every listed room regardless of scope", () => {
+    // Same defect, mirrored: the OLD description said every room comes "with
+    // the address to pass as `domain` on memory_write / memory_read" — a
+    // blanket claim false for any room where the caller's membership is
+    // "read" only.
+    const d = description("memory_list_rooms");
+    expect(d).toMatch(/read.?only/);
+    expect(d).not.toMatch(/each with the address to pass as `domain` on memory_write \/ memory_read\./);
+  });
+
+  it("memory_write.domain warns names are matched byte-for-byte and names the room-address escape hatch", () => {
+    // Bug hunt (pre-0.9.2): this is the ONE place a fork gets CREATED — the
+    // write handler explains at length, 30 lines below, why it deliberately
+    // does not normalise " engineering" into "engineering" (a second,
+    // permanent store), and memory_read.domain explains its half of the same
+    // rule — but this field, where the fork is actually opened, said nothing.
+    const d = paramDescription("memory_write", "domain");
+    expect(d).toContain("byte-for-byte");
+    expect(d).toContain("memory_stats");
+    expect(d).toContain("xroom:");
+    expect(d).toContain("memory_list_rooms");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/test/handlers.test.ts
+++ b/test/handlers.test.ts
@@ -1050,6 +1050,86 @@ describe("naming a store the reader has to reproduce", () => {
 // ---------------------------------------------------------------------------
 
 /**
+ * The room usage line matches what the membership scope actually allows (bug
+ * hunt, pre-0.9.2, P2). memory_join_room's usage sentence and memory_list_rooms'
+ * per-row tail both used to print the same "use domain=... [on memory_write /
+ * memory_read] to read and write" claim no matter what scope the invite
+ * granted — false for a "read" member: core answers that member's memory_write
+ * with a 403 "Read-only membership cannot write to this room" (src/errors.ts,
+ * confirmed against rooms_routes.py `_VALID_SCOPES = ("read", "read_write")`).
+ * A scope this response did not report at all gets the same treatment as
+ * "read" — no promise about write, because the server never said.
+ */
+describe("the room usage line names what the scope actually allows", () => {
+  it("memory_join_room: a read-only invite is told memory_write will be refused, not offered it", async () => {
+    mcp.on(JOIN, { name: "team", address: "xroom:room_01ABC", scope: "read" });
+
+    const text = await mcp.callText("memory_join_room", { code: "mnvr_abc" });
+
+    expect(text).toContain('Joined "team" (read).');
+    expect(text).toContain('pass domain="xroom:room_01ABC"');
+    expect(text).toContain("memory_read");
+    expect(text).toMatch(/read-only/);
+    expect(text).toContain("memory_write");
+    expect(text).toMatch(/refused/);
+    // Never claims this membership can write.
+    expect(text).not.toMatch(/to read and write the shared room/);
+  });
+
+  it("memory_join_room: a scope the server did not report makes no write promise either", async () => {
+    // No `scope` field at all — the Copilot-shaped partial body this file's
+    // other tests already treat as a real possibility (see the missing-address
+    // branch above).
+    mcp.on(JOIN, { name: "team", address: "xroom:room_01ABC" });
+
+    const text = await mcp.callText("memory_join_room", { code: "mnvr_abc" });
+
+    expect(text).toContain('Joined "team" (member).');
+    expect(text).toContain('pass domain="xroom:room_01ABC"');
+    expect(text).toContain("memory_read");
+    // Not a claim of read-only (that would assert something the server did
+    // not say either) — but also no promise that memory_write will work.
+    expect(text).not.toMatch(/to read and write the shared room/);
+    expect(text).not.toMatch(/will be refused/);
+  });
+
+  it("memory_join_room: a read_write invite keeps the unconditional read-and-write promise", async () => {
+    mcp.on(JOIN, { name: "team", address: "xroom:room_01ABC", scope: "read_write" });
+
+    const text = await mcp.callText("memory_join_room", { code: "mnvr_abc" });
+
+    expect(text).toContain(
+      'Use it: pass domain="xroom:room_01ABC" on memory_write / memory_read to read and write the shared room.',
+    );
+  });
+
+  it("memory_list_rooms: a read-only member row is not told it can write", async () => {
+    mcp.on(ROOMS, [
+      { room_id: "room_01R", name: "read-only-room", address: "xroom:room_01R", role: "member", scope: "read" },
+    ]);
+
+    const text = await mcp.callText("memory_list_rooms");
+
+    expect(text).toContain('use domain="xroom:room_01R"');
+    expect(text).toMatch(/read-only/);
+    expect(text).toMatch(/memory_write.*refused|refused.*memory_write/s);
+  });
+
+  it("memory_list_rooms: an owned (read_write) room row keeps the unqualified usage line", async () => {
+    mcp.on(ROOMS, [
+      { room_id: "room_01O", name: "my-room", address: "xroom:room_01O", role: "owner", scope: "read_write" },
+    ]);
+
+    const text = await mcp.callText("memory_list_rooms");
+
+    expect(text).toContain('use domain="xroom:room_01O"');
+    expect(text).not.toMatch(/read-only/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+/**
  * The escape legend and the size cap, in the only order that keeps both
  * (truth F6, 2026-08-08).
  *

--- a/test/llms-txt.test.ts
+++ b/test/llms-txt.test.ts
@@ -1,0 +1,38 @@
+/**
+ * llms.txt — the machine-readable install summary AI crawlers and agent
+ * frameworks read to learn how to set this server up (a GEO surface, read by
+ * agents rather than humans). It is hand-maintained: confirmed by grepping
+ * `OUTPUTS` in scripts/generate-configs.mjs, which lists 14 artifacts under
+ * docs/configs/, docs/snippets/ and server.json — no llms.txt entry — and by
+ * `git log --oneline -- llms.txt`, which shows only manual feature-commit
+ * edits, never a generator run. So a defect here is fixed at the source
+ * (this file), not chased through generate-configs.mjs.
+ *
+ * Bug hunt (pre-0.9.2, P2 candidate, confirmed): the Command line omitted
+ * `@latest` — `npx @mnemoverse/mcp-memory-server` — while README.md explains
+ * at length why every OTHER install snippet in this repo insists on it: bare
+ * `npx <pkg>` is cached indefinitely by npm and stops re-checking the
+ * registry, so an agent that installed via this exact command would silently
+ * stop receiving new releases (README.md, "Why `@latest`?"). Not the
+ * registry-pinned case server.json is deliberately exempt from (that exemption
+ * is about clients installed through the Official MCP Registry, which resolve
+ * their own pinned version from `server.json.version` — llms.txt describes a
+ * plain `npx` install, the same bleeding-edge case every docs/configs/*
+ * snippet covers).
+ */
+
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const llmsTxt = readFileSync(new URL("../llms.txt", import.meta.url), "utf8");
+
+describe("llms.txt install command", () => {
+  it("pins @latest, matching every other install surface in this repo", () => {
+    const commandLine = llmsTxt.split("\n").find((l) => l.startsWith("Command:"));
+    expect(commandLine, "llms.txt has no 'Command:' line").toBeTruthy();
+    // Byte-identical to the canonical CLI snippet in README.md ("Claude Code —
+    // add via CLI"), minus the `claude mcp add` wrapper — llms.txt describes
+    // the bare npx invocation, not a client-specific config file.
+    expect(commandLine).toBe("Command: npx -y @mnemoverse/mcp-memory-server@latest");
+  });
+});


### PR DESCRIPTION
Bug-hunt findings (pre-0.9.2), text-only: places where a tool description or a public text promised something the server refuses.

## What

1. **Room usage is now scope-aware.** `memory_join_room`'s description and usage sentence, and `memory_list_rooms`'s per-row tail, all promised "read and write" on a room address unconditionally — one line after printing `(read)`. Core refuses a read-only member's write with a 403 ("Read-only membership cannot write to this room"; confirmed against `_VALID_SCOPES` in core's rooms routes). All three surfaces now branch on the scope the response actually reports (`roomScopeVerdict`): `read_write` keeps the original promise; `read` is told memory_write will be refused; a scope the server did not report gets no write promise either way. `memory_create_room` was checked and deliberately left alone — the creator is always owner/read_write, so its promise is always true.
2. **`memory_write.domain` finally says byte-for-byte.** The write surface is where a fork gets *created* (a leading space opens a separate, permanent store) and was the only surface silent about it — the handler explains it 30 lines below, and `memory_read.domain` explains its half. The description now says so and points at `memory_stats` for exact names and at room addresses as the escape hatch.
3. **`package.json` keyword `"forgetting"` removed** — it contradicted 0.9.1's own retraction of "learns and forgets" (out-ranked, not erased; deletion administrative-only since 0.9.0). The npm surface was the last carrier.
4. **`llms.txt`'s install command gains `@latest` (and `-y`)** — every other snippet in the repo carries it and the README explains why (bare `npx` caches indefinitely). Confirmed hand-maintained (not in `generate-configs.mjs`'s OUTPUTS), fixed at source, now covered by a new `test/llms-txt.test.ts` — the file was previously pinned by nothing.

## Scope note (deviation from the brief, named)

The brief asked for the usage line of join and the tail of list_rooms; the **static descriptions of both tools** are fixed too — otherwise the tail would honestly say "read-only" while the description two lines up kept promising unconditional write, a freshly minted contradiction.

## Self-review (reviewer voice)

- Text-only: no tool, parameter, or annotation added, removed, renamed, or retyped.
- TDD held: red tests first for every claim (three join branches + the preserved read_write one, two list_rooms rows, both descriptions, the domain clause, the llms.txt line).
- New wire texts verified verbatim over a real stdio initialize/tools-list against `dist/index.js`.
- Gate mirrored CI: `tsc --noEmit`, `typecheck:test`, 424/424 (TZ=Asia/Tokyo), `verify:configs` 19/19, build + smoke.

**Flag for a separate decision (other repo):** core's own `/memory/rooms/join` builds a `next_steps` field with the same unconditional "pass domain=… on /memory/write and /memory/read", independent of scope. This client does not read that field, so the fix here is complete — but the pattern remains in core as a latent source for any client that relays `next_steps` literally.

Done-by: Σ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Room usage guidance now accurately reflects read-only, read/write, and unknown membership permissions.
  * Domain matching for memory writes now requires exact byte-for-byte matches.
  * Recent-page results now distinguish missing cursors from cursors that cannot be rendered.

* **Documentation**
  * Updated setup instructions to use the latest package version and approve installation automatically.
  * Corrected scope-dependent room usage guidance across related documentation.
  * Removed the misleading “forgetting” package keyword.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->