### PR TITLE
release: 0.10.0 — the key stays home, pages fit, surfaces tell the truth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ This file starts at 0.8.1. Entries for earlier versions are reconstructed from
 the release commits and are deliberately terse — for anything before 0.8.1 the
 git history and the GitHub releases are the record.
 
-## [Unreleased]
+## [0.10.0] — 2026-08-31
 
 A PATCH under this file's own rule, corrected from the MINOR this paragraph
 first claimed (Copilot caught it post-merge on #106). `formatRecentPage` now

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "mnemoverse-memory",
   "display_name": "Mnemoverse Memory",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Hosted memory for AI agents that learns from outcomes — one key across Claude, Cursor & ChatGPT.",
   "long_description": "Mnemoverse gives your AI assistant long-term memory that persists across sessions and across tools. Store preferences, decisions, and lessons with memory_write; recall them by natural-language search with memory_read. The same memory is shared everywhere you use your Mnemoverse API key — Claude, Cursor, VS Code, and any MCP client. Requires a free API key from https://console.mnemoverse.com.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mnemoverse/mcp-memory-server",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mnemoverse/mcp-memory-server",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mnemoverse/mcp-memory-server",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Hosted persistent memory for AI agents that learns which facts help — feedback re-ranks recall — one key across Claude Code, Cursor, VS Code & ChatGPT, no infra to run",
   "type": "module",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -9,12 +9,12 @@
     "source": "github",
     "id": "1207193530"
   },
-  "version": "0.9.1",
+  "version": "0.10.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mnemoverse/mcp-memory-server",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
The version flip for everything merged since 0.9.1 (#106–#112, #115–#117). MINOR by the CHANGELOG's own rules, twice over: the https/redirect guard is a deliberate break for non-loopback plain-http setups, and `memory_list_recent`'s `limit` became a ceiling under the byte budget.

Mechanics per release.yml's own recipe: `npm version 0.10.0` (lock follows), `generate:configs` (server.json + manifest.json picked up the version, 19/19 in sync), `## [Unreleased]` flipped to `## [0.10.0] — 2026-08-31`.

Gate: tsc --noEmit, typecheck:test, 522/522, verify:configs, build, clean tree.

After merge: tag `v0.10.0` → release.yml (ancestry → version match → CHANGELOG section → drift → build → mcpb pack → pack smoke → npm publish behind the newly protected `release` environment → MCP Registry → GitHub release).

Done-by: Σ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Version updated to **0.10.0**.
  * Published release notes for the **August 31, 2026** release.
  * Updated the displayed package and server version information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->