### PR TITLE
chore(review): fold in the post-merge bot findings on #106/#108/#112

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,10 +37,15 @@ git history and the GitHub releases are the record.
 
 ## [Unreleased]
 
-A MINOR change under this file's own rule: a new branch, not just reworded
-text — see "A patch may NOT change SHAPE or ROUTING" above. `formatRecentPage`
-now decides its tail on three states instead of two, so this is a behaviour
-change even though every touched line is prose.
+A PATCH under this file's own rule, corrected from the MINOR this paragraph
+first claimed (Copilot caught it post-merge on #106). `formatRecentPage` now
+picks its closing sentence from three states instead of two — but the states
+were always there: `next_cursor` present-and-well-shaped, present-and-not, and
+absent. What changed is WHICH SENTENCE an existing state gets, and a tool's
+output text is exactly what "A patch may change TEXT" above covers. No tool,
+parameter, annotation or route moves, and nothing moves data; the shape check
+itself is byte-identical. "A new branch" is not a criterion this file states —
+the criterion is SHAPE or ROUTING, and neither moved.
 
 MINOR by this file's own rules, and stated up front: `memory_list_recent`
 changes what goes on the wire. One request for the caller's `limit` becomes a
@@ -402,6 +407,36 @@ request against a refused URL, the skip line pinned verbatim, `redirect: "error"
 on the request it does make, and — as regression guards, so the fix cannot become
 a mute button — a healthy https URL and a plain-http `localhost` still probed,
 with the key, in silence.
+
+### Post-merge review follow-ups
+
+The bots kept reviewing after these merges landed. Four findings across #106,
+#108 and #112 are folded in here rather than left sitting in closed threads.
+
+- **The #67 paragraph at the top of this section said MINOR and meant PATCH**
+  (Copilot on #106). Rewritten against the rule it was citing: choosing which
+  sentence an already-existing state prints is TEXT, and "a new branch" is not
+  a criterion this file states. The two MINOR paragraphs beside it — #104's
+  wire change and #99's transport change — are untouched and still MINOR.
+- **The two rejected-cursor tests now assert the cursor is not echoed**
+  (Copilot on #106). They pinned the sentence only, so a build that printed the
+  right sentence AND interpolated the value it had just refused to trust passed
+  both. Checked by breaking it: with that value appended to the branch, both
+  tests fail.
+- **The early-stop budget test is now a boundary fixture** (CodeRabbit on
+  #108). Its entries sat far enough under the budget that deleting the note's
+  reservation from the fits check changed nothing it measured. Ten entries of
+  3,960 characters render to 39,907 — inside the 202-character window between
+  the reserved ceiling (39,798) and the budget (40,000) — and the sub-request
+  failure is now keyed to the CONTINUATION request rather than to a call
+  counter, so both arms reach the early-stop path instead of one of them
+  surfacing a raw error. With the reservation removed the page ships at 40,109
+  and the test fails on its own length assertion.
+- **`memory_join_room`'s description no longer promises a scope line in every
+  answer** (CodeRabbit on #112). The handler has a third branch for a response
+  that carried no `scope` at all, and that branch names the write access as
+  unknown rather than naming a scope; the description now says the scope is
+  named when the server reported one. Text-only.
 
 ## [0.9.1] — 2026-08-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -435,8 +435,10 @@ The bots kept reviewing after these merges landed. Four findings across #106,
 - **`memory_join_room`'s description no longer promises a scope line in every
   answer** (CodeRabbit on #112). The handler has a third branch for a response
   that carried no `scope` at all, and that branch names the write access as
-  unknown rather than naming a scope; the description now says the scope is
-  named when the server reported one. Text-only.
+  unknown rather than naming a scope (and an `already_member` answer names no
+  scope at all) - so the description now describes the write guidance instead
+  of promising a scope line: read_write may write, read-only has the write
+  refused, and an unreported scope leaves write access unknown. Text-only.
 
 ## [0.9.1] — 2026-08-24
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1828,7 +1828,7 @@ server.registerTool(
   "memory_join_room",
   {
     description:
-      "Join a shared memory room using an invite code (starts with 'mnvr_'). Use when the user pastes an invite code or says something like 'join room with code ...'. After joining, use the returned address as the `domain` on memory_read to read the shared room — the result names your membership scope, and memory_write to that address is only allowed when it is read_write; a read-only membership has that write refused.",
+      "Join a shared memory room using an invite code (starts with 'mnvr_'). Use when the user pastes an invite code or says something like 'join room with code ...'. After joining, use the returned address as the `domain` on memory_read to read the shared room — the result names your membership scope WHEN the server reported one, and memory_write to that address is only allowed when that scope is read_write; a read-only membership has that write refused, and a scope the server did not report is named as unknown rather than promised either way.",
     inputSchema: {
       code: z.string().min(1).max(200).describe("The invite code (mnvr_...)."),
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1828,7 +1828,7 @@ server.registerTool(
   "memory_join_room",
   {
     description:
-      "Join a shared memory room using an invite code (starts with 'mnvr_'). Use when the user pastes an invite code or says something like 'join room with code ...'. After joining, use the returned address as the `domain` on memory_read to read the shared room — the result names your membership scope WHEN the server reported one, and memory_write to that address is only allowed when that scope is read_write; a read-only membership has that write refused, and a scope the server did not report is named as unknown rather than promised either way.",
+      "Join a shared memory room using an invite code (starts with 'mnvr_'). Use when the user pastes an invite code or says something like 'join room with code ...'. After joining, use the returned address as the `domain` on memory_read to read the shared room — the result tells you what you may do with it: memory_write to that address is only allowed when your membership scope is read_write; a read-only membership has that write refused; and when the server does not report a scope, whether memory_write would succeed is stated as unknown rather than promised either way.",
     inputSchema: {
       code: z.string().min(1).max(200).describe("The invite code (mnvr_...)."),
     },

--- a/test/descriptions.test.ts
+++ b/test/descriptions.test.ts
@@ -192,7 +192,11 @@ describe("the advertised descriptions carry this release's truth claims", () => 
     expect(d).toContain("memory_read");
     expect(d).toMatch(/read.?only/);
     expect(d).not.toMatch(/to read and write the shared room/);
-    expect(d).toMatch(/did not report/);
+    // Pin the SEMANTIC, not a phrase: an unreported scope must specifically
+    // leave write access unknown. A loose /did not report/ would pass on any
+    // unrelated sentence even with the unconditional promise restored
+    // (Copilot, #116).
+    expect(d).toMatch(/does not report a scope[^.]*unknown/);
   });
 
   it("memory_list_rooms does not promise write for every listed room regardless of scope", () => {

--- a/test/descriptions.test.ts
+++ b/test/descriptions.test.ts
@@ -179,10 +179,20 @@ describe("the advertised descriptions carry this release's truth claims", () => 
     // that member's memory_write with a 403, src/errors.ts). The static
     // description cannot know the scope at advertise time, so it must not
     // promise write at all — it can only say the runtime answer will.
+    //
+    // POST-MERGE (CodeRabbit on #112): the same rule applies to the SCOPE
+    // itself. The description used to say the result "names your membership
+    // scope" flatly, but the handler has a third branch for a response that
+    // carried no scope at all, and that branch names the write access as
+    // unknown rather than naming a scope (handlers.test.ts, "a scope the
+    // server did not report makes no write promise either"). A description
+    // that promises a scope line the answer may not contain is the same
+    // over-promise one level up.
     const d = description("memory_join_room");
     expect(d).toContain("memory_read");
     expect(d).toMatch(/read.?only/);
     expect(d).not.toMatch(/to read and write the shared room/);
+    expect(d).toMatch(/did not report/);
   });
 
   it("memory_list_rooms does not promise write for every listed room regardless of scope", () => {

--- a/test/list-recent-budget.test.ts
+++ b/test/list-recent-budget.test.ts
@@ -294,20 +294,39 @@ describe("a sub-request that fails after entries were already accepted", () => {
 
   it("a page that stopped early still fits the budget, note included", async () => {
     // The note is appended AFTER the batches were sized, so its space is
-    // reserved during sizing (CodeRabbit, PR #108) — the invariant pinned
-    // here is end-to-end: accepted page PLUS the failure note never exceeds
-    // the budget, even when the accepted half filled most of it. The reserve
-    // itself is structural (the fits check subtracts the note's length), so
-    // this guards against gross regressions — the budget check disappearing,
-    // or the note outgrowing its reservation.
-    const feed = pagingFeed(entries(100, 3_800));
-    let n = 0;
+    // reserved during sizing (CodeRabbit, PR #108) — the invariant pinned here
+    // is end-to-end: accepted page PLUS the failure note never exceeds the
+    // budget.
+    //
+    // THE FIXTURE IS A BOUNDARY, and it has to be: with entries far from it
+    // this test passed with the reserve deleted, which is the whole thing it
+    // exists to catch (CodeRabbit, post-merge on #108). Ten entries of 3,960
+    // characters render to 39,907 — 109 over the reserved ceiling of 39,798
+    // (BUDGET minus the note), 93 under BUDGET itself. That window is the only
+    // place the reserve is observable at all:
+    //
+    //   WITH the reserve, the ten-entry batch does not fit, so the handler
+    //   narrows and accepts five (19,975); the failing continuation appends the
+    //   note, and the page ships at 20,177 — under budget.
+    //
+    //   WITHOUT it, the same batch fits, all ten ship, and the note pushes the
+    //   page to 40,109 — 109 over, and the length assertion below fails.
+    //
+    // The failure is keyed to the CONTINUATION request rather than to a call
+    // counter. The narrowing retry re-asks the same position and therefore
+    // carries no cursor, so a counter would fail the two arms at different
+    // points in the loop for a reason unrelated to the reserve — and, with
+    // nothing yet accepted, would surface a raw error instead of a page.
+    const feed = pagingFeed(entries(100, 3_960));
     mcp.on(RECENT, (req: StubbedRequest) =>
-      ++n === 1 ? feed(req) : httpError(503, "down"),
+      (req.body as { cursor?: string } | undefined)?.cursor
+        ? httpError(503, "down")
+        : feed(req),
     );
 
     const text = await mcp.callText("memory_list_recent", { limit: 100 });
 
+    expect(text).toContain("ITEM-0|");
     expect(text).toContain("stopped early");
     expect(text.length).toBeLessThanOrEqual(BUDGET);
   });

--- a/test/render.test.ts
+++ b/test/render.test.ts
@@ -142,17 +142,27 @@ describe("formatRecentItem / formatRecentPage", () => {
       "More entries exist but the continuation token could not be displayed — narrow the window with since/until instead",
     );
     expect(page).not.toContain("(end of feed — nothing older)");
+    // The half of CN-032 the sentence alone does not pin: a cursor that failed
+    // the shape check must not reach the page in ANY form. The three branches
+    // print different sentences, so a future edit could keep this one truthful
+    // and still interpolate the value it just refused to trust (Copilot, #106).
+    expect(page).not.toContain(oversized);
   });
 
   it("page with a cursor carrying disallowed characters does NOT claim the feed is empty (#67)", () => {
+    const rejectedCursor = "abc 123/../<script>";
     const page = formatRecentPage(
       [{ atom_id: ID, content: "a", created_at: "2026-08-02T10:00:00Z" }],
-      "abc 123/../<script>",
+      rejectedCursor,
     );
     expect(page).toContain(
       "More entries exist but the continuation token could not be displayed — narrow the window with since/until instead",
     );
     expect(page).not.toContain("(end of feed — nothing older)");
+    // Same guarantee as the oversized case above, against the payload shape
+    // that makes it matter: the rejected value carries markup and a traversal
+    // segment, and it stays off the page (Copilot, #106).
+    expect(page).not.toContain(rejectedCursor);
   });
 });
 


### PR DESCRIPTION
The bots kept reviewing after the #106–#112 batch was merged; all four findings are folded in — none touch shape or routing.

1. **CHANGELOG (Copilot, #106 — accepted):** the paragraph framing #67 claimed MINOR on a criterion the file does not state ("a new branch"). Choosing which sentence an existing `next_cursor` state prints is TEXT — explicitly a PATCH under the policy block above it. Rewritten; the #104 and #99 MINOR paragraphs are untouched and still correct, so the next release is still MINOR overall.
2. **test/render.test.ts (Copilot, #106 — accepted):** the rejected-cursor tests pinned the sentence only; both now also assert the rejected value is absent from the page. Verified RED by temporarily echoing the cursor in that branch.
3. **test/list-recent-budget.test.ts (CodeRabbit, #108 — accepted, with a correction):** CodeRabbit's arithmetic was right (39,997 for 3,969-char entries) but its scenario was not — under `n===1` feed the reserve routes the first batch into narrowing and the second request fails with nothing accepted, so the test dies on a bare error instead of reaching the early-stop path. The fixture is now 3,960 (renders 39,907 — inside the 202-char window between the reserved ceiling 39,798 and BUDGET 40,000, with margin on both sides) and the failure is keyed to the continuation request instead of a call counter. Verified both ways: reservation removed → 40,109 > 40,000, assertion fails; restored → 12/12.
4. **src/index.ts (CodeRabbit, #112 — accepted):** `memory_join_room`'s description no longer promises the result "names your membership scope" unconditionally — the no-scope branch reports write access as unknown, and the description now says so; the conditional clause is pinned in descriptions.test.ts.

Gate: tsc --noEmit, typecheck:test, 503/503 (UTC + Asia/Tokyo), verify:configs 19/19, build clean.

Done-by: Σ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that membership scope may be unavailable in server responses and will be shown as unknown rather than assumed.
  - Corrected the upcoming `formatRecentPage` release classification from minor to patch.

- **Bug Fixes**
  - Improved recent-page handling to keep responses within size limits and exclude oversized or disallowed cursors.

- **Tests**
  - Expanded coverage for cursor handling, response-size limits, continuation failures, and membership-scope messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->