### PR TITLE
docs(install): one-line PowerShell variant of the Claude Code add command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ claude mcp add mnemoverse -s user \
   -- npx -y @mnemoverse/mcp-memory-server@latest
 ```
 
+On Windows (PowerShell), paste the same command as one line — PowerShell does not read the `\` line continuations:
+
+```powershell
+claude mcp add mnemoverse -s user -e MNEMOVERSE_API_KEY=mk_live_YOUR_KEY -e MNEMOVERSE_API_URL=https://core.mnemoverse.com/api/v1 -- npx -y @mnemoverse/mcp-memory-server@latest
+```
+
 **Cursor** — click to install, or add to `.cursor/mcp.json`:
 
 [![Add to Cursor](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en/install-mcp?name=mnemoverse&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsIkBtbmVtb3ZlcnNlL21jcC1tZW1vcnktc2VydmVyQGxhdGVzdCJdLCJlbnYiOnsiTU5FTU9WRVJTRV9BUElfS0VZIjoibWtfbGl2ZV9ZT1VSX0tFWSIsIk1ORU1PVkVSU0VfQVBJX1VSTCI6Imh0dHBzOi8vY29yZS5tbmVtb3ZlcnNlLmNvbS9hcGkvdjEifX0%3D)

--- a/docs/snippets/claude-code.md
+++ b/docs/snippets/claude-code.md
@@ -8,3 +8,9 @@ claude mcp add mnemoverse -s user \
   -e MNEMOVERSE_API_URL=https://core.mnemoverse.com/api/v1 \
   -- npx -y @mnemoverse/mcp-memory-server@latest
 ```
+
+On Windows (PowerShell), paste the same command as one line — PowerShell does not read the `\` line continuations:
+
+```powershell
+claude mcp add mnemoverse -s user -e MNEMOVERSE_API_KEY=mk_live_YOUR_KEY -e MNEMOVERSE_API_URL=https://core.mnemoverse.com/api/v1 -- npx -y @mnemoverse/mcp-memory-server@latest
+```

--- a/scripts/generate-configs.mjs
+++ b/scripts/generate-configs.mjs
@@ -194,6 +194,16 @@ function genClaudeCodeCli() {
   return `claude mcp add ${source.name} -s user \\\n${envFlags} \\\n  -- ${source.command} ${source.args.join(" ")}\n`;
 }
 
+function genClaudeCodeCliOneLine() {
+  // Same command, single line: PowerShell (the default shell on Windows)
+  // does not read the backslash line continuations of the bash form, so a
+  // Windows user pasting the multiline block gets a parse error.
+  const envFlags = Object.entries(ENV_VALUES)
+    .map(([k, v]) => `-e ${k}=${v}`)
+    .join(" ");
+  return `claude mcp add ${source.name} -s user ${envFlags} -- ${source.command} ${source.args.join(" ")}\n`;
+}
+
 // NOTE: genSmitheryYaml() was removed on 2026-04-12 after an empirical
 // check showed that Smithery's current CLI (@smithery/cli 4.7.4) entirely
 // ignores the legacy `startCommand` / `configSchema` / `commandFunction`
@@ -223,11 +233,17 @@ const PARTIAL_HEADER =
   "<!-- AUTO-GENERATED from src/configs/source.json. Run `npm run generate:configs`. Do not edit by hand. -->\n\n";
 
 function snippetClaudeCodeCli() {
-  // shell command, multiline with backslash continuations
+  // shell command, multiline with backslash continuations, plus a one-line
+  // variant for Windows: PowerShell rejects the `\` continuations, and the
+  // multiline block pasted there fails with a parse error.
   return (
     "**Claude Code** — add via CLI:\n\n" +
     "```bash\n" +
     genClaudeCodeCli().trim() +
+    "\n```\n\n" +
+    "On Windows (PowerShell), paste the same command as one line — PowerShell does not read the `\\` line continuations:\n\n" +
+    "```powershell\n" +
+    genClaudeCodeCliOneLine().trim() +
     "\n```\n"
   );
 }


### PR DESCRIPTION
## What

The Claude Code install snippet ships only as a bash block with backslash line continuations. PowerShell, the default shell on Windows, does not read `\` continuations, so a Windows user pasting the block gets a parse error on line two. This adds a one-line variant right under the bash block, generated from the same `source.json` by a sibling function, so the two forms cannot drift apart.

## Why now

Caught by dogfooding: a fresh agent following the published Claude Code page on a Windows machine hit the parse error as the first step of setup. The snippet is the canonical source (this repo) and syncs into the docs site, so the fix lands everywhere from here.

## Changes

- `scripts/generate-configs.mjs`: new `genClaudeCodeCliOneLine()` + the snippet emits both forms
- `docs/snippets/claude-code.md`, `README.md`: regenerated (`npm run generate:configs`, output committed verbatim)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Windows PowerShell installation instructions for configuring the Mnemoverse MCP server in Claude Code.
  * Added a single-line PowerShell command alongside the existing multi-line bash command.
  * Updated generated configuration snippets to include both bash and PowerShell formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->