### PR TITLE
chore: add .github/FUNDING.yml (Sponsors button)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [izgorodin]


### PR DESCRIPTION
## What

Adds `.github/FUNDING.yml` with a single line:

```yaml
github: [izgorodin]
```

## Why

`funding.json` in the repository root already declares `github-sponsors` at `https://github.com/sponsors/izgorodin`, and that Sponsors listing is active (`hasSponsorsListing: true` for `izgorodin` via the GraphQL API, checked 2026-08-30). GitHub only renders the native Sponsor button from `.github/FUNDING.yml`, which the repository did not have, so the button never appeared while `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md` and `LICENSE` were all in place.

No code change. Not merging myself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added GitHub Sponsors funding support for the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->