### PR TITLE
ci(release): a failed release must reach a human, not the Actions tab

### DIFF
--- a/.github/workflows/release-sync-check.yml
+++ b/.github/workflows/release-sync-check.yml
@@ -51,6 +51,18 @@ jobs:
   # Deliberately a separate job: the `issues: write` scope must never sit on the
   # job that executes repository code (`npm run check:release-sync`).
   #
+  # Two lifecycle properties are chosen, not overlooked:
+  #  * the search is scoped to OPEN issues, so closing the tracker while the
+  #    cause is still live does not silence the alarm — the next run files a
+  #    fresh one. An alarm you can switch off by closing a tab is not one.
+  #  * a persisting drift adds one comment per run and never a second issue.
+  #    On this daily cron that is one line a day: a heartbeat, deliberately
+  #    not throttled, because "still drifting on day nine" is the signal.
+  #
+  # Unlike release.yml's twin, this one does NOT fire on cancelled(): a check
+  # that was cancelled simply did not run, and tomorrow's cron runs it again.
+  # It leaves no half-landed state behind, which is the thing worth announcing.
+  #
   # The issue text lives in `env` as a block scalar, not inside the script, so
   # the markdown can carry real backticks with no escaping.
   notify-on-failure:
@@ -58,6 +70,13 @@ jobs:
     needs: [check]
     if: failure()
     runs-on: ubuntu-latest
+    # One alarm at a time. Two failures landing together would both miss the
+    # dedupe lookup and both take the create path — the exact duplication the
+    # lookup exists to prevent. Queue instead of cancelling: a dropped second
+    # run is a dropped alarm.
+    concurrency:
+      group: release-alarm-${{ github.workflow }}
+      cancel-in-progress: false
     permissions:
       issues: write
     env:
@@ -89,35 +108,82 @@ jobs:
         with:
           script: |
             const MARKER = 'Public surfaces are not tracking the released version';
-            const runUrl = process.env.RUN_URL;
+            try {
+              const runUrl = process.env.RUN_URL;
 
-            // Dedupe on the TITLE, never on labels. A label filter silently matches
-            // nothing when the label does not exist in this repo (only `bug` does
-            // today), which would make this open a fresh issue on every failure —
-            // the same class of quiet malfunction this job exists to end.
-            const open = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              per_page: 100,
-            });
-            const existing = open.data.find((i) => i.title.includes(MARKER));
-
-            if (existing) {
-              await github.rest.issues.createComment({
+              // Dedupe on the TITLE, never on labels. A label filter silently matches
+              // nothing when the label does not exist in this repo (only `bug` does
+              // today), which would make this open a fresh issue on every failure —
+              // the same class of quiet malfunction this job exists to end.
+              // github.paginate, not a bare listForRepo: the REST endpoint caps a
+              // page at 100, so an older tracking issue past that boundary would be
+              // missed and this would open a duplicate.
+              const open = await github.paginate(github.rest.issues.listForRepo, {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: existing.number,
-                body: 'Still drifting as of ' + new Date().toISOString() + ' — [run](' + runUrl + ').',
+                state: 'open',
+                per_page: 100,
+                // This repository is PUBLIC with issues enabled, so anyone at all
+                // can open an issue whose title contains the marker below. Applying
+                // a LABEL, however, needs triage permission, so an outsider's issue
+                // can never carry `bug` and never enters this list. It also bounds
+                // the pagination that an issue flood could otherwise inflate.
+                labels: 'bug',
               });
-              core.notice('Updated existing issue #' + existing.number);
-            } else {
-              const created = await github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title: MARKER,
-                body: process.env.ISSUE_BODY,
-                labels: ['bug'],
-              });
-              core.notice('Opened issue #' + created.data.number);
+              // Adopt ONLY an issue this workflow itself opened, and match on a PREFIX
+              // rather than a substring.
+              //
+              // listForRepo returns pull requests too — GitHub models every PR as an
+              // issue, and they carry a `pull_request` property. But the sharper
+              // problem is not accidental: `includes` over an unfiltered list is a
+              // capture primitive. listForRepo returns newest-first and `find` takes
+              // the first hit, so an issue planted by any passer-by would absorb the
+              // alarm for as long as its author kept re-planting, and the triage body
+              // below would never be posted at all. An alarm a stranger can switch
+              // off is not an alarm.
+              //
+              // `github-actions[bot]` is a reserved login that no human account can
+              // hold, so authorship is the guard that actually closes this. The label
+              // filter above is the cheap first cut, not the guarantee.
+              const existing = open.find(
+                (i) =>
+                  !i.pull_request &&
+                  i.user &&
+                  i.user.type === 'Bot' &&
+                  i.user.login === 'github-actions[bot]' &&
+                  i.title.startsWith(MARKER)
+              );
+
+              if (existing) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: existing.number,
+                  body: 'Still drifting as of ' + new Date().toISOString() + ' — [run](' + runUrl + ').',
+                });
+                core.notice('Updated existing issue #' + existing.number);
+              } else {
+                const created = await github.rest.issues.create({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  title: MARKER,
+                  body: process.env.ISSUE_BODY,
+                  labels: ['bug'],
+                });
+                core.notice('Opened issue #' + created.data.number);
+              }
+            } catch (err) {
+              // The one job whose purpose is "do not fail silently" must not fail
+              // silently either. If the Issues API rejects this (rate limit, 5xx),
+              // the report still has to reach a human, so it goes into the run log
+              // and the job summary before this goes red. The workflow has already
+              // failed by the time this job runs, so this cannot turn a green run red.
+              core.error('Could not file the tracking issue: ' + err.message);
+              await core.summary
+                .addHeading('Tracking issue could not be filed')
+                .addRaw('The GitHub Issues API rejected the write. The report follows so it is not lost.')
+                .addSeparator()
+                .addRaw(process.env.ISSUE_BODY)
+                .write();
+              core.setFailed(process.env.ISSUE_BODY);
             }

--- a/.github/workflows/release-sync-check.yml
+++ b/.github/workflows/release-sync-check.yml
@@ -8,6 +8,12 @@ name: release-sync check
 # Runs on a schedule (not on every push — a release needs a moment to propagate,
 # and we don't want a false red right after tagging) plus manual dispatch.
 # A red run = drift; open release.yml and re-run the missing leg.
+#
+# Until 2026-09-01 that sentence was the entire alerting story, and it assumed a
+# human watching the Actions tab. On 2026-08-31 the v0.10.0 release failed its npm
+# publish; this check went red on schedule the next morning and named all three
+# drifted surfaces correctly — and it was still unread two days later. The notify
+# job at the bottom is the missing half: red now opens an issue.
 
 on:
   schedule:
@@ -36,3 +42,82 @@ jobs:
         run: npm run check:release-sync
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # The check above is correct, and it was correct on the morning it mattered.
+  # What was missing is that a scheduled workflow's failure is invisible unless
+  # somebody happens to be looking at the Actions tab. This job gives it a
+  # destination.
+  #
+  # Deliberately a separate job: the `issues: write` scope must never sit on the
+  # job that executes repository code (`npm run check:release-sync`).
+  #
+  # The issue text lives in `env` as a block scalar, not inside the script, so
+  # the markdown can carry real backticks with no escaping.
+  notify-on-failure:
+    name: Drift must reach a human
+    needs: [check]
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    env:
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      ISSUE_BODY: |
+        `release-sync check` is red: at least one first-party surface — npm, the Official
+        MCP Registry, or the GitHub release — is not serving `package.json#version`.
+        **The run log names which ones.**
+        [Open the run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+
+        This means a release half-landed. The publish legs in `release.yml` run in the
+        order npm → Official MCP Registry → GitHub release, and each is skipped once an
+        earlier one fails, so the first drifted surface in the list is where to look.
+
+        If the failing leg is the npm publish, read its error before assuming a missing
+        package: `npm error code E404` on `PUT` for a package that exists is an
+        **authentication** failure, not a missing package — npm answers 404 rather than
+        401 so that it does not disclose whether a private package exists. Check
+        `NPM_TOKEN`.
+
+        This issue is updated rather than duplicated while the drift persists, and stops
+        being updated once this check goes green.
+
+        ---
+        *Opened automatically by the release-sync check.*
+    steps:
+      - name: Open or update the drift issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const MARKER = 'Public surfaces are not tracking the released version';
+            const runUrl = process.env.RUN_URL;
+
+            // Dedupe on the TITLE, never on labels. A label filter silently matches
+            // nothing when the label does not exist in this repo (only `bug` does
+            // today), which would make this open a fresh issue on every failure —
+            // the same class of quiet malfunction this job exists to end.
+            const open = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            });
+            const existing = open.data.find((i) => i.title.includes(MARKER));
+
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body: 'Still drifting as of ' + new Date().toISOString() + ' — [run](' + runUrl + ').',
+              });
+              core.notice('Updated existing issue #' + existing.number);
+            } else {
+              const created = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: MARKER,
+                body: process.env.ISSUE_BODY,
+                labels: ['bug'],
+              });
+              core.notice('Opened issue #' + created.data.number);
+            }

--- a/.github/workflows/release-sync-check.yml
+++ b/.github/workflows/release-sync-check.yml
@@ -92,10 +92,12 @@ jobs:
         earlier one fails, so the first drifted surface in the list is where to look.
 
         If the failing leg is the npm publish, read its error before assuming a missing
-        package: `npm error code E404` on `PUT` for a package that exists is an
-        **authentication** failure, not a missing package — npm answers 404 rather than
-        401 so that it does not disclose whether a private package exists. Check
-        `NPM_TOKEN`.
+        package: `npm error code E404` on `PUT` for a package that exists points at
+        **authorization**, not absence — npm answers 404 rather than 401 so that it does
+        not disclose whether a private package exists. Check `NPM_TOKEN`: present,
+        unrevoked, granting publish on the `@mnemoverse` scope, and minted by an account
+        still in the org. Expiry is the least likely branch if the documented Automation
+        token was used, since those do not expire.
 
         This issue is updated rather than duplicated while the drift persists, and stops
         being updated once this check goes green.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -314,9 +314,13 @@ jobs:
   # ---------------------------------------------------------------------------
   # A failed release used to reach nobody.
   #
-  # 2026-08-31 21:27Z: v0.10.0 was tagged and merged, twelve of the thirteen
-  # steps above passed, and "Publish to npm" failed with `npm error code E404`
-  # on `PUT .../@mnemoverse%2fmcp-memory-server`. The tag then sat unpublished
+  # 2026-08-31 21:27Z: v0.10.0 was tagged and merged. Every gate above the npm
+  # publish passed; "Publish to npm" then failed with `npm error code E404` on
+  # `PUT .../@mnemoverse%2fmcp-memory-server`, and the SIX steps after it — the
+  # registry publish, the GitHub release, the docs dispatch — never ran at all.
+  # Say it that way round: "twelve of thirteen passed" reads as "only the last
+  # one failed", and an on-call engineer would conclude the release page and the
+  # docs notification had happened. They had not. The tag then sat unpublished
   # while npm kept serving 0.9.1. The release-sync check caught the drift the
   # next morning at 07:07Z and went red — into the same empty room, because a
   # scheduled workflow's red X is only visible to someone already looking at
@@ -381,10 +385,17 @@ jobs:
         > `npm error code E404` — `PUT https://registry.npmjs.org/@mnemoverse%2fmcp-memory-server`
 
         A 404 on `PUT` for a package that plainly exists is **not** "package not found".
-        npm answers 404 instead of 401 so that it does not disclose whether a private
-        package exists, so this is an authentication failure: `NPM_TOKEN` is expired or
-        revoked. Check the secret's age — a granular npm token expires, an Automation
-        token does not.
+        npm answers 404 rather than 401 so that it does not disclose whether a private
+        package exists. So read it as an **authorization** problem and check, cheapest
+        first: is `NPM_TOKEN` present and unrevoked; does it grant publish on the
+        `@mnemoverse` scope; is the account behind it still in the npm org; and was
+        publish-time 2FA turned on for the package.
+
+        One branch is worth ranking DOWN. This file's own setup section calls for a
+        classic **Automation** token, and those do not expire — so if setup was followed,
+        plain expiry is the least likely cause, and a revoked token or one minted by the
+        wrong account fits the same error more cheaply. Confirm which kind is actually in
+        the secret before spending time on the expiry theory.
 
         **After fixing the cause**, re-run this workflow from the tag. The publish legs
         run in the order npm → Official MCP Registry → GitHub release, and each is

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -310,3 +310,98 @@ jobs:
           else
             echo "::warning::dispatch failed (expired/revoked DOCS_DISPATCH_TOKEN?) — the docs cron will catch up within a day"
           fi
+
+  # ---------------------------------------------------------------------------
+  # A failed release used to reach nobody.
+  #
+  # 2026-08-31 21:27Z: v0.10.0 was tagged and merged, twelve of the thirteen
+  # steps above passed, and "Publish to npm" failed with `npm error code E404`
+  # on `PUT .../@mnemoverse%2fmcp-memory-server`. The tag then sat unpublished
+  # while npm kept serving 0.9.1. The release-sync check caught the drift the
+  # next morning at 07:07Z and went red — into the same empty room, because a
+  # scheduled workflow's red X is only visible to someone already looking at
+  # the Actions tab.
+  #
+  # This job is the missing half. It gates nothing and cannot fail the release
+  # (that already failed); it only gives the failure a destination. Deduped the
+  # way the docs repo's link-checker does it: comment on the open issue rather
+  # than opening a second one.
+  #
+  # The issue text lives in `env` as a block scalar, not inside the script, so
+  # the markdown can carry real backticks with no escaping.
+  # ---------------------------------------------------------------------------
+  notify-on-failure:
+    name: A failed release must reach a human
+    needs: [release]
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    env:
+      TAG: ${{ github.ref_name }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      ISSUE_BODY: |
+        The release workflow failed for **${{ github.ref_name }}**, so at least one public
+        surface is not serving this version.
+        [Open the run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+
+        **Read the failing step before assuming.** The one that has bitten us:
+
+        > `npm error code E404` — `PUT https://registry.npmjs.org/@mnemoverse%2fmcp-memory-server`
+
+        A 404 on `PUT` for a package that plainly exists is **not** "package not found".
+        npm answers 404 instead of 401 so that it does not disclose whether a private
+        package exists, so this is an authentication failure: `NPM_TOKEN` is expired or
+        revoked. Check the secret's age — a granular npm token expires, an Automation
+        token does not.
+
+        **After fixing the cause**, re-run this workflow from the tag. The publish legs
+        run in the order npm → Official MCP Registry → GitHub release, and each is
+        skipped once an earlier one fails, so a partial release means the later surfaces
+        were never attempted at all.
+
+        `release-sync check` (daily, 07:00 UTC) is what verifies the recovery: it compares
+        every first-party surface against `package.json#version` and stays red until they
+        agree.
+
+        ---
+        *Opened automatically by the release workflow.*
+    steps:
+      - name: Open or update the release-failure issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const MARKER = 'Release did not complete';
+            const tag = process.env.TAG;
+            const runUrl = process.env.RUN_URL;
+
+            // Dedupe on the TITLE, never on labels. A label filter silently matches
+            // nothing when the label does not exist in this repo (only `bug` does
+            // today), which would make this open a fresh issue on every failure —
+            // the same class of quiet malfunction this job exists to end.
+            const open = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            });
+            const existing = open.data.find((i) => i.title.includes(MARKER));
+
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body: 'Failed again for **' + tag + '** at ' + new Date().toISOString() + ' — [run](' + runUrl + ').',
+              });
+              core.notice('Updated existing issue #' + existing.number);
+            } else {
+              const created = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: MARKER + ': ' + tag,
+                body: process.env.ISSUE_BODY,
+                labels: ['bug'],
+              });
+              core.notice('Opened issue #' + created.data.number);
+            }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -327,22 +327,53 @@ jobs:
   # way the docs repo's link-checker does it: comment on the open issue rather
   # than opening a second one.
   #
+  # Two lifecycle properties are chosen, not overlooked:
+  #  * the search is scoped to OPEN issues, so closing the tracker while the
+  #    cause is still live does not silence the alarm — the next failure files
+  #    a fresh one. An alarm you can switch off by closing a tab is not one.
+  #  * a persisting failure adds one comment per run and never a second issue.
+  #    On the daily cron that is one line a day: a heartbeat, deliberately not
+  #    throttled, because "still broken on day nine" is the signal.
+  #
   # The issue text lives in `env` as a block scalar, not inside the script, so
   # the markdown can carry real backticks with no escaping.
   # ---------------------------------------------------------------------------
   notify-on-failure:
     name: A failed release must reach a human
     needs: [release]
-    if: failure()
+    # failure() and cancelled() are DIFFERENT status functions, and an explicit
+    # `if:` replaces the implicit success(). failure() alone stays false when the
+    # release job is cancelled — including a rejected or abandoned approval on the
+    # `release` environment above, which this file itself recommends protecting
+    # with required reviewers. A cancelled release leaves exactly the state this
+    # job exists to announce: a tag that nothing published. So both count.
+    if: failure() || cancelled()
     runs-on: ubuntu-latest
+    # One alarm at a time. Two failures landing together would both miss the
+    # dedupe lookup and both take the create path — the exact duplication the
+    # lookup exists to prevent. Queue instead of cancelling: a dropped second
+    # run is a dropped alarm.
+    concurrency:
+      group: release-alarm-${{ github.workflow }}
+      cancel-in-progress: false
     permissions:
       issues: write
     env:
-      TAG: ${{ github.ref_name }}
+      # Same resolution the seven gates above use. On a workflow_dispatch
+      # re-run — which is exactly the recovery path this job exists to serve —
+      # github.ref_name is the BRANCH, so a bare ref_name would title the issue
+      # after 'main' instead of the tag that failed.
+      TAG: ${{ github.event.inputs.tag || github.ref_name }}
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      # __HEADING__ is substituted by the script with a heading built from a
+      # VALIDATED tag. The raw tag is deliberately not interpolated here: this
+      # block is rendered markdown, and `workflow_dispatch.inputs.tag` is an
+      # unvalidated free-form string.
       ISSUE_BODY: |
-        The release workflow failed for **${{ github.ref_name }}**, so at least one public
-        surface is not serving this version.
+        __HEADING__
+
+        The release workflow did not complete — it failed or was cancelled — so at
+        least one public surface is not serving this version.
         [Open the run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
 
         **Read the failing step before assuming.** The one that has bitten us:
@@ -372,36 +403,98 @@ jobs:
         with:
           script: |
             const MARKER = 'Release did not complete';
-            const tag = process.env.TAG;
-            const runUrl = process.env.RUN_URL;
+            try {
+              // `workflow_dispatch.inputs.tag` is `type: string`, which GitHub does not
+              // validate at all, and the REST API will accept a multi-line value. It
+              // reaches two rendered sinks — the issue title and the body heading — so
+              // an unchecked value could forge markdown under this bot's name, hide the
+              // real advisory inside an unclosed HTML comment, or fire an @org/team
+              // mention. That needs write access, so it buys attribution rather than
+              // privilege; it is still not this job's to hand out.
+              //
+              // Refuse anything that is not a plausible tag rather than trying to escape
+              // it. A rejected value still produces a usable alarm — the run link and the
+              // triage body do not depend on it.
+              const rawTag = process.env.TAG || '';
+              const tag = /^[A-Za-z0-9][A-Za-z0-9._+-]{0,63}$/.test(rawTag)
+                ? rawTag
+                : '(tag name refused as unsafe)';
+              const heading = 'Release did not complete for **' + tag + '**.';
+              const runUrl = process.env.RUN_URL;
 
-            // Dedupe on the TITLE, never on labels. A label filter silently matches
-            // nothing when the label does not exist in this repo (only `bug` does
-            // today), which would make this open a fresh issue on every failure —
-            // the same class of quiet malfunction this job exists to end.
-            const open = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              per_page: 100,
-            });
-            const existing = open.data.find((i) => i.title.includes(MARKER));
-
-            if (existing) {
-              await github.rest.issues.createComment({
+              // Dedupe on the TITLE, never on labels. A label filter silently matches
+              // nothing when the label does not exist in this repo (only `bug` does
+              // today), which would make this open a fresh issue on every failure —
+              // the same class of quiet malfunction this job exists to end.
+              // github.paginate, not a bare listForRepo: the REST endpoint caps a
+              // page at 100, so an older tracking issue past that boundary would be
+              // missed and this would open a duplicate.
+              const open = await github.paginate(github.rest.issues.listForRepo, {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: existing.number,
-                body: 'Failed again for **' + tag + '** at ' + new Date().toISOString() + ' — [run](' + runUrl + ').',
+                state: 'open',
+                per_page: 100,
+                // This repository is PUBLIC with issues enabled, so anyone at all
+                // can open an issue whose title contains the marker below. Applying
+                // a LABEL, however, needs triage permission, so an outsider's issue
+                // can never carry `bug` and never enters this list. It also bounds
+                // the pagination that an issue flood could otherwise inflate.
+                labels: 'bug',
               });
-              core.notice('Updated existing issue #' + existing.number);
-            } else {
-              const created = await github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title: MARKER + ': ' + tag,
-                body: process.env.ISSUE_BODY,
-                labels: ['bug'],
-              });
-              core.notice('Opened issue #' + created.data.number);
+              // Adopt ONLY an issue this workflow itself opened, and match on a PREFIX
+              // rather than a substring.
+              //
+              // listForRepo returns pull requests too — GitHub models every PR as an
+              // issue, and they carry a `pull_request` property. But the sharper
+              // problem is not accidental: `includes` over an unfiltered list is a
+              // capture primitive. listForRepo returns newest-first and `find` takes
+              // the first hit, so an issue planted by any passer-by would absorb the
+              // alarm for as long as its author kept re-planting, and the triage body
+              // below would never be posted at all. An alarm a stranger can switch
+              // off is not an alarm.
+              //
+              // `github-actions[bot]` is a reserved login that no human account can
+              // hold, so authorship is the guard that actually closes this. The label
+              // filter above is the cheap first cut, not the guarantee.
+              const existing = open.find(
+                (i) =>
+                  !i.pull_request &&
+                  i.user &&
+                  i.user.type === 'Bot' &&
+                  i.user.login === 'github-actions[bot]' &&
+                  i.title.startsWith(MARKER)
+              );
+
+              if (existing) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: existing.number,
+                  body: 'Failed again for **' + tag + '** at ' + new Date().toISOString() + ' — [run](' + runUrl + ').',
+                });
+                core.notice('Updated existing issue #' + existing.number);
+              } else {
+                const created = await github.rest.issues.create({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  title: MARKER + ': ' + tag,
+                  body: process.env.ISSUE_BODY.replace('__HEADING__', heading),
+                  labels: ['bug'],
+                });
+                core.notice('Opened issue #' + created.data.number);
+              }
+            } catch (err) {
+              // The one job whose purpose is "do not fail silently" must not fail
+              // silently either. If the Issues API rejects this (rate limit, 5xx),
+              // the report still has to reach a human, so it goes into the run log
+              // and the job summary before this goes red. The workflow has already
+              // failed by the time this job runs, so this cannot turn a green run red.
+              core.error('Could not file the tracking issue: ' + err.message);
+              await core.summary
+                .addHeading('Tracking issue could not be filed')
+                .addRaw('The GitHub Issues API rejected the write. The report follows so it is not lost.')
+                .addSeparator()
+                .addRaw(process.env.ISSUE_BODY)
+                .write();
+              core.setFailed(process.env.ISSUE_BODY);
             }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,7 +175,15 @@ That push fires [`.github/workflows/release.yml`](.github/workflows/release.yml)
 8. Verifies the registry entry via a direct curl against the public API.
 9. Creates a GitHub release with auto-generated notes.
 
-If any step fails, the release is aborted — nothing partial gets published. You can re-push the same tag after fixing the issue.
+A failing step aborts the job, so every step after it is skipped. That is **not** the
+same as "nothing partial gets published": whatever already succeeded stays published.
+
+- Fail **at** the npm publish and nothing landed — fix the cause and re-run from the tag.
+- Fail **after** npm published and the package is live while the registry entry and the
+  release page lag. That is a half-landed release, and it is what the daily
+  `release-sync check` exists to catch. A plain re-run will **not** recover it: it dies
+  at the npm publish step, because that version already exists (`403`). Finish the
+  remaining legs by hand, or cut a new patch version.
 
 ### One-time setup for the workflow
 


### PR DESCRIPTION
## What happened

`v0.10.0` was tagged and merged on **2026-08-31 21:27Z**. Every gate above the npm
publish passed: tag/version agreement, artifact-drift check, bundle validation, a
smoke test through the packed tarball's own bin entry. Then:

```
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/@mnemoverse%2fmcp-memory-server
```

The **six** steps after it, the MCP Registry publish, the GitHub release and the docs
dispatch, never ran. The tag sat unpublished for **fifteen days** while npm served `0.9.1`.

**Nobody was told.** That is what this PR fixes. The credential itself is a separate,
human action.

## Why nobody was told

| surface | what it did | why it was silent |
|---|---|---|
| `release.yml` | failed | no failure path at all. Its only notifier, `Notify mnemoverse-docs`, sits on the success branch and is skipped once an earlier step fails |
| `release-sync check` | **worked perfectly** | went red at 07:07Z the next morning naming all three drifted surfaces, into an empty room. A scheduled workflow's red X is visible only to someone already on the Actions tab. It was also `permissions: contents: read`, so it could not have opened an issue even if asked |

Its own header said *"A red run = drift; open release.yml and re-run the missing leg"*,
an instruction addressed to a human who was not watching.

## Final behaviour

Both workflows now end in a `notify-on-failure` job that opens one issue and comments
on it thereafter. Neither gates anything; neither can fail a release that already failed.

**What fires it.** `release.yml`: `failure() || cancelled()`. Those are distinct status
functions, and an explicit `if:` replaces the implicit `success()`. The `release` job
carries `environment: release`, which this file recommends protecting with required
reviewers, so a rejected or abandoned approval leaves the same unpublished tag that a
failure does. `release-sync-check.yml`: `failure()` only. A cancelled check simply did
not run, and tomorrow's cron runs it again.

**What the alarm adopts.** An open issue authored by `github-actions[bot]` (a reserved
login no human account can hold), carrying the `bug` label (applying a label needs triage
permission, so an outsider's issue cannot enter the list), whose title starts with this
workflow's marker. `github.paginate`, not a bare `listForRepo`, so a tracker past the
first hundred is not missed. Pull requests are filtered out: GitHub models every PR as an
issue. Without all of that, `includes` over an unfiltered newest-first list was a capture
primitive on a public repository.

**Dedup across red, green, red.** The lookup is scoped to `state: 'open'`, and the job
only runs on failure, so a green run changes nothing about the tracker:

| sequence | result |
|---|---|
| first red | creates the issue |
| red again, issue still open | comments on it, never a second issue |
| green | job does not run; the issue stays open as the record |
| red again after green, issue still open | comments on the same issue |
| red again after a human **closed** it | opens a fresh one (a closed tracker must not silence the alarm) |
| release fails on a **later tag** | prefix match adopts the same tracker and comments naming the new tag |

Exercised locally against a stubbed Issues API, including the two capture attempts
(a human-authored look-alike title, and a PR with the same title). Both are refused.

**What red means in `release-sync check`.** Two different things, now reported as two
different things: a surface **drifted** (it answered, with the wrong version, so a release
half-landed) or it **could not be checked** (it did not answer, so its version is unknown).
Only the first is grounds to open `release.yml`. Both are still red, because an unverified
surface is not a verified one.

## Review history

Two external reviewers and a four-lens internal panel ran on this, then an adversarial
pass over the result found four more. Every finding was verified against the file before
being acted on; none was taken on faith.

**CodeRabbit and Copilot converged independently on the same two defects:**

- `issues.listForRepo` returns pull requests as well, and only the first page. Now `github.paginate`, with PR records filtered out.
- The tag. The `release` job resolves it as `github.event.inputs.tag || github.ref_name` in **seven** places; this job used a bare `ref_name`, which on a `workflow_dispatch` re-run is the **branch**. The issue would have been titled after `main`, in exactly the recovery path this job exists to serve.

**Adversarial security pass, one real break.** This repository is public with issues
enabled. The lookup matched any open issue whose title merely *contained* the marker, so
any passer-by could plant an issue and capture the alarm, re-planting a newer one at will,
and the triage body would never have been posted. Closed by the authorship, label and
prefix conditions described above. Separately, `workflow_dispatch.inputs.tag` is an
unvalidated `type: string` that reached two rendered markdown sinks; it is now validated
in the script and the raw value no longer appears in the body block at all.

**Internal panel:** `if: failure()` never fires on `cancelled`; no try/catch, so the one
job whose purpose is "do not fail silently" could fail silently on a rate limit; no
concurrency guard, so two simultaneous failures could both create.

**Factual audit, three of my own claims did not survive:** the "twelve of thirteen steps"
count was the run's numbering rather than the file's and read as "only the tail was lost";
the 404 diagnosis was asserted as fact and is now an ordered checklist; and
`CONTRIBUTING.md` claimed *"If any step fails, the release is aborted, nothing partial
gets published"*, which is the opposite of this pipeline's behaviour and is the first
document a responder opens.

**Second adversarial pass, four more (commit `27dbd44`):**

1. **The last-resort report was the one report that was not valid markdown.** `ISSUE_BODY` carries a `__HEADING__` placeholder substituted at the `issues.create()` call. The catch path, which runs precisely when the Issues API is unavailable and the job summary is the only surface left, passed the **raw template** to `core.summary.addRaw` and `core.setFailed`; `heading` and `tag` were declared inside the `try`, so it could not have reached the rendered values anyway. The body is now rendered **once**, before the `try`, and every consumer uses that one string (`release.yml:462`, `:521`, `:537`). Same shape given to the sibling in `release-sync-check.yml:153`, which has no placeholder today but would grow the same bug on the day it gained one. Confirmed in both directions by running the old and new scripts against a throwing Issues API.

2. **A network blip claimed a half-landed release.** `scripts/check-release-sync.mjs` set `drift = true` inside `catch (err)`, so a timeout, a 5xx or a rate limit produced an issue asserting a partial release and sent a responder into recovery. Unreachable is not drift: it means the version that surface serves is **unknown**. Now two separate lists (`:120-136`), two separate summary lines (`:143-149`), a `? could not be checked` row instead of `unreachable`, and an issue body and file header that say which of the two calls for opening `release.yml` (`release-sync-check.yml:11-16`, `:102-118`). Both still exit 1.

3. **The concurrency comment promised a guarantee Actions does not give.** It said "queue instead of cancelling: a dropped second run is a dropped alarm", implying none is dropped. A group holds one running run plus at most **one** waiting; a third arrival replaces the waiting one, which is cancelled. The comment now states that, and states the trade as accepted rather than hidden: the run holding the group opens or adopts the tracker, and a displaced run would only have added a heartbeat comment to an issue that already names the failure (`release.yml:356-371`, `release-sync-check.yml:79-93`).

4. **The npm triage text contradicted the setup section it cited.** It said *"this file's own setup section calls for a classic Automation token, and those do not expire"*, and ranked expiry down on that basis. The setup section (`release.yml:33-34`, `CONTRIBUTING.md:194`) points at npm's **granular access tokens** page; "Automation" is a token type offered there. Expiry is now a live branch in the checklist, not a deprioritized one. Added alongside it, from this file's own security note at `:68`: the secret is recommended as an **environment** secret on the `release` environment, so a renamed or deleted environment leaves `secrets.NPM_TOKEN` empty and produces the same 404 with nothing revoked.

Point 4 was also raised by both bots on the separate grounds that npm's token policy has
moved. That external claim is not encoded here and the correction does not depend on it:
it stands on this repository's own link. The setup instructions are left alone for the
same reason. They already point at the granular page, and rewriting them toward trusted
publishing or OIDC would change how this project authenticates to npm, which is a
credential decision for a human.

## Deliberate non-changes

- **The matcher is not unit-tested in the repo suite.** Extracting it into vitest would require the notify job to check out repository code, putting `issues: write` next to executable repo code, the exact split this design protects. Kept inline and small, and exercised out-of-tree instead (below).
- **Closing the tracker does not silence the alarm** (the search is scoped to open issues), and **a persisting drift adds one comment per run** as a deliberate heartbeat. Both documented in the files so neither reads as an oversight.
- `actions/*@v7` and `@v4` remain unpinned: pre-existing repo-wide posture, recorded in `release-sync-check.yml`.
- The recovery-instruction thread on `release.yml:403` (a re-run cannot recover once npm published) is left open. It is a real point, it is already documented correctly in `CONTRIBUTING.md`, and it is outside the four defects this pass was scoped to.

## Gates

`origin/main` merged in (0.10.0 released, #124 and #126 landed). No conflict: main moved
in `README.md`, `docs/` and `scripts/generate-configs.mjs`.

| gate | result |
|---|---|
| `npm ci` | exit 0 |
| `npm test` | exit 0, 522 passed (17 files) |
| `npm run verify:configs` | exit 0, 19 artifacts in sync |
| `node --check scripts/check-release-sync.mjs` | exit 0 |
| YAML parse, both workflows | OK |
| `node --check`, both embedded scripts extracted from the YAML | exit 0 |
| `actionlint` | not installed on this machine, skipped |

Because the notify job cannot be exercised without opening a public issue, the logic was
run out-of-tree instead of dispatched:

- **`check-release-sync.mjs` with a stubbed `fetch`**, four scenarios. `all-green` exits 0. `npm-drift` exits 1 with a `DRIFT:` line only. `npm-blip` exits 1 with a `COULD NOT BE CHECKED:` line and **no** `DRIFT:` line, the regression this pass exists to prevent. `drift+blip` exits 1 with both, separately.
- **Both notify scripts extracted from the YAML and run against a stubbed Issues API**, fifteen assertions: body rendering, the API-error fallback (no `__HEADING__` in the summary or in `setFailed`), the unsafe-tag refusal, the six dedup rows in the table above, and the two capture attempts. All pass. Against the parent commit the same harness reports `BEFORE summary leaks literal __HEADING__: true`.

**Still not verified:** the notify job has never executed in CI. `release-sync check` is
red right now for a real reason, so dispatching it on this branch would exercise the job
end-to-end and produce the tracking issue for this very incident. That opens a publicly
visible issue, so it is Eduard's call, not something this pass took on its own.
